### PR TITLE
Fix OPML Imports on invalid XML characters

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleLayout.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleLayout.kt
@@ -132,10 +132,6 @@ fun ArticleLayout(
             onFeedRefresh {
                 state.endRefresh()
                 pagingArticles.refresh()
-                coroutineScope.launch {
-                    delay(200)
-                    listState.scrollToItem(0)
-                }
             }
         }
     }

--- a/capy/src/main/java/com/jocmp/capy/opml/OPMLHandler.kt
+++ b/capy/src/main/java/com/jocmp/capy/opml/OPMLHandler.kt
@@ -1,107 +1,60 @@
 package com.jocmp.capy.opml
 
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.parser.Parser
 import org.xml.sax.Attributes
 import org.xml.sax.SAXException
 import org.xml.sax.helpers.DefaultHandler
 import java.io.InputStream
 import javax.xml.parsers.SAXParserFactory
 
-internal class OPMLHandler : DefaultHandler() {
-    lateinit var opmlDocument: OPMLDocument
-    private var currentValue: StringBuilder? = null
-    private var outlines = ArrayDeque<Outline>()
+internal object OPMLHandler {
+    fun parse(inputStream: InputStream): List<Outline> {
+        val res = Jsoup.parse(inputStream, "UTF-8", "", Parser.xmlParser())
 
-    @Throws(SAXException::class)
-    override fun characters(ch: CharArray, start: Int, length: Int) {
-        val value = currentValue
-
-        if (value == null) {
-            currentValue = StringBuilder()
-        } else {
-            currentValue = value.appendRange(ch, start, start + length)
-        }
-    }
-
-    @Throws(SAXException::class)
-    override fun startDocument() {
-        opmlDocument = OPMLDocument()
-    }
-
-    @Throws(SAXException::class)
-    override fun startElement(
-        uri: String,
-        localName: String,
-        qName: String,
-        attributes: Attributes
-    ) {
-        if (qName != OUTLINE) {
-            return
-        }
-
-        if (attributes.getValue("type") == "rss") {
-            val feed = Feed(
-                id = attributes.getValue("basil_id"),
-                title = attributes.getValue("title"),
-                text = attributes.getValue("text"),
-                htmlUrl = attributes.getValue("htmlUrl"),
-                xmlUrl = attributes.getValue("xmlUrl"),
-            )
-
-            outlines.add(Outline.FeedOutline(feed))
-        } else {
-            val folder = Folder(
-                title = attributes.getValue("title"),
-                text = attributes.getValue("text")
-            )
-
-            outlines.add(Outline.FolderOutline(folder))
-        }
-    }
-
-    @Throws(SAXException::class)
-    override fun endElement(uri: String, localName: String, qName: String) {
-        if (qName != OUTLINE) {
-            return
-        }
-
-        val outline = outlines.removeLastOrNull() ?: return
-
-        if (outlines.isEmpty()) {
-            opmlDocument.outlines.add(outline)
-        }
-
-        val parentFolder = (outlines.lastOrNull() as? Outline.FolderOutline)?.folder ?: return
-
-        if (outline is Outline.FeedOutline) {
-            parentFolder.feeds.add(outline.feed)
-        } else if (outline is Outline.FolderOutline) {
-            parentFolder.folders.add(outline.folder)
-        }
-    }
-
-    companion object {
-        private const val OUTLINE = "outline"
-
-        fun parse(filePath: String): List<Outline> {
-            val handler = OPMLHandler()
-
-            SAXParserFactory
-                .newInstance()
-                .newSAXParser()
-                .parse(filePath, handler)
-
-            return handler.opmlDocument.outlines
-        }
-
-        fun parse(inputStream: InputStream): List<Outline> {
-            val handler = OPMLHandler()
-
-            SAXParserFactory
-                .newInstance()
-                .newSAXParser()
-                .parse(inputStream, handler)
-
-            return handler.opmlDocument.outlines
+        return res.getElementsByTag("body").flatMap { body ->
+            body
+                .select("> outline")
+                .map { element ->
+                    if (element.isFeed) {
+                        Outline.FeedOutline(element.toFeed)
+                    } else {
+                        Outline.FolderOutline(element.toFolder)
+                    }
+                }
         }
     }
 }
+
+private val Element.toFeed
+    get() = Feed(
+        title = attr("title"),
+        text = attr("text"),
+        htmlUrl = attr("htmlUrl"),
+        xmlUrl = attr("xmlUrl"),
+    )
+
+private val Element.toFolder: Folder
+    get() {
+        val elements = children().map { child ->
+            if (child.isFeed) {
+                child.toFeed
+            } else {
+                child.toFolder
+            }
+        }
+
+        val feeds = elements.filterIsInstance<Feed>().toMutableList()
+        val folders = elements.filterIsInstance<Folder>().toMutableList()
+
+        return Folder(
+            title = attr("title"),
+            text = attr("text"),
+            feeds = feeds,
+            folders = folders
+        )
+    }
+
+private val Element.isFeed
+    get() = attr("type").lowercase() == "rss"

--- a/capy/src/main/java/com/jocmp/capy/opml/OPMLImporter.kt
+++ b/capy/src/main/java/com/jocmp/capy/opml/OPMLImporter.kt
@@ -5,11 +5,6 @@ import java.io.InputStream
 import java.net.URL
 import kotlin.math.roundToInt
 
-/**
- * 1. Load file via `OPMLFile`
- * 2. Normalize feeds
- * 3. When normalized, iterate through each feed and call `createFeed` on account
- */
 internal class OPMLImporter(private val account: Account) {
     internal suspend fun import(
         onProgress: (progress: ImportProgress) -> Unit = {},

--- a/capy/src/test/java/com/jocmp/capy/OPMLFileTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/OPMLFileTest.kt
@@ -48,7 +48,6 @@ class OPMLFileTest {
 
     @Test
     fun opmlDocument_serializes() = runTest {
-
         "Tech".also { folderName ->
             feedFixture.create(
                 title = "The Verge",

--- a/capy/src/test/java/com/jocmp/capy/opml/OPMLHandlerTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/opml/OPMLHandlerTest.kt
@@ -1,41 +1,46 @@
 package com.jocmp.capy.opml
 
+import com.jocmp.capy.testFile
 import org.junit.Test
 import javax.xml.parsers.SAXParserFactory
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class OPMLHandlerTest {
     @Test
     fun parse_TopLevelFeed() {
-        val factory = SAXParserFactory.newInstance()
-        val saxParser = factory.newSAXParser()
-        val handler = OPMLHandler()
+        val outlines = OPMLHandler.parse(testFile("local.xml").inputStream())
 
-        saxParser.parse("src/test/resources/local.xml", handler)
-
-        assertEquals(3, handler.opmlDocument.outlines.size)
+        assertEquals(3, outlines.size)
     }
 
     @Test
     fun parse_NestedFolders() {
-        val factory = SAXParserFactory.newInstance()
-        val saxParser = factory.newSAXParser()
-        val handler = OPMLHandler()
+        val outlines = OPMLHandler.parse(testFile("nested_import.xml").inputStream())
 
-        saxParser.parse("src/test/resources/nested_import.xml", handler)
-        handler.opmlDocument
-
-        val news = handler
-            .opmlDocument
-            .outlines
+        val news = outlines
             .find { (it as? Outline.FolderOutline)?.folder?.title == "News" } as Outline.FolderOutline
 
-        val topLevelOutlines = handler.opmlDocument.outlines.map { it.title }
+        val topLevelOutlines = outlines.map { it.title }
         val newsFeeds = news.folder.feeds.map { it.title }
         val localNewsFeeds = news.folder.folders.first().feeds.map { it.title }
 
-        assertEquals(expected = listOf("Daring Fireball", "News", "Julia Evans"), actual = topLevelOutlines)
+        assertEquals(
+            expected = listOf("Daring Fireball", "News", "Julia Evans"),
+            actual = topLevelOutlines
+        )
         assertEquals(expected = listOf("BBC News - World", "NetNewsWire"), actual = newsFeeds)
         assertEquals(expected = listOf("Block Club Chicago"), actual = localNewsFeeds)
+    }
+
+    @Test
+    fun `it handles invalid characters like ampersands`() {
+        val inputStream = testFile("local_with_invalid_characters.xml").inputStream()
+
+        val outlines = OPMLHandler.parse(inputStream)
+
+        assertTrue(outlines.size == 3)
+        assertNotNull(outlines.find { it.title == "R&A Enterprise Architecture" })
     }
 }

--- a/capy/src/test/java/com/jocmp/capy/opml/OPMLImporterTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/opml/OPMLImporterTest.kt
@@ -11,13 +11,17 @@ import com.jocmp.capy.testFile
 import com.jocmp.feedfinder.parser.Feed
 import io.mockk.mockk
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import org.junit.Before
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class OPMLImporterTest {
     @JvmField
@@ -61,7 +65,7 @@ class OPMLImporterTest {
     }
 
     @Test
-    fun `it imports feeds and folders`() = runBlocking {
+    fun `it imports feeds and folders`() = runTest {
         val inputStream = testFile("nested_import.xml").inputStream()
 
         OPMLImporter(account).import(inputStream = inputStream)
@@ -77,7 +81,7 @@ class OPMLImporterTest {
     }
 
     @Test
-    fun `it handles feeds nested in multiple folders`() = runBlocking {
+    fun `it handles feeds nested in multiple folders`() = runTest {
         val inputStream = testFile("multiple_matching_feeds.xml").inputStream()
 
         OPMLImporter(account).import(inputStream = inputStream)

--- a/capy/src/test/resources/local_with_invalid_characters.xml
+++ b/capy/src/test/resources/local_with_invalid_characters.xml
@@ -7,9 +7,9 @@
     <body>
         <outline text="Daring Fireball" title="Daring Fireball" description="" type="RSS" version="RSS" htmlUrl="https://daringfireball.net/" xmlUrl="https://daringfireball.net/feeds/json"/>
         <outline text="News" title="News">
-            <outline text="BBC News - World" title="BBC News - World" description="" type="rss" version="RSS" htmlUrl="https://www.bbc.co.uk/news/" xmlUrl="https://feeds.bbci.co.uk/news/world/rss.xml"/>
+            <outline text="BBC News \n- World" title="BBC News - World" description="" type="rss" version="RSS" htmlUrl="https://www.bbc.co.uk/news/" xmlUrl="https://feeds.bbci.co.uk/news/world/rss.xml"/>
             <outline text="NetNewsWire" title="NetNewsWire" description="" type="rss" version="RSS" htmlUrl="https://netnewswire.blog/" xmlUrl="https://netnewswire.blog/feed.json"/>
         </outline>
-        <outline text="R&amp;A Enterprise Architecture" title="R&amp;A Enterprise Architecture" description="" type="rss" version="RSS" htmlUrl="" xmlUrl="https://ea.rna.nl/feed/" />
+        <outline text="R&A Enterprise Architecture" title="R&A Enterprise Architecture" description="" type="rss" version="RSS" htmlUrl="" xmlUrl="https://ea.rna.nl/feed/" />
     </body>
 </opml>


### PR DESCRIPTION
Uses JSoup as an XML parser instead of a handmade SAX Parser in order to catch unescaped characters like `&` instead of `&amp;`

Closes #166