### PR TITLE
Add swipe gesture for feed list on small screens

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScaffold.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScaffold.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.layout.AnimatedPane
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
+import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldRole
 import androidx.compose.material3.adaptive.navigation.ThreePaneScaffoldNavigator
 import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
 import androidx.compose.material3.rememberDrawerState
@@ -20,6 +21,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import com.capyreader.app.ui.components.safeEdgePadding
+import com.capyreader.app.ui.isCompact
 import com.capyreader.app.ui.theme.CapyTheme
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
@@ -31,9 +33,12 @@ fun ArticleScaffold(
     listPane: @Composable () -> Unit,
     detailPane: @Composable () -> Unit,
 ) {
+    val enableGesture = drawerState.isOpen ||
+            isCompact() && scaffoldNavigator.currentDestination?.pane != ThreePaneScaffoldRole.Primary
+
     ModalNavigationDrawer(
         drawerState = drawerState,
-        gesturesEnabled = drawerState.isOpen,
+        gesturesEnabled = enableGesture,
         drawerContent = {
             ModalDrawerSheet {
                 drawerPane()


### PR DESCRIPTION
Enables the drawer swipe for compact screens (phone, portrait).

Tablet swiping may be enabled by restricting gesture propagation.

Closes #145 

https://github.com/user-attachments/assets/a3a8bbba-49a0-449b-a121-5539f77982f2

