### PR TITLE
Fix bug causing background crashes

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
@@ -83,7 +83,7 @@ class ArticleScreenViewModel(
     fun selectArticleFilter() {
         val nextFilter = ArticleFilter.default().withStatus(status = filterStatus)
 
-        updateFilterValue(nextFilter)
+        selectArticleFilter(nextFilter)
     }
 
     fun selectStatus(status: ArticleStatus) {

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticlesModule.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticlesModule.kt
@@ -2,6 +2,7 @@ package com.capyreader.app.ui.articles
 
 import com.jocmp.capy.Account
 import com.capyreader.app.common.AppPreferences
+import com.jocmp.capy.articles.ArticleRenderer
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.parameter.parametersOf
 import org.koin.dsl.module
@@ -16,6 +17,9 @@ internal val articlesModule = module {
         AddFeedStateHolder(
             account = get<Account>(parameters = { parametersOf(get<AppPreferences>().accountID.get()) }),
         )
+    }
+    single {
+        ArticleRenderer(context = get())
     }
     viewModel {
         val appPreferences = get<AppPreferences>()

--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleView.kt
@@ -41,6 +41,11 @@ fun ArticleView(
         }
     )
 
+    val clearWebView = {
+        webViewNavigator.clearView()
+        renderer.clear()
+    }
+
     val extractedContent = extractedContentState.content
 
     fun onToggleExtractContent() {
@@ -96,13 +101,12 @@ fun ArticleView(
     }
 
     BackHandler(article != null) {
-        webViewNavigator.clearView()
         onBackPressed()
     }
 
     LaunchedEffect(articleID) {
         if (articleID == null) {
-            renderer.clear()
+            clearWebView()
             return@LaunchedEffect
         }
 
@@ -113,8 +117,7 @@ fun ArticleView(
             return@LaunchedEffect
         }
 
-        webViewNavigator.clearView()
-        renderer.clear()
+        clearWebView()
 
         if (extractedContent.requestShow) {
             extractedContentState.fetch()

--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleView.kt
@@ -16,7 +16,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.capyreader.app.ui.components.WebView
 import com.capyreader.app.ui.components.WebViewNavigator
+import com.capyreader.app.ui.components.WebViewState
 import com.capyreader.app.ui.components.rememberSaveableWebViewState
+import com.capyreader.app.ui.components.rememberWebViewState
 import com.jocmp.capy.Article
 import com.jocmp.capy.articles.ArticleRenderer
 
@@ -30,14 +32,13 @@ fun ArticleView(
 ) {
     val articleID = article?.id
     val context = LocalContext.current
-    val webViewState = rememberSaveableWebViewState(key = articleID)
     val templateColors = articleTemplateColors()
     val (initialized, setInitialized) = rememberSaveable(articleID) {
         mutableStateOf(false)
     }
 
     val renderer = ArticleRenderer(context = context, colors = templateColors.asMap())
-
+    val webViewState = rememberSaveableWebViewState(key = articleID)
     val extractedContentState = rememberExtractedContent(
         article = article,
         onComplete = { content ->
@@ -107,33 +108,17 @@ fun ArticleView(
     }
 
     LaunchedEffect(articleID) {
-        if (articleID == null || initialized) {
+        if (articleID == null) {
             return@LaunchedEffect
         }
 
-        if (extractedContent.showOnLoad) {
-
-            webViewNavigator.clearView()
+        if (extractedContent.requestShow) {
             extractedContentState.fetch()
         } else {
-
             webViewNavigator.loadHtml(renderer.render(article))
         }
 
         setInitialized(true)
-    }
-
-    // https://github.com/google/accompanist/pull/1557
-    LaunchedEffect(webViewNavigator) {
-        if (webViewState.viewState != null || article == null) {
-            return@LaunchedEffect
-        }
-
-        if (extractedContent.showByDefault) {
-            extractedContentState.fetch()
-        } else {
-            webViewNavigator.loadHtml(renderer.render(article))
-        }
     }
 
     LaunchedEffect(templateColors) {

--- a/capy/src/main/java/com/jocmp/capy/articles/ArticleRenderer.kt
+++ b/capy/src/main/java/com/jocmp/capy/articles/ArticleRenderer.kt
@@ -10,8 +10,11 @@ import com.jocmp.capy.R as CapyRes
 
 class ArticleRenderer(
     private val context: Context,
-    private val colors: Map<String, String>
 ) {
+    private var articleID: String? = null
+
+    private var html: String = ""
+
     private val styles by lazy {
         context.resources.openRawResource(CapyRes.raw.stylesheet)
             .bufferedReader()
@@ -27,7 +30,10 @@ class ArticleRenderer(
     fun render(
         article: Article,
         extractedContent: ExtractedContent = ExtractedContent(),
+        colors: Map<String, String>,
     ): String {
+        articleID = article.id
+
         val substitutions = colors + mapOf(
             "external_link" to article.url.toString(),
             "title" to article.title,
@@ -38,10 +44,25 @@ class ArticleRenderer(
             "script" to script(article, extractedContent)
         )
 
-        return MacroProcessor(
+        html = MacroProcessor(
             template = template,
             substitutions = substitutions
         ).renderedText
+
+        return html
+    }
+
+    fun fetchCached(article: Article): String {
+        if (article.id != articleID) {
+           return ""
+        }
+
+        return html
+    }
+
+    fun clear() {
+        articleID = null
+        html = ""
     }
 
     private fun script(article: Article, extractedContent: ExtractedContent): String {


### PR DESCRIPTION
The "saveState" method on WebView will persistent the entire contents of the webview and info about the backstack. This can rack up megabytes worth of data. The bundle limit is about 500KB.

The fix is to only save the scroll-y position and rebuild the webview from other state. This prevents the bundle size from exceeding the max size of an integer.


Ref: https://developer.android.com/reference/android/os/TransactionTooLargeException

Link #179, Closes #184