### PR TITLE
Make "Manually Only" skip on-start refresh

### DIFF
--- a/app/src/main/java/com/capyreader/app/refresher/RefreshInterval.kt
+++ b/app/src/main/java/com/capyreader/app/refresher/RefreshInterval.kt
@@ -2,11 +2,12 @@ package com.capyreader.app.refresher
 
 enum class RefreshInterval {
     MANUALLY_ONLY,
+    ON_START,
     EVERY_FIFTEEN_MINUTES,
     EVERY_THIRTY_MINUTES,
     EVERY_HOUR;
 
     companion object {
-        val default = MANUALLY_ONLY
+        val default = ON_START
     }
 }

--- a/app/src/main/java/com/capyreader/app/refresher/RefreshIntervalDurationExt.kt
+++ b/app/src/main/java/com/capyreader/app/refresher/RefreshIntervalDurationExt.kt
@@ -1,9 +1,6 @@
 package com.capyreader.app.refresher
 
-import com.capyreader.app.refresher.RefreshInterval.EVERY_FIFTEEN_MINUTES
-import com.capyreader.app.refresher.RefreshInterval.EVERY_HOUR
-import com.capyreader.app.refresher.RefreshInterval.EVERY_THIRTY_MINUTES
-import com.capyreader.app.refresher.RefreshInterval.MANUALLY_ONLY
+import com.capyreader.app.refresher.RefreshInterval.*
 import java.util.concurrent.TimeUnit
 
 val RefreshInterval.toTime: Pair<Long, TimeUnit>?
@@ -11,5 +8,6 @@ val RefreshInterval.toTime: Pair<Long, TimeUnit>?
         EVERY_FIFTEEN_MINUTES -> Pair(15, TimeUnit.MINUTES)
         EVERY_THIRTY_MINUTES -> Pair(30, TimeUnit.MINUTES)
         EVERY_HOUR -> Pair(1, TimeUnit.HOURS)
+        ON_START -> null
         MANUALLY_ONLY -> null
     }

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleLayout.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleLayout.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.paging.PagingData
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.capyreader.app.R
+import com.capyreader.app.refresher.RefreshInterval
 import com.capyreader.app.ui.articles.detail.ArticleView
 import com.capyreader.app.ui.components.rememberWebViewNavigator
 import com.capyreader.app.ui.fixtures.FeedPreviewFixture
@@ -65,6 +66,7 @@ fun ArticleLayout(
     articles: Flow<PagingData<Article>>,
     article: Article?,
     statusCount: Long,
+    refreshInterval: RefreshInterval,
     onFeedRefresh: (completion: () -> Unit) -> Unit,
     onSelectFolder: (folderTitle: String) -> Unit,
     onSelectFeed: suspend (feedID: String) -> Unit,
@@ -81,7 +83,11 @@ fun ArticleLayout(
     showUnauthorizedMessage: Boolean,
     onUnauthorizedDismissRequest: () -> Unit
 ) {
-    val (isInitialized, setInitialized) = rememberSaveable { mutableStateOf(false) }
+    val skipInitialRefresh = refreshInterval == RefreshInterval.MANUALLY_ONLY
+
+    val (isInitialized, setInitialized) = rememberSaveable {
+        mutableStateOf(skipInitialRefresh)
+    }
     val (isUpdatePasswordDialogOpen, setUpdatePasswordDialogOpen) = rememberSaveable {
         mutableStateOf(false)
     }
@@ -327,6 +333,7 @@ fun ArticleLayoutPreview() {
             folders = folders,
             feeds = feeds,
             articles = emptyFlow(),
+            refreshInterval = RefreshInterval.MANUALLY_ONLY,
             article = null,
             statusCount = 30,
             onFeedRefresh = {},

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -3,11 +3,14 @@ package com.capyreader.app.ui.articles
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.capyreader.app.common.AppPreferences
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 
 @Composable
 fun ArticleScreen(
     viewModel: ArticleScreenViewModel = koinViewModel(),
+    appPreferences: AppPreferences = koinInject(),
     onNavigateToSettings: () -> Unit,
 ) {
     val feeds by viewModel.feeds.collectAsStateWithLifecycle(initialValue = emptyList())
@@ -39,6 +42,7 @@ fun ArticleScreen(
         onToggleArticleStar = viewModel::toggleArticleStar,
         onMarkAllRead = viewModel::markAllRead,
         showUnauthorizedMessage = viewModel.showUnauthorizedMessage,
-        onUnauthorizedDismissRequest = viewModel::dismissUnauthorizedMessage
+        onUnauthorizedDismissRequest = viewModel::dismissUnauthorizedMessage,
+        refreshInterval = appPreferences.refreshInterval.get()
     )
 }

--- a/app/src/main/java/com/capyreader/app/ui/settings/RefreshIntervalMenu.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/RefreshIntervalMenu.kt
@@ -18,10 +18,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.capyreader.app.R
 import com.capyreader.app.refresher.RefreshInterval
-import com.capyreader.app.refresher.RefreshInterval.EVERY_FIFTEEN_MINUTES
-import com.capyreader.app.refresher.RefreshInterval.EVERY_HOUR
-import com.capyreader.app.refresher.RefreshInterval.EVERY_THIRTY_MINUTES
-import com.capyreader.app.refresher.RefreshInterval.MANUALLY_ONLY
+import com.capyreader.app.refresher.RefreshInterval.*
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -76,6 +73,7 @@ private fun Context.translationKey(refreshInterval: RefreshInterval): String {
         EVERY_FIFTEEN_MINUTES -> getString(R.string.refresh_minutes, 15)
         EVERY_THIRTY_MINUTES -> getString(R.string.refresh_minutes, 30)
         EVERY_HOUR -> resources.getQuantityString(R.plurals.refresh_hours, 1)
+        ON_START -> getString(R.string.refresh_on_start)
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,4 +113,5 @@
     <string name="settings_option_copy_version">Copy version</string>
     <string name="settings_option_full_content_title">Show Full Content</string>
     <string name="settings_option_full_content_subtitle">Load full article content by default</string>
+    <string name="refresh_on_start">On Start</string>
 </resources>


### PR DESCRIPTION
Link #180 

Ensures that "Manually Only" does not refresh feeds on start.

Periodic refresh selections will still fetch on start.