### PR TITLE
Revise Full Content setting

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleLayout.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleLayout.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.TopAppBar
@@ -158,7 +159,11 @@ fun ArticleLayout(
 
     val showSnackbar = { message: String ->
         coroutineScope.launch {
-            snackbarHost.showSnackbar(message)
+            snackbarHost.showSnackbar(
+                message,
+                withDismissAction = true,
+                duration = SnackbarDuration.Short
+            )
         }
     }
 

--- a/app/src/main/java/com/capyreader/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/SettingsViewModel.kt
@@ -20,6 +20,7 @@ import com.jocmp.capy.Account
 import com.jocmp.capy.AccountManager
 import com.jocmp.capy.accounts.Source
 import com.jocmp.capy.opml.ImportProgress
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class SettingsViewModel(
@@ -126,6 +127,12 @@ class SettingsViewModel(
         appPreferences.enableStickyFullContent.set(enable)
 
         _enableStickyFullContent.value = enable
+
+        if (!enable) {
+            viewModelScope.launch(Dispatchers.IO) {
+                account.clearStickyFullContent()
+            }
+        }
     }
 
     fun removeAccount() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,8 +111,8 @@
     <string name="settings_more_display_options_button">More Display Options</string>
     <string name="settings_section_version">Version</string>
     <string name="settings_option_copy_version">Copy version</string>
-    <string name="settings_option_full_content_title">Show Full Content</string>
-    <string name="settings_option_full_content_subtitle">Load full article content by default</string>
+    <string name="settings_option_full_content_title">Sticky Full Content</string>
+    <string name="settings_option_full_content_subtitle">Remember choice to load full article content</string>
     <string name="refresh_on_start">On start</string>
     <string name="empty_onboarding_title">No feeds yet.</string>
     <string name="empty_onboarding_prompt">Start by adding a feed</string>

--- a/capy/src/main/java/com/jocmp/capy/Account.kt
+++ b/capy/src/main/java/com/jocmp/capy/Account.kt
@@ -14,7 +14,6 @@ import com.jocmp.capy.opml.OPMLImporter
 import com.jocmp.capy.persistence.ArticleRecords
 import com.jocmp.capy.persistence.FeedRecords
 import com.jocmp.feedbinclient.Feedbin
-import com.jocmp.feedfinder.DefaultFeedFinder
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -178,6 +177,18 @@ data class Account(
         }
 
         return opml
+    }
+
+    fun enableStickyContent(feedID: String) {
+        feedRecords.updateStickyFullContent(enabled = true, feedID = feedID)
+    }
+
+    fun disableStickyContent(feedID: String) {
+        feedRecords.updateStickyFullContent(enabled = false, feedID = feedID)
+    }
+
+    fun clearStickyFullContent() {
+        feedRecords.clearStickyFullContent()
     }
 }
 

--- a/capy/src/main/java/com/jocmp/capy/Article.kt
+++ b/capy/src/main/java/com/jocmp/capy/Article.kt
@@ -19,4 +19,5 @@ data class Article(
     val starred: Boolean,
     val feedName: String = "",
     val faviconURL: String? = null,
+    val enableStickyFullContent: Boolean = false,
 )

--- a/capy/src/main/java/com/jocmp/capy/Feed.kt
+++ b/capy/src/main/java/com/jocmp/capy/Feed.kt
@@ -11,5 +11,6 @@ data class Feed(
     val siteURL: String = "",
     val folderName: String = "",
     val faviconURL: String? = null,
-    override val count: Long = 0
+    override val count: Long = 0,
+    val enableStickyFullContent: Boolean = false,
 ): Countable

