### PR TITLE
Allow any file type when importing

### DIFF
--- a/app/src/main/java/com/capyreader/app/common/GetContentFromMimeTypes.kt
+++ b/app/src/main/java/com/capyreader/app/common/GetContentFromMimeTypes.kt
@@ -1,0 +1,27 @@
+package com.capyreader.app.common
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.annotation.CallSuper
+
+open class GetOPMLContent : ActivityResultContract<Unit, Uri?>() {
+    @CallSuper
+    override fun createIntent(context: Context, input: Unit): Intent {
+        return Intent(Intent.ACTION_GET_CONTENT)
+            .addCategory(Intent.CATEGORY_OPENABLE)
+            .setType("text/xml,text/x-opml,application/*")
+            .putExtra(Intent.EXTRA_MIME_TYPES, listOf("text/xml", "text/x-opml", "application/*").toTypedArray())
+    }
+
+    final override fun getSynchronousResult(
+        context: Context,
+        input: Unit
+    ): SynchronousResult<Uri?>? = null
+
+    final override fun parseResult(resultCode: Int, intent: Intent?): Uri? {
+        return intent.takeIf { resultCode == Activity.RESULT_OK }?.data
+    }
+}

--- a/app/src/main/java/com/capyreader/app/common/GetContentFromMimeTypes.kt
+++ b/app/src/main/java/com/capyreader/app/common/GetContentFromMimeTypes.kt
@@ -7,18 +7,18 @@ import android.net.Uri
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.CallSuper
 
