### PR TITLE
Add custom postlight parser for tagesschau

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 capy/src/main/res/raw/*.html linguist-generated=true
-capy/src/main/res/raw/*.js linguist-generated=true
+capy/src/main/assets/*.css linguist-generated=true
+capy/src/main/assets/*.js linguist-generated=true
 capy/src/test/resources/*.html linguist-generated=true
 feedfinder/src/test/resources/*.html linguist-generated=true
 feedfinder/src/test/resources/*.xml linguist-generated=true

--- a/capy/src/main/assets/custom-extractors.js
+++ b/capy/src/main/assets/custom-extractors.js
@@ -1,0 +1,23 @@
+const tagesschauExtractor = {
+  domain: 'www.tagesschau.de',
+  title: {
+    selectors: ['.seitenkopf__headline'],
+  },
+  author: {
+    selectors: ['.authorline__author'],
+  },
+  content: {
+    selectors: ['article'],
+    clean: [
+      '[data-config]',
+      '.seitenkopf__headline',
+      '.authorline__author',
+      '.metatextline'
+    ],
+  },
+  date_published: {
+    selectors: ['.metatextline'],
+  },
+};
+
+Mercury.addExtractor(tagesschauExtractor)

--- a/capy/src/main/java/com/jocmp/capy/articles/ArticleRenderer.kt
+++ b/capy/src/main/java/com/jocmp/capy/articles/ArticleRenderer.kt
@@ -62,7 +62,7 @@ class ArticleRenderer(
         val content = extractedContent.value()
 
         if (extractedContent.requestShow && content != null) {
-            return context.extractedTemplate(article, content)
+            return extractedTemplate(article, content)
         }
 
         return ""

--- a/capy/src/main/java/com/jocmp/capy/articles/ExtractedTemplate.kt
+++ b/capy/src/main/java/com/jocmp/capy/articles/ExtractedTemplate.kt
@@ -2,7 +2,6 @@ package com.jocmp.capy.articles
 
 import com.jocmp.capy.Article
 import org.json.JSONObject
-import org.jsoup.Jsoup
 
 internal fun extractedTemplate(
     article: Article,

--- a/capy/src/main/java/com/jocmp/capy/articles/ExtractedTemplate.kt
+++ b/capy/src/main/java/com/jocmp/capy/articles/ExtractedTemplate.kt
@@ -1,11 +1,10 @@
 package com.jocmp.capy.articles
 
-import android.content.Context
 import com.jocmp.capy.Article
-import com.jocmp.capy.R
 import org.json.JSONObject
+import org.jsoup.Jsoup
 
-internal fun Context.extractedTemplate(
+internal fun extractedTemplate(
     article: Article,
     html: String,
 ): String {

--- a/capy/src/main/res/raw/template.html
+++ b/capy/src/main/res/raw/template.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -14,8 +13,9 @@
         --color-on-primary-container: {{color_on_primary_container}};
       }
     </style>
-    <link rel="stylesheet" href="file:///android_asset/stylesheet.css">
-    <script type="text/javascript" src="file:///android_asset/mercury.js"></script>
+    <link rel="stylesheet" href="/assets/stylesheet.css">
+    <script type="text/javascript" src="/assets/mercury.js"></script>
+    <script type="text/javascript" src="/assets/custom-extractors.js"></script>
   </head>
   <body>
     <article>
@@ -26,7 +26,7 @@
         <div>{{byline}}</div>
         <div>{{feed_name}}</div>
       </a>
-      <div class="article__body article__body--text-size-{{text_size}}">
+      <div class="article__body article__body--font-{{font_family}} article__body--text-size-{{text_size}}">
         <div id="article-body-content">
           {{body}}
         </div>


### PR DESCRIPTION
Link #205 

Adds a custom Postlight Parser for tagesschau.de.

The website embeds JavaScript into some HTML feeds which currently breaks the parser.