--- a/capy/src/main/java/com/jocmp/capy/persistence/ArticleMapper.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/ArticleMapper.kt
@@ -18,6 +18,7 @@ internal fun articleMapper(
     publishedAt: Long?,
     feedTitle: String?,
     faviconURL: String?,
+    enableStickyContent: Boolean = false,
     updatedAt: Long?,
     starred: Boolean?,
     read: Boolean?,
@@ -38,6 +39,7 @@ internal fun articleMapper(
         read = read ?: false,
         starred = starred ?: false,
         feedName = feedTitle ?: "",
+        enableStickyFullContent = enableStickyContent
     )
 }
 
@@ -46,7 +48,6 @@ internal fun listMapper(
     feedID: String?,
     title: String?,
     author: String?,
-    contentHtml: String?,
     extractedContentURL: String?,
     url: String?,
     summary: String?,

--- a/capy/src/main/java/com/jocmp/capy/persistence/FeedRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/FeedRecords.kt
@@ -47,6 +47,17 @@ internal class FeedRecords(private val database: Database) {
         )
     }
 
+    fun updateStickyFullContent(feedID: String, enabled: Boolean) {
+        database.feedsQueries.updateStickyFullContent(
+            enabled = enabled,
+            feedID = feedID
+        )
+    }
+
+    fun clearStickyFullContent() {
+        database.feedsQueries.clearStickyFullContent()
+    }
+
     suspend fun findFolder(title: String): Folder? {
         val feeds = database.feedsQueries.findByFolder(title, mapper = ::feedMapper)
             .asFlow()
@@ -78,18 +89,18 @@ internal class FeedRecords(private val database: Database) {
         feedURL: String,
         siteURL: String?,
         faviconURL: String?,
+        enableStickyFullContent: Boolean = false,
         folderName: String? = "",
-        articleCount: Long = 0
-    ): Feed {
-        return Feed(
-            id = id,
-            subscriptionID = subscriptionID,
-            title = title,
-            feedURL = feedURL,
-            siteURL = siteURL.orEmpty(),
-            faviconURL = faviconURL,
-            folderName = folderName.orEmpty(),
-            count = articleCount
-        )
-    }
+        articleCount: Long = 0,
+    ) = Feed(
+        id = id,
+        subscriptionID = subscriptionID,
+        title = title,
+        feedURL = feedURL,
+        siteURL = siteURL.orEmpty(),
+        faviconURL = faviconURL,
+        folderName = folderName.orEmpty(),
+        count = articleCount,
+        enableStickyFullContent = enableStickyFullContent
+    )
 }

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/5_AddFeedStickyContentSetting.sqm
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/5_AddFeedStickyContentSetting.sqm
@@ -1,0 +1,4 @@
+import kotlin.Boolean;
+
+ALTER TABLE feeds
+ADD COLUMN enable_sticky_full_content INTEGER AS Boolean NOT NULL DEFAULT 0;

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articles.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articles.sq
@@ -1,6 +1,14 @@
 findByStatus:
 SELECT
-  articles.*,
+  articles.id,
+  articles.feed_id,
+  articles.title,
+  articles.author,
+  articles.extracted_content_url,
+  articles.url,
+  articles.summary,
+  articles.image_url,
+  articles.published_at,
   feeds.title AS feed_title,
   feeds.favicon_url,
   article_statuses.updated_at,
@@ -17,7 +25,15 @@ LIMIT :limit OFFSET :offset;
 
 findByFeeds:
 SELECT
-  articles.*,
+  articles.id,
+  articles.feed_id,
+  articles.title,
+  articles.author,
+  articles.extracted_content_url,
+  articles.url,
+  articles.summary,
+  articles.image_url,
+  articles.published_at,
   feeds.title AS feed_title,
   feeds.favicon_url,
   article_statuses.updated_at,
@@ -104,6 +120,7 @@ SELECT
   articles.*,
   feeds.title AS feed_title,
   feeds.favicon_url,
