### PR TITLE
Disable dependency metadata in binaries

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,6 +30,11 @@ android {
         }
     }
 
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
+
     flavorDimensions += listOf("license")
 
     productFlavors {


### PR DESCRIPTION
Addresses #165 

Reference: https://developer.android.com/build/dependencies#dependency-info-play