### PR TITLE
Check for xmlUrl instead of type

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
@@ -8,7 +8,11 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
-import androidx.paging.cachedIn
+import com.capyreader.app.common.AppPreferences
+import com.capyreader.app.sync.addStarAsync
+import com.capyreader.app.sync.markReadAsync
+import com.capyreader.app.sync.markUnreadAsync
+import com.capyreader.app.sync.removeStarAsync
 import com.jocmp.capy.Account
 import com.jocmp.capy.Article
 import com.jocmp.capy.ArticleFilter
@@ -20,11 +24,6 @@ import com.jocmp.capy.MarkRead
 import com.jocmp.capy.buildArticlePager
 import com.jocmp.capy.common.UnauthorizedError
 import com.jocmp.capy.countAll
-import com.capyreader.app.common.AppPreferences
-import com.capyreader.app.sync.addStarAsync
-import com.capyreader.app.sync.markReadAsync
-import com.capyreader.app.sync.markUnreadAsync
-import com.capyreader.app.sync.removeStarAsync
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -55,7 +54,6 @@ class ArticleScreenViewModel(
 
     val articles: Flow<PagingData<Article>> = filter
         .flatMapLatest { account.buildArticlePager(it).flow }
-        .cachedIn(viewModelScope)
 
     val folders: Flow<List<Folder>> = account.folders.combine(_counts) { folders, latestCounts ->
         folders.map { copyFolderCounts(it, latestCounts) }

--- a/capy/src/main/java/com/jocmp/capy/accounts/LocalAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/LocalAccountDelegate.kt
@@ -178,10 +178,16 @@ class LocalAccountDelegate(
     ) {
         val feedURL = feed.feedURL.toString()
 
+        val feedTitle = if (title.isNullOrBlank()) {
+            feed.name
+        } else {
+            title
+        }
+
         database.feedsQueries.upsert(
             id = feedURL,
             subscription_id = feedURL,
-            title = title ?: feed.name,
+            title = feedTitle,
             feed_url = feedURL,
             site_url = feed.siteURL?.toString(),
             favicon_url = feed.faviconURL?.toString()

--- a/capy/src/main/java/com/jocmp/capy/opml/OPMLHandler.kt
+++ b/capy/src/main/java/com/jocmp/capy/opml/OPMLHandler.kt
@@ -57,4 +57,4 @@ private val Element.toFolder: Folder
     }
 
 private val Element.isFeed
-    get() = attr("type").lowercase() == "rss"
+    get() = attr("xmlUrl").isNotBlank()

--- a/capy/src/test/java/com/jocmp/capy/opml/OPMLHandlerTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/opml/OPMLHandlerTest.kt
@@ -2,7 +2,6 @@ package com.jocmp.capy.opml
 
 import com.jocmp.capy.testFile
 import org.junit.Test
-import javax.xml.parsers.SAXParserFactory
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue


### PR DESCRIPTION
Addresses #166 

[ReadYou](https://github.com/Ashinch/ReadYou) exports outlines without the "type" attribute. This change bases a feed on whether the xmlUrl attribute is present instead.