+  feeds.enable_sticky_full_content,
   article_statuses.updated_at,
   article_statuses.starred,
   article_statuses.read

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/feeds.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/feeds.sq
@@ -43,6 +43,12 @@ VALUES (
 updateName:
 UPDATE feeds SET title = :title WHERE feeds.id = :feedID;
 
+updateStickyFullContent:
+UPDATE feeds SET enable_sticky_full_content = :enabled WHERE feeds.id = :feedID;
+
+clearStickyFullContent:
+UPDATE feeds SET enable_sticky_full_content = 0;
+
 delete {
   DELETE FROM article_statuses WHERE article_statuses.article_id IN (
       SELECT id

--- a/capy/src/test/java/com/jocmp/capy/IntExt.kt
+++ b/capy/src/test/java/com/jocmp/capy/IntExt.kt
@@ -1,10 +1,22 @@
 package com.jocmp.capy
 
+import kotlinx.coroutines.runBlocking
+
 internal fun <T> Int.repeated(action: (i: Int) -> T): List<T> {
     val list = mutableListOf<T>()
 
     repeat(this) {
         list.add(action(it))
+    }
+
+    return list
+}
+
+internal fun <T> Int.awaitRepeated(action: suspend (i: Int) -> T): List<T> {
+    val list = mutableListOf<T>()
+
+    repeat(this) {
+        list.add(runBlocking { action(it) })
     }
 
     return list

--- a/capy/src/test/java/com/jocmp/capy/fixtures/FeedFixture.kt
+++ b/capy/src/test/java/com/jocmp/capy/fixtures/FeedFixture.kt
@@ -6,9 +6,10 @@ import com.jocmp.capy.persistence.FeedRecords
 import kotlinx.coroutines.runBlocking
 import java.security.SecureRandom
 
-class FeedFixture(database: Database) {
-    private val records = FeedRecords(database)
-
+internal class FeedFixture(
+    database: Database,
+    private val records: FeedRecords = FeedRecords(database)
+) {
     fun create(
         feedID: String = randomID(),
         feedURL: String = "https://example.com",

--- a/capy/src/test/java/com/jocmp/capy/persistence/FeedRecordsTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/persistence/FeedRecordsTest.kt
@@ -1,11 +1,17 @@
 package com.jocmp.capy.persistence
 
 import com.jocmp.capy.InMemoryDatabaseProvider
+import com.jocmp.capy.awaitRepeated
 import com.jocmp.capy.db.Database
 import com.jocmp.capy.fixtures.ArticleFixture
+import com.jocmp.capy.fixtures.FeedFixture
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class FeedRecordsTest {
     private lateinit var database: Database
@@ -32,4 +38,41 @@ class FeedRecordsTest {
         assertNull(result)
     }
 
+    @Test
+    fun updateStickyFullContent() = runTest {
+        val records = FeedRecords(database)
+        var feed = FeedFixture(database, records = records).create()
+
+        assertFalse(feed.enableStickyFullContent)
+
+        records.updateStickyFullContent(enabled = true, feedID = feed.id)
+
+        feed = records.findBy(feed.id)!!
+
+        assertTrue(feed.enableStickyFullContent)
+    }
+
+    @Test
+    fun clearStickyFullContent() = runTest {
+        val records = FeedRecords(database)
+        val feeds = 3.awaitRepeated {
+            val feed = FeedFixture(database, records = records).create()
+            records.updateStickyFullContent(enabled = true, feedID = feed.id)
+
+            records.findBy(feed.id)!!
+        }
+
+        assertEquals(
+            expected = setOf(true),
+            actual = feeds.map { it.enableStickyFullContent }.toSet()
+        )
+
+        records.clearStickyFullContent()
+
+        val updated = feeds.map { records.findBy(it.id)!! }
+        assertEquals(
+            expected = setOf(false),
+            actual = updated.map { it.enableStickyFullContent }.toSet()
+        )
+    }
 }


### PR DESCRIPTION
Closes #215 

Updates the "Show Full Content" setting to bring it in line with Feedbin's implementation of
"Sticky Full Content." When enabled, this setting will rememeber the full content setting for a given feed when it's toggled on.

When the setting is toggled off, all feeds are reset.