-open class GetOPMLContent : ActivityResultContract<Unit, Uri?>() {
+open class GetOPMLContent : ActivityResultContract<List<String>, Uri?>() {
     @CallSuper
-    override fun createIntent(context: Context, input: Unit): Intent {
+    override fun createIntent(context: Context, input: List<String>): Intent {
         return Intent(Intent.ACTION_GET_CONTENT)
             .addCategory(Intent.CATEGORY_OPENABLE)
-            .setType("text/xml,text/x-opml,application/*")
-            .putExtra(Intent.EXTRA_MIME_TYPES, listOf("text/xml", "text/x-opml", "application/*").toTypedArray())
+            .setType(input.joinToString(","))
+            .putExtra(Intent.EXTRA_MIME_TYPES, input.toTypedArray())
     }
 
     final override fun getSynchronousResult(
         context: Context,
-        input: Unit
+        input: List<String>
     ): SynchronousResult<Uri?>? = null
 
     final override fun parseResult(resultCode: Int, intent: Intent?): Uri? {

--- a/app/src/main/java/com/capyreader/app/transfers/OPMLImportWorker.kt
+++ b/app/src/main/java/com/capyreader/app/transfers/OPMLImportWorker.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
 import android.net.Uri
 import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.core.app.NotificationCompat
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
@@ -28,6 +29,8 @@ import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.UUID
+import java.util.concurrent.ExecutionException
+import javax.xml.parsers.ParserConfigurationException
 import kotlin.math.roundToInt
 
 
@@ -49,9 +52,14 @@ class OPMLImportWorker(
         val opmlURI = Uri.parse(uriValue)
 
         setForeground(createForegroundInfo())
-        import(opmlURI)
 
-        showCompleteToast()
+        try {
+            import(opmlURI)
+
+            showToast(R.string.opml_import_toast_complete)
+        } catch (e: Throwable) {
+            showToast(R.string.opml_import_toast_failed)
+        }
 
         return Result.success()
     }
@@ -128,10 +136,10 @@ class OPMLImportWorker(
         notificationManager.createNotificationChannel(channel)
     }
 
-    private suspend fun showCompleteToast() = withContext(Dispatchers.Main) {
+    private suspend fun showToast(@StringRes string: Int) = withContext(Dispatchers.Main) {
         Toast.makeText(
             applicationContext,
-            applicationContext.getString(R.string.opml_import_toast_complete),
+            applicationContext.getString(string),
             Toast.LENGTH_SHORT
         ).show()
     }

--- a/app/src/main/java/com/capyreader/app/ui/settings/OPMLImportButton.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/OPMLImportButton.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -50,11 +51,7 @@ fun OPMLImportButton(
 private fun ButtonText(progress: ImportProgress?) {
     if (progress != null) {
         Text(
-            stringResource(
-                R.string.settings_import_progress,
-                progress.currentCount,
-                progress.total
-            ),
+            text(progress),
             fontStyle = FontStyle.Italic
         )
     } else {
@@ -62,14 +59,34 @@ private fun ButtonText(progress: ImportProgress?) {
     }
 }
 
+@Composable
+fun text(progress: ImportProgress): String {
+    return if (progress.total == 0) {
+        stringResource(
+            R.string.settings_import_progress_placeholder
+        )
+    } else {
+        stringResource(
+            R.string.settings_import_progress,
+            progress.currentCount,
+            progress.total
+        )
+    }
+}
 
 @Preview
 @Composable
 private fun OPMLImportButtonPreview() {
     CapyTheme {
-        OPMLImportButton(
-            onClick = {},
-            importProgress = ImportProgress(currentCount = 0, total = 10)
-        )
+        Column {
+            OPMLImportButton(
+                onClick = {},
+                importProgress = ImportProgress(currentCount = 0, total = 10)
+            )
+            OPMLImportButton(
+                onClick = {},
+                importProgress = ImportProgress(currentCount = 0, total = 0)
+            )
+        }
     }
 }

--- a/app/src/main/java/com/capyreader/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/SettingsScreen.kt
@@ -5,6 +5,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
+import com.capyreader.app.common.GetOPMLContent
 import com.capyreader.app.transfers.OPMLExporter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -20,13 +21,13 @@ fun SettingsScreen(
     val coroutineScope = rememberCoroutineScope()
 
     val picker = rememberLauncherForActivityResult(
-        ActivityResultContracts.GetContent()
+        GetOPMLContent()
     ) { uri ->
         viewModel.startOPMLImport(uri = uri)
     }
 
     val importOPML = {
-        picker.launch("text/xml")
+        picker.launch(Unit)
     }
 
     val exportOPML = {

--- a/app/src/main/java/com/capyreader/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/SettingsScreen.kt
@@ -27,7 +27,7 @@ fun SettingsScreen(
     }
 
     val importOPML = {
-        picker.launch(Unit)
+        picker.launch(listOf("text/xml", "text/x-opml", "application/*"))
     }
 
     val exportOPML = {

--- a/app/src/main/java/com/capyreader/app/ui/settings/SettingsView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/SettingsView.kt
@@ -34,8 +34,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.capyreader.app.BuildConfig
-import com.jocmp.capy.accounts.Source
-import com.jocmp.capy.opml.ImportProgress
 import com.capyreader.app.R
 import com.capyreader.app.common.ThemeOption
 import com.capyreader.app.refresher.RefreshInterval
@@ -43,6 +41,8 @@ import com.capyreader.app.setupCommonModules
 import com.capyreader.app.ui.components.TextSwitch
 import com.capyreader.app.ui.isCompact
 import com.capyreader.app.ui.theme.CapyTheme
+import com.jocmp.capy.accounts.Source
+import com.jocmp.capy.opml.ImportProgress
 import org.koin.android.ext.koin.androidContext
 import org.koin.compose.KoinApplication
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,7 @@
     <string name="opml_import_button_text">Import from File</string>
     <string name="opml_export_button_text">Export to OPML</string>
     <string name="opml_import_progress_content_text_start">Starting import</string>
+    <string name="settings_import_progress_placeholder">Importing subscriptions…</string>
     <string name="settings_import_progress">Importing subscriptions %1$d of %2$d</string>
     <string name="opml_import_toast_complete">Import complete</string>
     <string name="opml_import_toast_failed">Import failed</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,6 +93,7 @@
     <string name="opml_import_progress_content_text_start">Starting import</string>
     <string name="settings_import_progress">Importing subscriptions %1$d of %2$d</string>
     <string name="opml_import_toast_complete">Import complete</string>
+    <string name="opml_import_toast_failed">Import failed</string>
     <string name="settings_section_display_appearance">Display &amp; Appearance</string>
     <string name="theme_menu_label">Theme</string>
     <string name="theme_menu_option_light">Light</string>


### PR DESCRIPTION
Adds "application/*" mimetype when importing and add an error message if it fails. This will allow both XML and OPML files to get imported.