### PR TITLE
Allow feeds with missing link

### DIFF
--- a/feedfinder/src/main/java/com/jocmp/feedfinder/parser/XMLFeed.kt
+++ b/feedfinder/src/main/java/com/jocmp/feedfinder/parser/XMLFeed.kt
@@ -11,7 +11,6 @@ internal class XMLFeed(
 ) : Feed {
     override fun isValid(): Boolean {
         return channel != null &&
-                !channel.link.isNullOrBlank() &&
                 hasEntries()
     }
 

--- a/feedfinder/src/test/java/com/jocmp/feedfinder/parser/XMLFeedTest.kt
+++ b/feedfinder/src/test/java/com/jocmp/feedfinder/parser/XMLFeedTest.kt
@@ -19,6 +19,19 @@ class XMLFeedTest {
     }
 
     @Test
+    fun siteURLIsMissing() = runTest {
+        val responseBody = File("src/test/resources/microsoft_support.xml").readText()
+
+        val feed = XMLFeed.from(
+            url = URL("https://support.microsoft.com/en-us/feed/rss/6ae59d69-36fc-8e4d-23dd-631d98bf74a9"),
+            body = responseBody
+        )
+
+        assertTrue(feed.isValid())
+        assertNull(feed.siteURL)
+    }
+
+    @Test
     fun siteURLIsInvalid() = runTest {
         val responseBody = File("src/test/resources/brasildefato_com_br.xml").readText()
 

--- a/feedfinder/src/test/resources/microsoft_support.xml
+++ b/feedfinder/src/test/resources/microsoft_support.xml
@@ -1,0 +1,7624 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss
+  version="2.0">
+  <channel>
+    <title>Microsoft Support - Windows 10</title>
+    <description>Microsoft Support</description>
+    <copyright>2024 Microsoft</copyright>
+    <lastBuildDate>Tue, 30 Jul 2024 21:25:20 Z</lastBuildDate>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/what-to-do-if-microsoft-edge-isn-t-working-cc0657a6-acd2-cbbd-1528-c0335c71312a</link>
+      <title>What to do if Microsoft Edge isn't working - Microsoft Support</title>
+      <description>This article gives you a few tips to help you get Microsoft Edge up and running
+        again after a crash.</description>
+      <pubDate>Tue, 30 Jul 2024 17:31:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5001716-update-for-windows-update-service-components-fb9dd3d3-d702-4f8a-af10-b9551cfa6e13</link>
+      <title>KB5001716: Update for Windows Update Service components - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 30 Jul 2024 17:00:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/user-account-control-settings-d5b2046b-dcb8-54eb-f732-059f321afe18</link>
+      <title>User Account Control settings - Microsoft Support</title>
+      <description>Learn about User Account Control settings in Windows.</description>
+      <pubDate>Tue, 30 Jul 2024 12:58:18 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/temporarily-allow-cookies-and-site-data-in-microsoft-edge-597f04f2-c0ce-f08c-7c2b-541086362bd2</link>
+      <title>Temporarily allow cookies and site data in Microsoft Edge - Microsoft Support</title>
+      <description>Learn how you can manage cookies and site data you've temporarily allowed in
+        Microsoft Edge.</description>
+      <pubDate>Mon, 29 Jul 2024 18:03:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/keyboard-shortcuts-in-windows-dcc61a57-8ff0-cffe-9796-cb9706c75eec</link>
+      <title>Keyboard shortcuts in Windows - Microsoft Support</title>
+      <description>Learn how to navigate Windows using keyboard shortcuts. Explore a full list of
+        taskbar, command prompt, and general Windows shortcuts.</description>
+      <pubDate>Mon, 29 Jul 2024 16:41:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/troubleshoot-problems-signing-in-to-windows-298cfd5f-df1f-c66b-36ad-f2a61a73baad</link>
+      <title>Troubleshoot problems signing in to Windows - Microsoft Support</title>
+      <description>Learn how to troubleshoot Windows sign in issues, including problems signing in
+        to your Windows device after upgrading.</description>
+      <pubDate>Fri, 26 Jul 2024 19:10:40 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-hello-common-issues-and-troubleshooting-tips-bf68539e-e95e-48b6-a6cb-455649db3887</link>
+      <title>Windows Hello common issues and troubleshooting tips - Microsoft Support</title>
+      <description>Learn how to troubleshoot Windows Hello sign in issues, error messages, or facial
+        recognition.</description>
+      <pubDate>Fri, 26 Jul 2024 18:53:27 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/create-and-use-strong-passwords-c5cebb49-8c53-4f5e-2bc4-fe357ca048eb</link>
+      <title>Create and use strong passwords - Microsoft Support</title>
+      <description>Follow these tips to improve the safety and security of your online accounts by
+        creating strong passwords and keeping them secure.</description>
+      <pubDate>Fri, 26 Jul 2024 15:13:57 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-9-2024-kb5040427-os-builds-19044-4651-and-19045-4651-78458e76-9404-41b4-91b2-6d3cdcf4a530</link>
+      <title>July 9, 2024—KB5040427 (OS Builds 19044.4651 and 19045.4651) - Microsoft Support</title>
+      <description>July 9, 2024—KB5040427 (OS Builds 19044.4651 and 19045.4651)</description>
+      <pubDate>Fri, 26 Jul 2024 02:53:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-9-2024-kb5040434-os-build-14393-7159-40d1baef-65b4-467f-9bd9-729d369fcc4c</link>
+      <title>July 9, 2024—KB5040434 (OS Build 14393.7159) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 25 Jul 2024 23:28:57 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-9-2024-kb5040430-os-build-17763-6054-0bb10c24-db8c-47eb-8fa9-9ebc06afa4e7</link>
+      <title>July 9, 2024—KB5040430 (OS Build 17763.6054) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 25 Jul 2024 23:26:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-23-2024-kb5040525-os-build-19045-4717-preview-381f029e-b20e-4a0f-9b7e-695ee7845168</link>
+      <title>July 23, 2024—KB5040525 (OS Build 19045.4717) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 25 Jul 2024 23:24:11 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/configure-windows-hello-dae28983-8242-bb2a-d3d1-87c9d265a5f0</link>
+      <title>Configure Windows Hello - Microsoft Support</title>
+      <description>Learn how to sign into your PC with Windows Hello using a PIN, facial
+        recognition, or fingerprint.</description>
+      <pubDate>Thu, 25 Jul 2024 20:34:27 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-error-message-we-can-t-sign-in-to-your-account-18d55f00-a6e7-9106-29ee-54fa223c0ca8</link>
+      <title>Windows error message: "We can't sign in to your account" - Microsoft Support</title>
+      <description>Get help fixing the error "We can't sign in to your account."</description>
+      <pubDate>Thu, 25 Jul 2024 19:24:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/join-the-windows-insider-program-and-manage-insider-settings-ef20bb3d-40f4-20cc-ba3c-a72c844b563c</link>
+      <title>Join the Windows Insider Program and manage Insider settings - Microsoft Support</title>
+      <description>Join the Windows Insider Program</description>
+      <pubDate>Wed, 24 Jul 2024 22:15:28 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/help-in-wordpad-e52d0c6f-da12-ec16-eb79-73d31e5136fc</link>
+      <title>Help in WordPad - Microsoft Support</title>
+      <description>Get answers to common questions about WordPad.</description>
+      <pubDate>Wed, 24 Jul 2024 20:20:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/view-and-delete-browser-history-in-microsoft-edge-00cf7943-a9e1-975a-a33d-ac10ce454ca4</link>
+      <title>View and delete browser history in Microsoft Edge - Microsoft Support</title>
+      <description>Learn how to view and delete your browser history and other history in Microsoft
+        Edge.</description>
+      <pubDate>Tue, 23 Jul 2024 21:29:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/view-cookies-in-microsoft-edge-a7d95376-f2cd-8e4a-25dc-1de753474879</link>
+      <title>View cookies in Microsoft Edge - Microsoft Support</title>
+      <description>Get the steps for how to view cookies in Microsoft Edge.</description>
+      <pubDate>Tue, 23 Jul 2024 18:54:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/web-links-from-outlook-emails-and-teams-chats-open-in-microsoft-edge-b0e1a1c1-bd62-462c-9ed5-5938b9c649f0</link>
+      <title>Web links from Outlook emails and Teams chats open in Microsoft Edge - Microsoft
+        Support</title>
+      <description>Discover how Microsoft Edge helps you stay more focused and organized online with
+        Microsoft 365 features built-in.</description>
+      <pubDate>Tue, 23 Jul 2024 18:52:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/understanding-the-risks-why-you-should-not-uninstall-security-updates-52b21351-8e09-477d-b19a-b55d1c77f377</link>
+      <title>Understanding the risks: Why you should not uninstall security updates - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Tue, 23 Jul 2024 17:00:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/calculate-days-between-dates-or-calculate-a-future-or-past-date-c12972c8-1c93-a4e6-32d0-0067004faa43</link>
+      <title>Calculate days between dates or calculate a future or past date - Microsoft Support</title>
+      <description>Calculate the number of days between two dates or calculate a past or future
+        date.</description>
+      <pubDate>Tue, 23 Jul 2024 16:41:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/why-can-t-i-uninstall-microsoft-edge-ee150b3b-7d7a-9984-6d83-eb36683d526d</link>
+      <title>Why can't I uninstall Microsoft Edge? - Microsoft Support</title>
+      <description>Learn more about why you can't uninstall Microsoft Edge on your Windows computer.</description>
+      <pubDate>Tue, 23 Jul 2024 16:20:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5042421-crowdstrike-issue-impacting-windows-endpoints-causing-an-0x50-or-0x7e-error-message-on-a-blue-screen-b1c700e0-7317-4e95-aeee-5d67dd35b92f</link>
+      <title>KB5042421: CrowdStrike issue impacting Windows endpoints causing an 0x50 or 0x7E error
+        message on a blue screen - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 22 Jul 2024 21:20:10 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/sign-in-options-in-windows-8ae09c04-c5da-41c9-972f-b126a13d18a8</link>
+      <title>Sign-in options in Windows - Microsoft Support</title>
+      <description>Learn about the sign-in options in Windows settings.</description>
+      <pubDate>Mon, 22 Jul 2024 14:54:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/inside-this-update-93c5c27c-f96e-43c2-a08e-5812d92f220d</link>
+      <title>Inside this update - Microsoft Support</title>
+      <description>Learn what's new in the latest Windows update. Explore new features and apps to
+        help you be more productive.</description>
+      <pubDate>Sat, 20 Jul 2024 01:02:28 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/what-s-new-in-recent-windows-updates-2df971e0-341a-68b1-3bf8-bc3e3ff8c3a5</link>
+      <title>What's new in recent Windows updates - Microsoft Support</title>
+      <description>See what's new in recent Windows 10 and Windows 11 updates, including a chat from
+        the taskbar, widgets, snap groups, and more.</description>
+      <pubDate>Sat, 20 Jul 2024 01:01:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/keep-the-windows-calculator-app-window-on-top-914ecdc3-fd12-d10f-0bf7-53132745478e</link>
+      <title>Keep the Windows Calculator app window on top - Microsoft Support</title>
+      <description>Keep the calculator window on top of other windows as you work if you're using
+        the Standard mode.</description>
+      <pubDate>Fri, 19 Jul 2024 23:52:57 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-the-calculator-in-windows-8dc0eb59-a45f-72b6-71bd-e752920f36c3</link>
+      <title>Use the Calculator in Windows - Microsoft Support</title>
+      <description>See what's new in the Calculator app in Windows.</description>
+      <pubDate>Fri, 19 Jul 2024 22:05:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-9-2024-kb5040448-os-build-10240-20710-b0358c81-9036-4452-84aa-e08e040d012b</link>
+      <title>July 9, 2024—KB5040448 (OS Build 10240.20710) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 19 Jul 2024 00:20:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5028997-instructions-to-manually-resize-your-partition-to-install-the-winre-update-400faa27-9343-461c-ada9-24c8229763bf</link>
+      <title>KB5028997: Instructions to manually resize your partition to install the WinRE update -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 18 Jul 2024 17:34:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-snipping-tool-to-capture-screenshots-00246869-1843-655f-f220-97299b865f6b</link>
+      <title>Use Snipping Tool to capture screenshots - Microsoft Support</title>
+      <description>Learn how to use Snipping Tool to capture a screenshot, or snip, of any object on
+        your screen, and then annotate, save, or share the image.</description>
+      <pubDate>Thu, 18 Jul 2024 17:30:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/open-snipping-tool-and-take-a-screenshot-a35ac9ff-4a58-24c9-3253-f12bac9f9d44</link>
+      <title>Open Snipping Tool and take a screenshot - Microsoft Support</title>
+      <description>Take a screenshot with the Snipping Tool.</description>
+      <pubDate>Thu, 18 Jul 2024 16:04:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/convert-currency-with-the-windows-calculator-app-e45b7e2c-0ea7-93a0-82a1-e279b170941b</link>
+      <title>Convert currency with the Windows Calculator app - Microsoft Support</title>
+      <description>Use the Windows Calculator app to convert more than 100 different currencies from
+        around the world, even if you're offline.</description>
+      <pubDate>Wed, 17 Jul 2024 23:39:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-the-scientific-calculator-in-windows-e53b404e-9223-5e99-4c54-5dc8645552ab</link>
+      <title>Use the scientific calculator in Windows - Microsoft Support</title>
+      <description>The Calculator app for Windows is a desktop calculator that includes standard,
+        scientific, programmer, and date calculation modes.</description>
+      <pubDate>Wed, 17 Jul 2024 23:39:09 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/your-games-on-windows-eda734d0-e4a6-c29e-b22c-5eee94b053c7</link>
+      <title>Your games on Windows - Microsoft Support</title>
+      <description>Find and play the games already installed on your PC and in your collection using
+        the Xbox Console Companion app on your Windows 10 PC.</description>
+      <pubDate>Wed, 17 Jul 2024 23:25:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/older-versions-of-battleye-software-may-not-be-compatible-with-windows-10-version-1903-26ad3ec8-e5af-c0e2-ac70-df7c4a0aca4c</link>
+      <title>Older versions of BattlEye software may not be compatible with Windows 10, version 1903
+        - Microsoft Support</title>
+      <description>There is a compatability issue with older versions of BattlEye software and the
+        Windows 10, version 1903 update.</description>
+      <pubDate>Wed, 17 Jul 2024 23:24:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-header-and-footer-commands-in-notepad-c1b0e27b-497d-c478-c4c1-0da491cac148</link>
+      <title>Change Header and Footer Commands in Notepad - Microsoft Support</title>
+      <description>Learn about changing Header and Footer commands in Notepad.</description>
+      <pubDate>Wed, 17 Jul 2024 21:54:18 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-stickers-in-paint-3d-53dd7adf-c332-c7b8-9693-b214c10d0a6f</link>
+      <title>Use stickers in Paint 3D - Microsoft Support</title>
+      <description>Stickers help personalize your 3D projects in Paint 3D on Windows 10.</description>
+      <pubDate>Wed, 17 Jul 2024 18:34:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/paint-3d-for-2d-24e34aa5-afb2-b395-814b-682d9d4fbbad</link>
+      <title>Paint 3D for 2D - Microsoft Support</title>
+      <description>Beyond it’s new, 3D capabilities, Paint 3D on Windows 10 has awesome tools for
+        editing on the 2D canvas.</description>
+      <pubDate>Wed, 17 Jul 2024 18:32:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/make-a-3d-doodle-67f18c4d-3970-7ee8-5e33-0286592c2af1</link>
+      <title>Make a 3D doodle - Microsoft Support</title>
+      <description>Turn a freehand sketch into a 3D object with Paint 3D on Windows 10.</description>
+      <pubDate>Wed, 17 Jul 2024 18:31:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/basic-3d-modeling-dbd08140-2cf2-3e72-69a7-842de1782e7c</link>
+      <title>Basic 3D modeling - Microsoft Support</title>
+      <description>Learn to get started making basic 3D objects in Paint 3D.</description>
+      <pubDate>Wed, 17 Jul 2024 18:29:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/diagnostics-feedback-and-privacy-in-windows-28808a2b-a31b-dd73-dcd3-4559a5199319</link>
+      <title>Diagnostics, feedback, and privacy in Windows - Microsoft Support</title>
+      <description>Learn how Microsoft collects and uses different kinds of diagnostic information
+        to help fix problems quickly and improve your Windows experience, and how to control the
+        data you share.</description>
+      <pubDate>Mon, 15 Jul 2024 20:01:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/automatically-finish-setting-up-a-windows-device-after-an-update-a0dadce5-dca1-1c4d-ce14-a0f480f3265e</link>
+      <title>Automatically finish setting up a Windows device after an update - Microsoft Support</title>
+      <description>Speed up the sign-in process by having Windows 10 or Windows 11 automatically
+        sign you in after an update or restart. You can choose this option in Settings.</description>
+      <pubDate>Thu, 11 Jul 2024 21:41:30 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/user-account-access-in-windows-8f1f3c05-e479-4e9a-666b-90091d052aaf</link>
+      <title>User account access in Windows - Microsoft Support</title>
+      <description>Learn how to sign in, sign out, lock, and switch user account in Windows.</description>
+      <pubDate>Thu, 11 Jul 2024 17:14:41 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5025885-how-to-manage-the-windows-boot-manager-revocations-for-secure-boot-changes-associated-with-cve-2023-24932-41a975df-beb2-40c1-99a3-b3ff139f832d</link>
+      <title>KB5025885: How to manage the Windows Boot Manager revocations for Secure Boot changes
+        associated with CVE-2023-24932 - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 11 Jul 2024 01:41:18 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-11-2024-kb5039217-os-build-17763-5936-d435559e-ae16-44d0-b145-027eb4af7f47</link>
+      <title>June 11, 2024—KB5039217 (OS Build 17763.5936) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 11 Jul 2024 00:03:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-use-3d-scan-for-windows-320561db-2946-f399-a8f3-efa22b26344b</link>
+      <title>How to use 3D Scan for Windows - Microsoft Support</title>
+      <description>Information about 3D Scan for Windows 10.</description>
+      <pubDate>Wed, 10 Jul 2024 22:45:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-use-3d-builder-for-windows-e7acb10c-d468-af62-dc1d-26eccd94fae3</link>
+      <title>How to use 3D Builder for Windows - Microsoft Support</title>
+      <description>How to use 3D Builder and 3D Scan for Windows</description>
+      <pubDate>Wed, 10 Jul 2024 22:35:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/install-and-use-a-scanner-in-windows-10-4fd9f33a-25b6-159a-3cde-3f009b02a81a</link>
+      <title>Install and use a scanner in Windows 10 - Microsoft Support</title>
+      <description>Learn how to install a scanner and use it to scan pictures and documents in
+        Windows 10.</description>
+      <pubDate>Wed, 10 Jul 2024 22:16:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/deploy-windows-malicious-software-removal-tool-in-an-enterprise-environment-kb891716-a10cc756-2b3b-32e3-9ee3-2c1298ea3538</link>
+      <title>Deploy Windows Malicious Software Removal Tool in an enterprise environment (KB891716)
+        - Microsoft Support</title>
+      <description>Describes how to deploy the Microsoft Windows Malicious Software Removal Tool
+        (MSRT) in an enterprise environment.</description>
+      <pubDate>Tue, 09 Jul 2024 17:12:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5040562-servicing-stack-update-for-windows-10-version-1607-and-server-2016-july-9-2024-281c97b9-c566-417e-8406-a84efd30f70c</link>
+      <title>KB5040562: Servicing stack update for Windows 10, version 1607 and Server 2016: July 9,
+        2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Jul 2024 17:01:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5040566-servicing-stack-update-for-windows-10-july-9-2024-02c0bb5d-9b1c-4cd0-9822-5a65076eb5ee</link>
+      <title>KB5040566: Servicing stack update for Windows 10: July 9, 2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Jul 2024 17:01:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5034441-windows-recovery-environment-update-for-windows-10-version-21h2-and-22h2-january-9-2024-62c04204-aaa5-4fee-a02a-2fdea17075a8</link>
+      <title>KB5034441: Windows Recovery Environment update for Windows 10, version 21H2 and 22H2:
+        January 9, 2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Jul 2024 17:01:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5040268-how-to-manage-the-access-request-packets-attack-vulnerability-associated-with-cve-2024-3596-a0e2f0b1-f200-4a7b-844f-48d1d5ab9e66</link>
+      <title>KB5040268: How to manage the Access-Request packets attack vulnerability associated
+        with CVE-2024-3596 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Jul 2024 17:01:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/using-generative-erase-in-microsoft-photos-e0b4df42-3372-4dfd-9d28-c4ef408454a7</link>
+      <title>Using generative erase in Microsoft Photos - Microsoft Support</title>
+      <description>The generative erase feature in Microsoft Photos uses AI machine learning to
+        predict what pixels will look like behind an object you want to erase, allowing you to make
+        your photos look better than ever.</description>
+      <pubDate>Mon, 08 Jul 2024 19:19:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/edit-photos-and-videos-in-windows-a3a6e711-1b70-250a-93fa-ef99048a2c86</link>
+      <title>Edit photos and videos in Windows - Microsoft Support</title>
+      <description>Learn how to edit photos and videos using the Photos app in Windows.</description>
+      <pubDate>Mon, 08 Jul 2024 19:03:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/manage-photos-and-videos-with-microsoft-photos-app-c0c6422f-d4cb-2e3d-eb65-7069071b2f9b</link>
+      <title>Manage photos and videos with Microsoft Photos app - Microsoft Support</title>
+      <description>Learn how the Photos app for Windows lets you view photos and videos from your PC
+        alongside those from OneDrive, and keeps them organized by date, album, or folder.</description>
+      <pubDate>Mon, 08 Jul 2024 18:51:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-help-with-microsoft-photos-app-702104c6-7541-6757-d624-c0846b3bdbd3</link>
+      <title>Get help with Microsoft Photos app - Microsoft Support</title>
+      <description>Get help with your questions about the Photos app from our selection of how-to
+        articles, tutorials, and support content.</description>
+      <pubDate>Mon, 08 Jul 2024 18:46:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-11-2024-kb5039225-os-build-10240-20680-48d7d7c2-bf55-458b-bdc2-06eb6be3d912</link>
+      <title>June 11, 2024—KB5039225 (OS Build 10240.20680) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 03 Jul 2024 22:32:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-11-2024-kb5039214-os-build-14393-7070-07836869-b221-42a9-a63a-62f10967068f</link>
+      <title>June 11, 2024—KB5039214 (OS Build 14393.7070) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 03 Jul 2024 22:30:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-11-2024-kb5039211-os-builds-19044-4529-and-19045-4529-f7e528c9-5e9f-4cd8-9161-704708448517</link>
+      <title>June 11, 2024—KB5039211 (OS Builds 19044.4529 and 19045.4529) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 03 Jul 2024 22:26:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/surface/download-drivers-and-firmware-for-surface-09bb2e09-2a4b-cb69-0951-078a7739e120</link>
+      <title>Download drivers and firmware for Surface - Microsoft Support</title>
+      <description>Update Surface devices and Windows. Download the latest drivers and firmware
+        updates to keep your Surface devices performing their best.</description>
+      <pubDate>Mon, 01 Jul 2024 20:33:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-25-2024-kb5039299-os-build-19045-4598-preview-d4e3e815-fdd8-465e-8144-42afa165efed</link>
+      <title>June 25, 2024—KB5039299 (OS Build 19045.4598) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 28 Jun 2024 23:37:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-from-a-local-account-to-a-microsoft-account-395203bf-9f1b-eb24-b042-5b8dae6c1d20</link>
+      <title>Change from a local account to a Microsoft account - Microsoft Support</title>
+      <description>Learn how to change your Windows sign in from a local account to a Microsoft
+        account to sync your settings across all your devices.</description>
+      <pubDate>Fri, 28 Jun 2024 17:55:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-or-reset-your-pin-a386c519-3ab2-b873-1e9b-bb228a98b904</link>
+      <title>Change or reset your PIN - Microsoft Support</title>
+      <description>Learn how to reset your PIN if you aren't signed in to Windows and having trouble
+        using your PIN.</description>
+      <pubDate>Fri, 28 Jun 2024 16:44:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-or-reset-your-password-8271d17c-9f9e-443f-835a-8318c8f68b9c</link>
+      <title>Change or reset your password - Microsoft Support</title>
+      <description>Learn how to change or reset your Windows password if you've forgotten or lost
+        it.</description>
+      <pubDate>Fri, 28 Jun 2024 16:44:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/welcome-to-copilot-on-windows-675708af-8c16-4675-afeb-85a5a476ccb0</link>
+      <title>Welcome to Copilot on Windows - Microsoft Support</title>
+      <description>Experience Microsoft Copilot on windows devices using the Copilot app! The
+        Copilot app helps you get answers and inspiration from across the web, supports creativity
+        and collaboration, and helps you focus on the task at hand.</description>
+      <pubDate>Thu, 27 Jun 2024 19:05:25 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-29-2024-kb5037849-os-build-19045-4474-preview-cda7ed71-6202-45ed-a649-63b11fedabfe</link>
+      <title>May 29, 2024—KB5037849 (OS Build 19045.4474) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 19 Jun 2024 20:05:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-14-2024-kb5037768-os-builds-19044-4412-and-19045-4412-cb676101-1641-4a6c-b512-8b277606c6e3</link>
+      <title>May 14, 2024—KB5037768 (OS Builds 19044.4412 and 19045.4412) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 19 Jun 2024 20:03:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-23-2024-kb5036979-os-build-19045-4355-preview-b99f7f72-e1bc-4d66-b7b4-fe2c5c9661df</link>
+      <title>April 23, 2024—KB5036979 (OS Build 19045.4355) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 19 Jun 2024 19:56:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/usb-c-port-not-working-ff073a88-953f-47fb-9062-a00a44cf79c2</link>
+      <title>USB-C port not working - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 19 Jun 2024 01:14:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/battery-saving-tips-for-windows-a850d64d-ee8e-c8d2-6c75-8ffe6ea3ea99</link>
+      <title>Battery saving tips for Windows - Microsoft Support</title>
+      <description>Learn how to extend your PC's battery life using battery saver and other
+        power-saving tips for Windows.</description>
+      <pubDate>Tue, 18 Jun 2024 19:51:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/copilot-in-windows-your-data-and-privacy-3e265e82-fc76-4d0a-afc0-4a0de528b73a</link>
+      <title>Copilot in Windows: Your data and privacy - Microsoft Support</title>
+      <description>Privacy information about Copilot in Windows and how it uses your data</description>
+      <pubDate>Tue, 18 Jun 2024 19:36:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-arm-based-pcs-faq-477f51df-2e3b-f68f-31b0-06f5e4f8ebb5</link>
+      <title>Windows Arm-based PCs FAQ - Microsoft Support</title>
+      <description>Learn about using a Windows Arm-based PC and get answers to common questions
+        about Arm-based PCs.</description>
+      <pubDate>Tue, 18 Jun 2024 18:02:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/faster-and-more-secure-wi-fi-in-windows-26177a28-38ed-1a8e-7eca-66f24dc63f09</link>
+      <title>Faster and more secure Wi-Fi in Windows - Microsoft Support</title>
+      <description>Learn how to use Wi-Fi 7 and Wi-Fi 6 and WPA3 in Windows for better wireless
+        coverage and network security.</description>
+      <pubDate>Tue, 18 Jun 2024 18:00:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/essential-services-and-connected-experiences-for-windows-eee3da50-e13a-4a1a-901f-714925287715</link>
+      <title>Essential services and connected experiences for Windows - Microsoft Support</title>
+      <description>Learn about Windows apps, services, and features that help you do more and other
+        experiences that connect to the internet to provide additional capabilities.</description>
+      <pubDate>Thu, 13 Jun 2024 22:26:30 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/manage-user-accounts-in-windows-104dc19f-6430-4b49-6a2b-e4dbd1dcdf32</link>
+      <title>Manage user accounts in Windows - Microsoft Support</title>
+      <description>Learn how to add user accounts in Windows 10 and Windows 11. With an account,
+        each person has separate files, browser favorites, and a private desktop.</description>
+      <pubDate>Thu, 13 Jun 2024 21:55:27 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/create-a-password-reset-disk-for-a-local-account-in-windows-9a54a5ca-27bc-de72-244a-27b7d62951de</link>
+      <title>Create a password reset disk for a local account in Windows - Microsoft Support</title>
+      <description>Learn how to create a password reset disk for a local account in Windows 10 and
+        Windows 11.</description>
+      <pubDate>Wed, 12 Jun 2024 14:52:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5039337-servicing-stack-update-for-windows-10-june-11-2024-5042e2f6-0cae-423a-85df-bd1fdf357d81</link>
+      <title>KB5039337: Servicing stack update for Windows 10: June 11, 2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 11 Jun 2024 17:01:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5039334-servicing-stack-update-for-windows-10-version-1607-and-server-2016-june-11-2024-06b19288-6b91-4cfa-bd3d-dd3b7920aa6a</link>
+      <title>KB5039334: Servicing stack update for Windows 10, version 1607 and Server 2016: June
+        11, 2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 11 Jun 2024 17:01:02 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/use-the-system-file-checker-tool-to-repair-missing-or-corrupted-system-files-79aa86cb-ca52-166a-92a3-966e85d4094e</link>
+      <title>Use the System File Checker tool to repair missing or corrupted system files -
+        Microsoft Support</title>
+      <description>Describes how to use the System File Checker tool to troubleshoot missing or
+        corrupted system files in Windows 8.1, Windows 8, Windows 7 or Windows Vista.</description>
+      <pubDate>Tue, 11 Jun 2024 14:58:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/microsoft-defender-update-for-windows-operating-system-installation-images-1c89630b-61ff-00a1-04e2-2d1f3865450d</link>
+      <title>Microsoft Defender update for Windows operating system installation images - Microsoft
+        Support</title>
+      <description>Describes a Windows Defender update package for Windows Server 2019, Windows
+        Server 2016, and Windows 10.</description>
+      <pubDate>Tue, 11 Jun 2024 03:44:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/go-passwordless-with-your-microsoft-account-585a71d7-2295-4878-aeac-a014984df856</link>
+      <title>Go passwordless with your Microsoft account - Microsoft Support</title>
+      <description>Learn how to go passwordless on Windows with Windows Hello and your Microsoft
+        account.</description>
+      <pubDate>Sat, 08 Jun 2024 21:02:09 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-voice-recognition-in-windows-83ff75bd-63eb-0b6c-18d4-6fae94050571</link>
+      <title>Use voice recognition in Windows - Microsoft Support</title>
+      <description>First, set up your microphone, then use Windows Speech Recognition to train your
+        PC.</description>
+      <pubDate>Thu, 06 Jun 2024 14:14:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-usb-c-problems-in-windows-f4e0e529-74f5-cdae-3194-43743f30eed2</link>
+      <title>Fix USB-C problems in Windows - Microsoft Support</title>
+      <description>Learn how to troubleshoot USB-C problems in Windows and fix USB devices, ports,
+        and adapters not working properly.</description>
+      <pubDate>Wed, 05 Jun 2024 05:56:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/create-films-with-a-video-editor-94e651f8-a5be-ae03-3c50-e49f013d47f6</link>
+      <title>Create films with a video editor - Microsoft Support</title>
+      <description>Learn how to use Clipchamp to create, edit, and share your own custom videos.</description>
+      <pubDate>Tue, 04 Jun 2024 21:00:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/lock-windows-automatically-d0a5f536-74ac-0859-820a-4140dac9fcaf</link>
+      <title>Lock Windows automatically - Microsoft Support</title>
+      <description>Learn how to configure dynamic lock, a Windows feature that automatically locks
+        your Windows device when you're away from it.</description>
+      <pubDate>Tue, 04 Jun 2024 14:27:47 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-use-the-camera-app-ea40b69f-be6a-840e-9c8c-1fd6eea97c22</link>
+      <title>How to use the Camera app - Microsoft Support</title>
+      <description>Create pictures and videos with the Camera app.</description>
+      <pubDate>Tue, 04 Jun 2024 00:55:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/turn-on-automatic-app-updates-70634d32-4657-dc76-632b-66048978e51b</link>
+      <title>Turn on automatic app updates - Microsoft Support</title>
+      <description>Learn how to turn on automatic app updates in Microsoft Store.</description>
+      <pubDate>Mon, 03 Jun 2024 23:32:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/troubleshooting-microsoft-wireless-display-adapter-9d2369cf-ba4b-908c-69c0-d4e5f4117d35</link>
+      <title>Troubleshooting Microsoft Wireless Display Adapter - Microsoft Support</title>
+      <description>Learn how to troubleshoot video and audio problems with your Microsoft wireless
+        display adapter.</description>
+      <pubDate>Mon, 03 Jun 2024 16:25:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/troubleshoot-problems-with-your-microsoft-mouse-or-keyboard-5afe478d-6402-d72b-93b9-e4235fd5c4cd</link>
+      <title>Troubleshoot problems with your Microsoft mouse or keyboard - Microsoft Support</title>
+      <description>If you have keyboard issues with wireless or Bluetooth, try these troubleshooting
+        tips.</description>
+      <pubDate>Mon, 03 Jun 2024 16:22:00 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5036210-deploying-windows-uefi-ca-2023-certificate-to-secure-boot-allowed-signature-database-db-a68a3eae-292b-4224-9490-299e303b450b</link>
+      <title>KB5036210: Deploying Windows UEFI CA 2023 certificate to Secure Boot Allowed Signature
+        Database (DB) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 30 May 2024 16:35:02 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/codecs-in-media-player-d5c2cdcd-83a2-4805-abb0-c6888138e456</link>
+      <title>Codecs in Media Player - Microsoft Support</title>
+      <description>Codecs allow you to play different formats of audio and video files. Media Player
+        supports a wide variety of codecs. Most are included out of the box; some additional codecs
+        can be installed from the Microsoft Store.</description>
+      <pubDate>Wed, 29 May 2024 12:49:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/recovery-options-in-windows-31ce2444-7de3-818c-d626-e3b5a3024da5</link>
+      <title>Recovery options in Windows - Microsoft Support</title>
+      <description>Learn about the recovery options in Windows. Find out how to reset your PC, go
+        back to a previous version of Windows, or use media to reinstall Windows.</description>
+      <pubDate>Fri, 24 May 2024 22:00:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-connected-when-setting-up-your-windows-11-pc-50dca26f-40d5-4c3b-853c-e972dafb7e08</link>
+      <title>Get connected when setting up your Windows 11 PC - Microsoft Support</title>
+      <description>Learn how to troubleshoot and fix problems connecting to the intent when setting
+        up your
+        Windows 10 or 11 PC.</description>
+      <pubDate>Fri, 24 May 2024 22:00:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-23-2024-kb5039705-os-build-17763-5830-out-of-band-2285667a-13a3-4fd9-98a0-e980eb996aac</link>
+      <title>May 23, 2024—KB5039705 (OS Build 17763.5830) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 24 May 2024 18:52:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-14-2024-kb5037765-os-build-17763-5820-82d1aefb-093c-4e4a-a729-cd4a829750ad</link>
+      <title>May 14, 2024—KB5037765 (OS Build 17763.5820) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 23 May 2024 23:03:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/office/set-up-your-device-to-work-with-accessibility-in-microsoft-365-a0ca81c1-fa3e-417e-9d3b-78b8816fce58</link>
+      <title>Set up your device to work with accessibility in Microsoft 365 - Microsoft Support</title>
+      <description>This article has brief descriptions of accessibility settings that help people
+        with disabilities for Windows, Mac, Android, and iOS devices.</description>
+      <pubDate>Thu, 23 May 2024 17:27:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/protect-your-pc-from-ransomware-08ed68a7-939f-726c-7e84-a72ba92c01c3</link>
+      <title>Protect your PC from ransomware - Microsoft Support</title>
+      <description>Learn how to identify, troubleshoot, and prevent ransomware on your PC.</description>
+      <pubDate>Wed, 22 May 2024 14:27:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/potentially-unwanted-apps-are-blocked-by-default-b9f53cb9-7f1e-40bb-8c6b-a17e0ab6289e</link>
+      <title>Potentially unwanted apps are blocked by default - Microsoft Support</title>
+      <description>We’re turning on Potentially Unwanted Apps (PUA) blocking by default in Windows
+        10 starting in August of 2021.</description>
+      <pubDate>Wed, 22 May 2024 14:27:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/protect-your-pc-from-potentially-unwanted-applications-c7668a25-174e-3b78-0191-faf0607f7a6e</link>
+      <title>Protect your PC from potentially unwanted applications - Microsoft Support</title>
+      <description>With reputation-based protection Windows users can be better protected from
+        potentially unwanted apps (PUA).</description>
+      <pubDate>Wed, 22 May 2024 14:27:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/protect-your-privacy-on-the-internet-ffe36513-e208-7532-6f95-a3b1c8760dfa</link>
+      <title>Protect your privacy on the internet - Microsoft Support</title>
+      <description>Learn how to stay safe online with tips to help you control the amount of
+        personal information you share and who has access to it.</description>
+      <pubDate>Wed, 22 May 2024 14:27:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/help-protect-my-pc-with-microsoft-defender-offline-9306d528-64bf-4668-5b80-ff533f183d6c</link>
+      <title>Help protect my PC with Microsoft Defender Offline - Microsoft Support</title>
+      <description>Learn how to use Microsoft Defender Offline to help remove malicious software and
+        other potential threats.</description>
+      <pubDate>Wed, 22 May 2024 14:27:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/using-microsoft-defender-offline-f9c340cb-f367-bd8d-0500-e07afedd5309</link>
+      <title>Using Microsoft Defender Offline - Microsoft Support</title>
+      <description>Using Microsoft Defender Offline</description>
+      <pubDate>Wed, 22 May 2024 14:27:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/update-for-microsoft-defender-antimalware-platform-kb4052623-92e21611-8cf1-8e0e-56d6-561a07d144cc</link>
+      <title>Update for Microsoft Defender antimalware platform (KB4052623) - Microsoft Support</title>
+      <description>An antimalware platform update package for Windows 10 and Windows Server 2016 is
+        available.</description>
+      <pubDate>Wed, 22 May 2024 14:21:49 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/personalize-your-lock-screen-81dab9b0-35cf-887c-84a0-6de8ef72bea0</link>
+      <title>Personalize your lock screen - Microsoft Support</title>
+      <description>Learn how to personalize a Windows lock screen with a background photo,
+        slideshow, or app notifications.</description>
+      <pubDate>Tue, 21 May 2024 19:19:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/manage-cookies-in-microsoft-edge-view-allow-block-delete-and-use-168dab11-0753-043d-7c16-ede5947fc64d</link>
+      <title>Manage cookies in Microsoft Edge: View, allow, block, delete and use - Microsoft
+        Support</title>
+      <description>Learn how to view, manage, and delete cookies in Microsoft Edge.</description>
+      <pubDate>Tue, 21 May 2024 13:50:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-your-account-picture-3645cdc7-acab-49d2-76a9-4ce7e5e10939</link>
+      <title>Change your account picture - Microsoft Support</title>
+      <description>Learn how to change your account picture in Windows. Choose from pictures on your
+        PC or take a new selfie.</description>
+      <pubDate>Fri, 17 May 2024 15:44:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/prevent-unauthorized-purchases-from-microsoft-store-21436cce-cd26-da18-f522-bb766a9dc8dd</link>
+      <title>Prevent unauthorized purchases from Microsoft Store - Microsoft Support</title>
+      <description>Learn how to set up a required password to prevent unauthorized purchases from
+        Microsoft Store on PC or mobile device using Windows.</description>
+      <pubDate>Thu, 16 May 2024 10:06:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/sign-out-of-windows-346925bb-024c-cd86-7a53-9066242a9ed3</link>
+      <title>Sign out of Windows - Microsoft Support</title>
+      <description>Sign out of Windows</description>
+      <pubDate>Wed, 15 May 2024 20:17:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-14-2024-kb5037763-os-build-14393-6981-0c46e802-c9a9-4ad3-816b-c7fa378d3dd3</link>
+      <title>May 14, 2024—KB5037763 (OS Build 14393.6981) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 15 May 2024 00:06:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/about-get-help-717c7ae9-5c45-45f0-b637-900b7437a395</link>
+      <title>About Get Help - Microsoft Support</title>
+      <description>Learn about the Windows Get Help app, including what it does and how to launch
+        it.</description>
+      <pubDate>Tue, 14 May 2024 21:16:40 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-help-for-microsoft-personal-account-users-aaf7f74b-026e-489b-a102-0570dfbfb192</link>
+      <title>Get Help for Microsoft personal account users - Microsoft Support</title>
+      <description>How to use the Windows Get Help app if you are using Windows with a Microsoft
+        personal account.</description>
+      <pubDate>Tue, 14 May 2024 21:16:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-help-for-microsoft-work-or-school-account-users-215deae6-5cc6-4ba0-9f7b-d75933ce179b</link>
+      <title>Get Help for Microsoft work or school account users - Microsoft Support</title>
+      <description>How to use the Windows Get Help app if you are using Windows while logged into a
+        Microsoft work or school account.</description>
+      <pubDate>Tue, 14 May 2024 21:15:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/running-troubleshooters-in-get-help-23bddffd-5495-47f6-a419-7efe166bf1a8</link>
+      <title>Running troubleshooters in Get Help - Microsoft Support</title>
+      <description>How to run the various troubleshooters within the Windows Get Help app.</description>
+      <pubDate>Tue, 14 May 2024 21:14:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/give-feedback-about-get-help-54a5b02a-071c-4b02-83d0-00c6ed99845b</link>
+      <title>Give feedback about Get Help - Microsoft Support</title>
+      <description>How to submit feedback within the Windows Get Help app, including asking for
+        support, suggesting a feature, or giving praise.</description>
+      <pubDate>Tue, 14 May 2024 21:14:15 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-9-2024-kb5036892-os-builds-19044-4291-and-19045-4291-cb5d2d42-6b10-48f7-829a-be7d416a811b</link>
+      <title>April 9, 2024—KB5036892 (OS Builds 19044.4291 and 19045.4291) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 14 May 2024 17:30:00 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-9-2024-kb5036896-os-build-17763-5696-efb580f1-2ce4-4695-b76c-d2068a00fb92</link>
+      <title>April 9, 2024—KB5036896 (OS Build 17763.5696) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 14 May 2024 17:23:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-9-2024-kb5036899-os-build-14393-6897-6a0b7cdd-dd67-4ef8-8c38-8a936b2f952c</link>
+      <title>April 9, 2024—KB5036899 (OS Build 14393.6897) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 14 May 2024 17:18:40 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-14-2024-kb5037788-os-build-10240-20651-6efe4a43-3962-4585-88af-3a3369ee561c</link>
+      <title>May 14, 2024—KB5037788 (OS Build 10240.20651) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 14 May 2024 17:02:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/install-quick-assist-c17479b7-a49d-4d12-938c-dbfb97c88bca</link>
+      <title>Install Quick Assist - Microsoft Support</title>
+      <description>Get help with installing Quick Assist from Microsoft Store.</description>
+      <pubDate>Fri, 10 May 2024 20:36:57 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/solve-pc-problems-remotely-with-remote-assistance-and-easy-connect-cf384ff4-6269-d86e-bcfe-92d72ed55922</link>
+      <title>Solve PC problems remotely with Remote Assistance and Easy Connect - Microsoft Support</title>
+      <description>Remote Assistance and Easy Connect let someone you trust take over your Windows
+        10 PC and fix a problem from wherever they are.</description>
+      <pubDate>Fri, 10 May 2024 20:31:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/solve-pc-problems-over-a-remote-connection-b077e31a-16f4-2529-1a47-21f6a9040bf3</link>
+      <title>Solve PC problems over a remote connection - Microsoft Support</title>
+      <description>Quick Assist lets someone you trust take over your Windows 10 or Windows 11 PC
+        and fix a problem from wherever they are.</description>
+      <pubDate>Fri, 10 May 2024 20:31:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/quick-assist-update-history-ec4c2c86-134a-4f3e-9fe2-c0030a751bd9</link>
+      <title>Quick Assist update history - Microsoft Support</title>
+      <description>Learn about the latest updates made to the Quick Assist app from the Microsoft
+        Store.</description>
+      <pubDate>Fri, 10 May 2024 20:29:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/art-tools-in-paint-3d-9a017572-dc0a-679a-e9a5-f27c747527dd</link>
+      <title>Art tools in Paint 3D - Microsoft Support</title>
+      <description>Get to know the new tools in Paint 3D, the latest evolution of Microsoft Paint on
+        Windows 10.</description>
+      <pubDate>Mon, 06 May 2024 19:08:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/write-on-the-web-8743d2bb-c4cf-ae40-2aa2-a88ae96a4a79</link>
+      <title>Write on the web - Microsoft Support</title>
+      <description>Learn how to ink, highlight, or take notes on web pages and share them with
+        others.</description>
+      <pubDate>Wed, 01 May 2024 21:24:49 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/import-your-favorites-in-microsoft-edge-278afd65-2294-9134-005a-ce7b48d868e1</link>
+      <title>Import your favorites in Microsoft Edge - Microsoft Support</title>
+      <description>See how to import favorites from other browsers into Microsoft Edge.</description>
+      <pubDate>Wed, 01 May 2024 20:57:18 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/what-is-a-microsoft-account-4a7c48e9-ff5a-e9c6-5a5c-1a57d66c3bfa</link>
+      <title>What is a Microsoft account? - Microsoft Support</title>
+      <description>Learn what a Microsoft account is and the benefits of using it.</description>
+      <pubDate>Tue, 30 Apr 2024 08:02:47 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/switch-your-windows-10-device-to-a-local-account-eb7e78a9-88ee-9bc3-8f06-831b56e339fd</link>
+      <title>Switch your Windows 10 device to a local account - Microsoft Support</title>
+      <description>Get the steps for switching your Windows 10 device to a local account.</description>
+      <pubDate>Mon, 29 Apr 2024 21:06:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/sign-in-to-your-microsoft-account-with-windows-hello-800a8c01-6b61-49f5-0660-c2159bea4d84</link>
+      <title>Sign in to your Microsoft account with Windows Hello - Microsoft Support</title>
+      <description>Learn how to use Windows Hello or a security key to sign in your Microsoft
+        account without a password.</description>
+      <pubDate>Mon, 29 Apr 2024 21:05:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/create-a-local-user-or-administrator-account-in-windows-20de74e0-ac7f-3502-a866-32915af2a34d</link>
+      <title>Create a local user or administrator account in Windows - Microsoft Support</title>
+      <description>Get the steps for creating a local user or administrator account in Windows 10
+        and Windows 11.</description>
+      <pubDate>Mon, 29 Apr 2024 21:02:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/accessing-credential-manager-1b5c916a-6a16-889f-8581-fc16e8165ac0</link>
+      <title>Accessing Credential Manager - Microsoft Support</title>
+      <description>Accessing Credential Manager</description>
+      <pubDate>Mon, 29 Apr 2024 20:00:53 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/troubleshoot-screen-flickering-in-windows-47d5b0a7-89ea-1321-ec47-dc262675fc7b</link>
+      <title>Troubleshoot screen flickering in Windows - Microsoft Support</title>
+      <description>Find out how to stop your screen from flickering after the upgrade to Windows 10.</description>
+      <pubDate>Fri, 26 Apr 2024 22:57:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/why-can-t-i-uninstall-the-your-phone-app-1c0ac9f4-26a2-7e5c-ec76-feb9e715db59</link>
+      <title>Why can't I uninstall the Your Phone app? - Microsoft Support</title>
+      <description>An explanation as to why the Your Phone app can't be uninstalled from Windows 10.</description>
+      <pubDate>Fri, 26 Apr 2024 22:41:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/complete-guide-to-narrator-e4397a0d-ef4f-b386-d8ae-c172f109bdb1</link>
+      <title>Complete guide to Narrator - Microsoft Support</title>
+      <description>Learn how to use Narrator, a screen-reading app built into Windows, with this
+        complete guide and how-to articles.</description>
+      <pubDate>Fri, 26 Apr 2024 11:38:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5037754-how-to-manage-pac-validation-changes-related-to-cve-2024-26248-and-cve-2024-29056-6e661d4f-799a-4217-b948-be0a1943fef1</link>
+      <title>KB5037754: How to manage PAC Validation changes related to CVE-2024-26248 and
+        CVE-2024-29056 - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 25 Apr 2024 16:24:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/how-to-sign-in-to-a-microsoft-account-2ffedaca-6e1b-bc18-f28c-58539e1cb6d3</link>
+      <title>How to sign in to a Microsoft account - Microsoft Support</title>
+      <description>Use your Microsoft account to sign in to Microsoft services like Windows,
+        Microsoft 365, OneDrive, Skype, Outlook, and Xbox Live.</description>
+      <pubDate>Thu, 25 Apr 2024 09:08:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/-an-operating-system-wasn-t-found-error-when-booting-windows-2c149e3a-dc37-0322-4d79-336f3888906b</link>
+      <title>“An operating system wasn’t found” error when booting Windows - Microsoft Support</title>
+      <description>When trying to boot Windows, you receive the error: An operating system wasn’t
+        found. Try disconnecting any drives that don’t contain an operating system. Press
+        Ctrl+Alt+Del to restart</description>
+      <pubDate>Wed, 24 Apr 2024 17:35:25 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5031539-servicing-stack-update-for-windows-10-version-21h2-and-22h2-october-10-2023-36e20da3-bf0d-4dc3-93d1-09af959e58f3</link>
+      <title>KB5031539: Servicing stack update for Windows 10, version 21H2 and 22H2: October 10,
+        2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 23 Apr 2024 21:13:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5036534-latest-windows-hardening-guidance-and-key-dates-eb1bd411-f68c-4d74-a4e1-456721a6551b</link>
+      <title>KB5036534: Latest Windows hardening guidance and key dates - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 19 Apr 2024 22:03:41 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/supported-mobile-operators-for-the-mobile-plans-app-in-windows-3c610166-9b89-6053-0a9b-a0abb97067a0</link>
+      <title>Supported mobile operators for the Mobile Plans app in Windows - Microsoft Support</title>
+      <description>Find out what mobile operators offer cellular data plans through the Mobile Plans
+        app when you have an eSIM in your PC.</description>
+      <pubDate>Thu, 18 Apr 2024 20:54:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/save-or-forget-passwords-in-microsoft-edge-b4beecb0-f2a8-1ca0-f26f-9ec247a3f336</link>
+      <title>Save or forget passwords in Microsoft Edge - Microsoft Support</title>
+      <description>Use Microsoft Edge settings to save user name and password information and save
+        time when signing in to websites.</description>
+      <pubDate>Thu, 18 Apr 2024 17:00:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb4073119-windows-client-guidance-for-it-pros-to-protect-against-silicon-based-microarchitectural-and-speculative-execution-side-channel-vulnerabilities-35820a8a-ae13-1299-88cc-357f104f5b11</link>
+      <title>KB4073119: Windows client guidance for IT Pros to protect against silicon-based
+        microarchitectural and speculative execution side-channel vulnerabilities - Microsoft
+        Support</title>
+      <description>Provides Windows client guidance for IT Pros to protect against speculative
+        execution side-channel vulnerabilities.</description>
+      <pubDate>Thu, 18 Apr 2024 15:18:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/create-a-recovery-drive-abb4691b-5324-6d4a-8766-73fab304c246</link>
+      <title>Create a recovery drive - Microsoft Support</title>
+      <description>Create a recovery drive so you can reinstall Windows 10 or Windows 11 in case you
+        experience a major issue such as hardware failure.</description>
+      <pubDate>Mon, 15 Apr 2024 21:08:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/trouble-finding-the-microsoft-store-app-in-windows-1d94d942-bc55-e762-6cda-ca5bbb383285</link>
+      <title>Trouble finding the Microsoft Store app in Windows - Microsoft Support</title>
+      <description>Learn how to find Microsoft Store from the Start menu or taskbar in Windows.</description>
+      <pubDate>Mon, 15 Apr 2024 10:46:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/fix-problems-with-apps-from-microsoft-store-93ed0bcf-9c12-3df6-6dda-92ec5d0415ac</link>
+      <title>Fix problems with apps from Microsoft Store - Microsoft Support</title>
+      <description>Get troubleshooting tips to fix problems with apps from Microsoft Store.</description>
+      <pubDate>Mon, 15 Apr 2024 10:46:09 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/troubleshooting-black-or-blank-screens-in-windows-51ef7b96-47cb-b454-fcab-fac643784457</link>
+      <title>Troubleshooting black or blank screens in Windows - Microsoft Support</title>
+      <description>If your computer is showing a black or blank screen in Windows, these
+        troubleshooting tips could help get your system back up and running.</description>
+      <pubDate>Sat, 13 Apr 2024 01:10:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-14-2023-kb5032196-os-build-17763-5122-f613961d-cb3e-400a-a83f-024566260eaf</link>
+      <title>November 14, 2023—KB5032196 (OS Build 17763.5122) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 11 Apr 2024 19:08:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-26-2024-kb5035941-os-build-19045-4239-preview-a170797c-503e-4372-b3b6-89f290b4f2cb</link>
+      <title>March 26, 2024—KB5035941 (OS Build 19045.4239) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 11 Apr 2024 17:23:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-12-2024-kb5035845-os-builds-19044-4170-and-19045-4170-24e9864f-0756-457e-bce9-3f681020d591</link>
+      <title>March 12, 2024—KB5035845 (OS Builds 19044.4170 and 19045.4170) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 11 Apr 2024 17:21:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-29-2024-kb5034843-os-build-19045-4123-preview-c576e1b5-9b0d-4411-9be8-57328f41954d</link>
+      <title>February 29, 2024—KB5034843 (OS Build 19045.4123) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 11 Apr 2024 17:19:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-13-2024-kb5034763-os-builds-19044-4046-and-19045-4046-f1c993e4-32b3-4cc8-947a-69e70ae124d5</link>
+      <title>February 13, 2024—KB5034763 (OS Builds 19044.4046 and 19045.4046) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 11 Apr 2024 17:17:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-23-2024-kb5034203-os-build-19045-3996-preview-d9540687-af96-46ba-9192-88fe44833561</link>
+      <title>January 23, 2024—KB5034203 (OS Build 19045.3996) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 11 Apr 2024 17:16:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb4073757-protect-windows-devices-against-silicon-based-microarchitectural-and-speculative-execution-side-channel-vulnerabilities-a0b9f66c-f426-d854-fdbb-0e6beaeeee87</link>
+      <title>KB4073757: Protect Windows devices against silicon-based microarchitectural and
+        speculative execution side-channel vulnerabilities - Microsoft Support</title>
+      <description>Learn more how to protect your Windows devices against silicon-based
+        microarchitectural and speculative execution side-channel vulnerabilities</description>
+      <pubDate>Tue, 09 Apr 2024 23:48:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5037019-servicing-stack-update-for-windows-10-april-9-2024-2d3b2b95-df26-4fcd-8108-459cb76f113e</link>
+      <title>KB5037019: Servicing stack update for Windows 10: April 9, 2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Apr 2024 17:05:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-9-2024-kb5036925-os-build-10240-20596-cdb343db-4032-4735-9609-a44a56922f66</link>
+      <title>April 9, 2024—KB5036925 (OS Build 10240.20596) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Apr 2024 17:04:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5037016-servicing-stack-update-for-windows-10-version-1607-and-server-2016-april-9-2024-fa80a866-2625-4f46-8f51-bffed6e7887e</link>
+      <title>KB5037016: Servicing stack update for Windows 10, version 1607 and Server 2016: April
+        9, 2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Apr 2024 17:03:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5016061-secure-boot-db-and-dbx-variable-update-events-37e47cf8-608b-4a87-8175-bdead630eb69</link>
+      <title>KB5016061: Secure Boot DB and DBX variable update events - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Apr 2024 17:00:20 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/hdr-settings-in-windows-2d767185-38ec-7fdc-6f97-bbc6c5ef24e6</link>
+      <title>HDR settings in Windows - Microsoft Support</title>
+      <description>Learn how to control HDR settings in Windows, turn on HDR, and troubleshoot
+        common problems with HDR-capable displays.</description>
+      <pubDate>Wed, 03 Apr 2024 18:58:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-desktop-background-and-colors-176702ca-8e24-393b-15f2-b15b38f69de6</link>
+      <title>Change desktop background and colors - Microsoft Support</title>
+      <description>Learn how to change your Windows desktop background (wallpaper) and accent color
+        using personalization settings.</description>
+      <pubDate>Wed, 27 Mar 2024 17:01:09 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-your-desktop-background-image-175618be-4cf1-c159-2785-ec2238b433a8</link>
+      <title>Change your desktop background image - Microsoft Support</title>
+      <description>Use the Windows Settings app to change your desktop backgrounds and colors.</description>
+      <pubDate>Wed, 27 Mar 2024 17:00:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/make-an-in-app-purchase-in-microsoft-store-1de1279a-be0e-6ad0-1d01-fbe59e90dc47</link>
+      <title>Make an in-app purchase in Microsoft Store - Microsoft Support</title>
+      <description>Some apps and games in Microsoft Store have the option for in-app purchases for
+        things like extra tokens or coins.</description>
+      <pubDate>Wed, 27 Mar 2024 11:16:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/information-about-the-attachment-manager-in-microsoft-windows-c48a4dcd-8de5-2af5-ee9b-cd795ae42738</link>
+      <title>Information about the Attachment Manager in Microsoft Windows - Microsoft Support</title>
+      <description>The Attachment Manager classifies files that you receive or that you download
+        based on the file type and the file name extension. The Attachment Manager classifies files
+        types as high risk, medium risk, and low risk.</description>
+      <pubDate>Tue, 26 Mar 2024 15:49:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-12-2024-kb5035849-os-build-17763-5576-719f5f8d-51c6-43f0-a612-1c15802fed06</link>
+      <title>March 12, 2024—KB5035849 (OS Build 17763.5576) - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 25 Mar 2024 18:38:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-25-2024-kb5037425-os-build-17763-5579-out-of-band-fa8fb7fa-8185-408f-bdd6-ea575ce2fcb5</link>
+      <title>March 25, 2024—KB5037425 (OS Build 17763.5579) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 25 Mar 2024 18:33:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-12-2024-kb5035855-os-build-14393-6796-6f2b7253-4f2d-49e9-aef8-c32d0b708a2f</link>
+      <title>March 12, 2024—KB5035855 (OS Build 14393.6796) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 22 Mar 2024 21:34:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-22-2024-kb5037423-os-build-14393-6799-out-of-band-1775cda2-4bb6-43a9-9fd4-ddc3528d3408</link>
+      <title>March 22, 2024—KB5037423 (OS Build 14393.6799) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 22 Mar 2024 21:34:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/people-app-help-144c4373-fa32-da81-f8b4-ee87589c509c</link>
+      <title>People app help - Microsoft Support</title>
+      <description>Learn how to get to and manage your contacts in the People app.</description>
+      <pubDate>Fri, 22 Mar 2024 18:00:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-20-2022-kb5022554-os-build-17763-3772-out-of-band-5e0b7ddb-7c78-43d4-a7ef-dd222f24ee49</link>
+      <title>December 20, 2022—KB5022554 (OS Build 17763.3772) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Mar 2024 17:50:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-your-pin-when-you-re-already-signed-in-to-your-device-0bd2ab85-b0df-c775-7aef-1324f2114b19</link>
+      <title>Change your PIN when you’re already signed in to your device - Microsoft Support</title>
+      <description>Learn how to reset your Microsoft PIN when you're signed in to your Windows
+        device.</description>
+      <pubDate>Mon, 18 Mar 2024 10:17:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/find-and-lock-a-lost-windows-device-890bf25e-b8ba-d3fe-8253-e98a12f26316</link>
+      <title>Find and lock a lost Windows device - Microsoft Support</title>
+      <description>Use Find my device to locate and lock your lost or stolen Windows devices.</description>
+      <pubDate>Fri, 15 Mar 2024 11:35:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/link-your-google-account-and-microsoft-account-2b0fcee7-34b5-e607-a284-6be5bc9e7899</link>
+      <title>Link your Google account and Microsoft account - Microsoft Support</title>
+      <description>Describes how you can link your Google account to your Microsoft account.</description>
+      <pubDate>Fri, 15 Mar 2024 11:32:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/share-files-in-file-explorer-19db5910-e59e-fab6-59c4-e60e6f6a08dc</link>
+      <title>Share files in File Explorer - Microsoft Support</title>
+      <description>There are several ways to share files using File Explorer including using an app
+        to share, using OneDrive, sending an email, or sharing over a network.</description>
+      <pubDate>Thu, 14 Mar 2024 23:40:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-your-lock-screen-background-afb20cda-c9e2-3be2-e2c5-1a1bfe63047c</link>
+      <title>Change your lock screen background - Microsoft Support</title>
+      <description>Change your lock screen background</description>
+      <pubDate>Thu, 14 Mar 2024 21:15:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/change-your-country-or-region-in-microsoft-store-5895e006-34f4-10f7-16b1-999e40adb048</link>
+      <title>Change your country or region in Microsoft Store - Microsoft Support</title>
+      <description>If you change your country or region for Microsoft Store, stuff you got in one
+        region might not work in another.</description>
+      <pubDate>Wed, 13 Mar 2024 13:12:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5035962-servicing-stack-update-for-windows-10-version-1607-and-server-2016-march-12-2024-d1397c5e-c2d2-4f52-afd6-dab075e3efb7</link>
+      <title>KB5035962: Servicing stack update for Windows 10, version 1607 and Server 2016: March
+        12, 2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 12 Mar 2024 17:00:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5035966-servicing-stack-update-for-windows-10-march-12-2024-4bc2e1af-d149-4c8f-ba6f-9a89e97adb02</link>
+      <title>KB5035966: Servicing stack update for Windows 10: March 12, 2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 12 Mar 2024 17:00:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-12-2024-kb5035858-os-build-10240-20526-0acba1a6-bd7e-4d2a-8603-a6c2f0331a14</link>
+      <title>March 12, 2024—KB5035858 (OS Build 10240.20526) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 12 Mar 2024 17:00:25 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/scan-an-item-with-windows-security-d1c8c01d-12ed-e768-cbb8-830ea8ccf8e6</link>
+      <title>Scan an item with Windows Security - Microsoft Support</title>
+      <description>Find out how to scan files and folders in Windows with Windows Security.</description>
+      <pubDate>Mon, 11 Mar 2024 20:10:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/turn-off-onedrive-in-windows-afe5d123-523d-f280-283b-5b2a5c1aa788</link>
+      <title>Turn off OneDrive in Windows - Microsoft Support</title>
+      <description>If you don't want to use OneDrive, the easiest solution is to unlink it.</description>
+      <pubDate>Fri, 08 Mar 2024 12:11:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/what-is-photos-legacy-61255007-a189-4a02-8193-6ba18e5f96d3</link>
+      <title>What is Photos Legacy? - Microsoft Support</title>
+      <description>Learn about the Photos Legacy app for Microsoft’s Legacy Collections, Albums, and
+        Video Editor.</description>
+      <pubDate>Tue, 05 Mar 2024 04:58:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/import-photos-and-videos-aed09800-f826-4d40-a243-7640de229d9d</link>
+      <title>Import photos and videos - Microsoft Support</title>
+      <description>Get the steps for how to transfer photos and videos from your portable devices to
+        your PC.</description>
+      <pubDate>Tue, 05 Mar 2024 04:55:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/microsoft-edge-browsing-data-and-privacy-bb8174ba-9d73-dcf2-9b4a-c582b4e640dd</link>
+      <title>Microsoft Edge, browsing data, and privacy - Microsoft Support</title>
+      <description>Find out how to change the privacy settings in Microsoft Edge.</description>
+      <pubDate>Mon, 04 Mar 2024 23:04:25 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/screen-mirroring-and-projecting-to-your-pc-or-wireless-display-5af9f371-c704-1c7f-8f0d-fa607551d09c</link>
+      <title>Screen mirroring and projecting to your PC or wireless display - Microsoft Support</title>
+      <description>Learn how to screen mirror or project content from one device to another.</description>
+      <pubDate>Thu, 29 Feb 2024 18:54:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-problems-with-nearby-sharing-in-windows-e6f5db3a-48c3-04f6-13d6-84db6f821455</link>
+      <title>Fix problems with nearby sharing in Windows - Microsoft Support</title>
+      <description>Learn how to troubleshoot and fix problems with nearby sharing in Windows.</description>
+      <pubDate>Thu, 29 Feb 2024 18:25:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-speech-recognition-commands-9d25ef36-994d-f367-a81a-a326160128c7</link>
+      <title>Windows Speech Recognition commands - Microsoft Support</title>
+      <description>Learn how to control your PC by voice using Windows Speech Recognition commands
+        for dictation, keyboard shortcuts, punctuation, apps, and more.</description>
+      <pubDate>Thu, 29 Feb 2024 18:08:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-connections-to-wireless-displays-or-docks-in-windows-f6a7cd01-fdec-560c-4593-698a1b3098c4</link>
+      <title>Fix connections to wireless displays or docks in Windows - Microsoft Support</title>
+      <description>Learn how to troubleshoot Miracast connections and fix problems connecting to a
+        wireless display or dock in Windows.</description>
+      <pubDate>Thu, 29 Feb 2024 18:00:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/appendix-a-supported-languages-and-voices-4486e345-7730-53da-fcfe-55cc64300f01</link>
+      <title>Appendix A: Supported languages and voices - Microsoft Support</title>
+      <description>Learn which languages are supported in Narrator in Windows and how to adjust your
+        Narrator Settings.</description>
+      <pubDate>Thu, 29 Feb 2024 18:00:20 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/chapter-3-using-scan-mode-7b2af804-5a2f-90fd-b0e0-672f7cbbf2da</link>
+      <title>Chapter 3: Using scan mode - Microsoft Support</title>
+      <description>Learn how to use Scan Mode in Narrator, a navigation and reading mode that lets
+        you navigate apps and the web using the up and down arrow keys.</description>
+      <pubDate>Thu, 29 Feb 2024 18:00:20 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-update-faq-8a903416-6f45-0718-f5c7-375e92dddeb2</link>
+      <title>Windows Update: FAQ - Microsoft Support</title>
+      <description>Learn how to get the latest Windows updates. Find answers to FAQ about updating
+        Windows to keep your PC up to date.</description>
+      <pubDate>Tue, 27 Feb 2024 02:29:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5034957-updating-the-winre-partition-on-deployed-devices-to-address-security-vulnerabilities-in-cve-2024-20666-0190331b-1ca3-42d8-8a55-7fc406910c10</link>
+      <title>KB5034957: Updating the WinRE partition on deployed devices to address security
+        vulnerabilities in CVE-2024-20666 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 27 Feb 2024 00:01:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/schedule-a-scan-in-microsoft-defender-antivirus-54b64e9c-880a-c6b6-2416-0eb330ed5d2d</link>
+      <title>Schedule a scan in Microsoft Defender Antivirus - Microsoft Support</title>
+      <description>Learn how to schedule a Windows Defender Antivirus scan at a time and frequency
+        that you choose.</description>
+      <pubDate>Wed, 21 Feb 2024 23:50:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/install-the-latest-updates-for-windows-92bb1064-cf3b-0b94-7c57-331f7b7db3c6</link>
+      <title>Install the latest updates for Windows - Microsoft Support</title>
+      <description>Learn about Windows service packs and download the latest updates for Windows 10
+        and Windows 8.1</description>
+      <pubDate>Tue, 20 Feb 2024 14:32:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-help-with-timeline-febc28db-034c-d2b0-3bbe-79aa0c501039</link>
+      <title>Get help with timeline - Microsoft Support</title>
+      <description>Learn how you can use timeline to go back to something you were doing earlier,
+        like working on a document or browsing a website, on any Windows 10 PC.</description>
+      <pubDate>Fri, 16 Feb 2024 18:07:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5032038-overview-of-windows-backup-as-installed-in-windows-10-and-windows-11-bd264359-4180-4541-a09f-738420f9900d</link>
+      <title>KB5032038: Overview of Windows Backup as installed in Windows 10 and Windows 11 -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Feb 2024 17:15:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-13-2024-kb5034768-os-build-17763-5458-f06ecec0-23b0-4860-880b-74a2fd1b56c0</link>
+      <title>February 13, 2024—KB5034768 (OS Build 17763.5458) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 14 Feb 2024 19:24:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-13-2024-kb5034767-os-build-14393-6709-e64b104e-984a-49fc-95ef-c3d84c159ba9</link>
+      <title>February 13, 2024—KB5034767 (OS Build 14393.6709) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 14 Feb 2024 19:22:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-13-2024-kb5034774-os-build-10240-20469-4747f1f2-9d1c-480f-b844-289df7d0c3fa</link>
+      <title>February 13, 2024—KB5034774 (OS Build 10240.20469) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 14 Feb 2024 19:20:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5034862-servicing-stack-update-for-windows-server-2016-february-13-2024-ac0b2a4e-bef4-4b67-8cdb-14be33220ffd</link>
+      <title>KB5034862: Servicing stack update for Windows Server 2016: February 13, 2024 -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 13 Feb 2024 18:00:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5034864-servicing-stack-update-for-windows-10-february-13-2024-cf2241fc-e6a6-4c04-9c0b-df2f692d4db4</link>
+      <title>KB5034864: Servicing stack update for Windows 10: February 13, 2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 13 Feb 2024 18:00:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/add-turn-off-or-remove-extensions-in-microsoft-edge-9c0ec68c-2fbc-2f2c-9ff0-bdc76f46b026</link>
+      <title>Add, turn off, or remove extensions in Microsoft Edge - Microsoft Support</title>
+      <description>Learn how to add, turn off, or remove extensions in Microsoft Edge.</description>
+      <pubDate>Thu, 08 Feb 2024 04:01:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/appendix-d-narrator-sounds-12a4cdaa-882c-c1a1-e666-ae8d6c570887</link>
+      <title>Appendix D: Narrator sounds - Microsoft Support</title>
+      <description>Hear the sounds Narrator makes and learn when they play. Narrator can replace
+        common announcements with sounds so that you hear less chatter.</description>
+      <pubDate>Tue, 06 Feb 2024 17:26:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/chapter-2-narrator-basics-5ff4591e-7b6d-245e-c95d-ce83c0a1a8d4</link>
+      <title>Chapter 2: Narrator basics - Microsoft Support</title>
+      <description>Learn about Narrator basics in Windows, including basic keyboard navigation and
+        how to get around the screen.</description>
+      <pubDate>Tue, 06 Feb 2024 17:26:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/chapter-1-introducing-narrator-7fe8fd72-541f-4536-7658-bfc37ddaf9c6</link>
+      <title>Chapter 1: Introducing Narrator - Microsoft Support</title>
+      <description>Learn about Narrator, a screen reading app in Windows, including how to start and
+        stop Narrator before and after you sign in to your PC.</description>
+      <pubDate>Tue, 06 Feb 2024 17:26:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/chapter-7-customizing-narrator-ce950246-c915-0d44-9be6-fb474387a285</link>
+      <title>Chapter 7: Customizing Narrator - Microsoft Support</title>
+      <description>Learn how to customize Narrator, choose a different voice for Narrator, and learn
+        about how to add a third-party text-to-speech (TTS) voice to Narrator.</description>
+      <pubDate>Tue, 06 Feb 2024 17:26:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/troubleshoot-windows-media-player-errors-b3a9ccc1-6267-093e-0aa3-ea860644ecd4</link>
+      <title>Troubleshoot Windows Media Player Errors - Microsoft Support</title>
+      <description>Learn how to troubleshoot Windows Media Player errors. Explore resources for
+        general help with Windows Media Player.</description>
+      <pubDate>Thu, 01 Feb 2024 06:41:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5035238-security-update-for-windows-10-version-1507-and-windows-server-2016-for-rsat-january-31-2024-ba756f68-c56c-4003-8e8b-078fec370a15</link>
+      <title>KB5035238: Security update for Windows 10, version 1507 and Windows Server 2016 for
+        RSAT: January 31, 2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 31 Jan 2024 22:00:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/get-microsoft-freecell-for-windows-10-b34651ff-9586-4b57-ee46-c565e5ca6e39</link>
+      <title>Get Microsoft FreeCell for Windows 10 - Microsoft Support</title>
+      <description>Download the Microsoft Solitaire Collection from Microsoft Store which includes
+        Microsoft FreeCell.</description>
+      <pubDate>Wed, 31 Jan 2024 15:17:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/get-updates-for-apps-and-games-in-microsoft-store-a1fe19c0-532d-ec47-7035-d1c5a1dd464f</link>
+      <title>Get updates for apps and games in Microsoft Store - Microsoft Support</title>
+      <description>Learn how to get Microsoft Store updates for your apps and games. Download the
+        latest versions of Microsoft Store apps and games.</description>
+      <pubDate>Wed, 31 Jan 2024 15:17:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/in-app-purchases-with-non-microsoft-billing-platforms-bdcd9b50-e275-4220-8979-6fd25a101fc5</link>
+      <title>In-app purchases with non-Microsoft billing platforms - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 31 Jan 2024 15:16:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/change-purchase-sign-in-settings-for-microsoft-store-on-windows-171151b7-d60e-aa57-666a-f87083d33437</link>
+      <title>Change purchase sign-in settings for Microsoft Store on Windows - Microsoft Support</title>
+      <description>Learn how to change purchase sign-in settings for Microsoft Store on Windows to
+        make a purchase without entering a password.</description>
+      <pubDate>Wed, 31 Jan 2024 15:16:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/microsoft-store-doesn-t-open-126a875d-8b72-def1-0af6-d325276a058b</link>
+      <title>Microsoft Store doesn't open - Microsoft Support</title>
+      <description>Try these troubleshooting steps if Microsoft Store does not launch in Windows 10.</description>
+      <pubDate>Wed, 31 Jan 2024 15:09:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5033052-update-stack-package-for-windows-10-version-21h2-and-22h2-72579852-8471-4e09-ae0d-a163eecde302</link>
+      <title>KB5033052: Update Stack Package for Windows 10, version 21H2 and 22H2 - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Fri, 26 Jan 2024 11:31:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/-windows-activity-history-and-your-privacy-2b279964-44ec-8c2f-e0c2-6779b07d2cbd</link>
+      <title> Windows activity history and your privacy - Microsoft Support</title>
+      <description>Find out how Microsoft uses activity history data to provide personalized
+        cross-device experiences and to help improve its products and services.</description>
+      <pubDate>Tue, 23 Jan 2024 18:42:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-9-2024-kb5034127-os-build-17763-5329-4de58ce5-eb0d-4b9a-95d1-aa15fe30b082</link>
+      <title>January 9, 2024—KB5034127 (OS Build 17763.5329) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 23 Jan 2024 18:16:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5020276-netjoin-domain-join-hardening-changes-2b65a0f3-1f4c-42ef-ac0f-1caaf421baf8</link>
+      <title>KB5020276—Netjoin: Domain join hardening changes - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 17 Jan 2024 17:34:49 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/fix-screen-time-limits-not-working-9ae1f6b2-4c40-212e-bf70-556d1235a0ce</link>
+      <title>Fix screen time limits not working - Microsoft Support</title>
+      <description>Fix screen time limits not working on Windows 10 and Xbox.</description>
+      <pubDate>Tue, 16 Jan 2024 20:10:00 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/filter-websites-and-searches-using-microsoft-family-safety-3034d91e-5efa-9fbe-1384-46009f087ccf</link>
+      <title>Filter websites and searches using Microsoft Family Safety - Microsoft Support</title>
+      <description>Use family safety settings to block inappropriate websites and searches on
+        Windows, Xbox and mobile devices.</description>
+      <pubDate>Tue, 16 Jan 2024 18:59:20 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/back-up-your-windows-pc-87a81f8a-78fa-456e-b521-ac0560e32338</link>
+      <title>Back up your Windows PC - Microsoft Support</title>
+      <description>Learn how to back up apps, settings, files, photos, and Microsoft Edge favorites
+        and preferences on your Windows PC.</description>
+      <pubDate>Tue, 16 Jan 2024 18:43:25 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5034232-compatibility-update-for-installing-and-recovering-windows-10-version-21h2-and-22h2-january-9-2024-93af23bb-0d5f-4f19-8a36-401443b53ad9</link>
+      <title>KB5034232: Compatibility update for installing and recovering Windows 10, version 21H2
+        and 22H2: January 9, 2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 12 Jan 2024 18:16:11 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/surface/surface-touchpad-use-and-settings-6c32fd32-23f4-c2d3-a3f9-cfc70feff233</link>
+      <title>Surface touchpad use and settings - Microsoft Support</title>
+      <description>Surface Typing Covers have a two-button touchpad that supports gestures and works
+        like a mouse. Explore its features, learn how to change touchpad settings</description>
+      <pubDate>Fri, 12 Jan 2024 04:55:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5034510-microsoft-printer-metadata-troubleshooter-tool-december-2023-b3197f24-fd25-430d-96d2-70f2044ce6a1</link>
+      <title>KB5034510: Microsoft Printer Metadata Troubleshooter Tool - December 2023 - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Tue, 09 Jan 2024 23:38:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-9-2024-kb5034134-os-build-10240-20402-d1ec02fa-4508-44b0-9a59-cb3aca089039</link>
+      <title>January 9, 2024—KB5034134 (OS Build 10240.20402) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Jan 2024 19:30:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-9-2024-kb5034119-os-build-14393-6614-7e7dae78-5944-4041-bf3d-4660e5ef7bb4</link>
+      <title>January 9, 2024—KB5034119 (OS Build 14393.6614) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Jan 2024 19:28:30 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-9-2024-kb5034122-os-builds-19044-3930-and-19045-3930-7656c6a4-0b06-4424-86a9-d0719f4ac252</link>
+      <title>January 9, 2024—KB5034122 (OS Builds 19044.3930 and 19045.3930) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Jan 2024 19:25:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/2020-2023-and-2024-ldap-channel-binding-and-ldap-signing-requirements-for-windows-kb4520412-ef185fb8-00f7-167d-744c-f299a66fc00a</link>
+      <title>2020, 2023, and 2024 LDAP channel binding and LDAP signing requirements for Windows
+        (KB4520412) - Microsoft Support</title>
+      <description>Describes 2020 LDAP channel binding and LDAP signing requirements for Windows</description>
+      <pubDate>Tue, 09 Jan 2024 18:08:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5034231-compatibility-update-for-installing-and-recovering-windows-10-enterprise-version-1809-and-windows-server-2019-january-9-2024-ebdb37a3-afaa-4ef0-82b2-29dbe90622ea</link>
+      <title>KB5034231: Compatibility update for installing and recovering Windows 10 Enterprise,
+        version 1809 and Windows Server 2019: January 9, 2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Jan 2024 18:04:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5034230-compatibility-update-for-installing-and-recovering-windows-server-2016-january-9-2024-16fc82c3-4aeb-4a7e-bf05-10a444acdc44</link>
+      <title>KB5034230: Compatibility update for installing and recovering Windows Server 2016:
+        January 9, 2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Jan 2024 18:01:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5034233-compatibility-update-for-installing-and-recovering-windows-10-version-1507-january-9-2024-25921abb-2478-4fed-9ea7-c324d9ecdf2a</link>
+      <title>KB5034233: Compatibility update for installing and recovering Windows 10, version 1507:
+        January 9, 2024 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Jan 2024 18:01:00 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/device-protection-in-windows-security-afa11526-de57-b1c5-599f-3a4c6a61c5e2</link>
+      <title>Device protection in Windows Security - Microsoft Support</title>
+      <description>Learn how to access Windows device security settings in Windows Security to help
+        protect your device from malicious software.</description>
+      <pubDate>Tue, 09 Jan 2024 17:20:57 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/help-protect-your-family-online-with-windows-security-5e8b9fd8-8372-dba0-eba2-46da8e407026</link>
+      <title>Help protect your family online with Windows Security - Microsoft Support</title>
+      <description>Learn how Family options in Windows Security can help protect your children when
+        they're online.</description>
+      <pubDate>Tue, 09 Jan 2024 17:11:11 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/check-your-device-performance-and-health-in-windows-security-59d8499d-b6fd-6930-7667-ebf8ae10e08d</link>
+      <title>Check your device performance and health in Windows Security - Microsoft Support</title>
+      <description>Learn how to use a health report in Windows Security to manage your device
+        performance and keep your device secure.</description>
+      <pubDate>Tue, 09 Jan 2024 17:09:09 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/app-browser-control-in-windows-security-8f68fb65-ebb4-3cfb-4bd7-ef0f376f3dc3</link>
+      <title>App &amp; browser control in Windows Security - Microsoft Support</title>
+      <description>Learn how to protect your device with Windows Defender SmartScreen and other app
+        and browser control settings in Windows Security.</description>
+      <pubDate>Tue, 09 Jan 2024 17:07:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/firewall-network-protection-in-windows-security-aef9838b-d081-fd75-3b1b-e5fa794c003b</link>
+      <title>Firewall &amp; network protection in Windows Security - Microsoft Support</title>
+      <description>Learn how to manage Windows Firewall and your networks in Windows Security.</description>
+      <pubDate>Tue, 09 Jan 2024 17:06:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-sign-in-options-and-account-protection-7b34d4cf-794f-f6bd-ddcc-e73cdf1a6fbf</link>
+      <title>Windows sign-in options and account protection - Microsoft Support</title>
+      <description>Learn how to access and manage your Windows sign in options. Use a password,
+        Windows Hello, or a security key to unlock your device.</description>
+      <pubDate>Tue, 09 Jan 2024 17:05:10 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/virus-threat-protection-in-windows-security-1362f4cd-d71a-b52a-0b66-c2820032b65e</link>
+      <title>Virus &amp; threat protection in Windows Security - Microsoft Support</title>
+      <description>Learn how to use virus and threat protection options in Windows Security to scan
+        your device for threats and view the results.</description>
+      <pubDate>Tue, 09 Jan 2024 16:57:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/surface/change-surface-pen-batteries-aebc1082-c21c-c9ff-6e6e-9df029f17bb4</link>
+      <title>Change Surface Pen batteries - Microsoft Support</title>
+      <description>Get help with how to change the battery in your Surface Pen.</description>
+      <pubDate>Mon, 08 Jan 2024 22:00:20 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/windows-scaling-issues-for-high-dpi-devices-508483cd-7c59-0d08-12b0-960b99aa347d</link>
+      <title>Windows scaling issues for high-DPI devices - Microsoft Support</title>
+      <description>Discusses Windows scaling issues for high-DPI devices. Provides resolutions and
+        workarounds for various scenarios.</description>
+      <pubDate>Thu, 04 Jan 2024 22:20:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/find-settings-in-windows-6ffbef87-e633-45ac-a1e8-b7a834578ac6</link>
+      <title>Find settings in Windows - Microsoft Support</title>
+      <description>Learn how to find and change settings in Windows.</description>
+      <pubDate>Wed, 03 Jan 2024 18:05:15 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/add-an-app-to-run-automatically-at-startup-in-windows-10-150da165-dcd9-7230-517b-cf3c295d89dd</link>
+      <title>Add an app to run automatically at startup in Windows 10 - Microsoft Support</title>
+      <description>Learn how to add an app to run automatically at startup.</description>
+      <pubDate>Wed, 03 Jan 2024 17:24:00 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-the-refresh-rate-on-your-monitor-in-windows-c8ea729e-0678-015c-c415-f806f04aae5a</link>
+      <title>Change the refresh rate on your monitor in Windows - Microsoft Support</title>
+      <description>Learn how to change the refresh rate for your display in Windows to determine how
+        smoothly motion appears on your screen.</description>
+      <pubDate>Fri, 29 Dec 2023 18:06:53 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-download-and-install-the-latest-printer-drivers-4ff66446-a2ab-b77f-46f4-a6d3fe4bf661</link>
+      <title>How to download and install the latest printer drivers - Microsoft Support</title>
+      <description>Find out how to install the latest driver for your printer. If you recently
+        upgraded Windows, your printer driver might need to be reinstalled.</description>
+      <pubDate>Fri, 29 Dec 2023 16:46:47 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-bluetooth-problems-in-windows-723e092f-03fa-858b-5c80-131ec3fba75c</link>
+      <title>Fix Bluetooth problems in Windows - Microsoft Support</title>
+      <description>Learn how to troubleshoot Bluetooth problems in Windows. Resolve issues
+        connecting a Bluetooth device or accessory.</description>
+      <pubDate>Fri, 29 Dec 2023 16:19:15 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/get-apps-from-microsoft-store-on-your-windows-pc-f69412b3-3e5c-9122-1e87-820bd718058a</link>
+      <title>Get apps from Microsoft Store on your Windows PC - Microsoft Support</title>
+      <description>Get apps and games from Microsoft Store on a Windows 10 PC.</description>
+      <pubDate>Thu, 21 Dec 2023 16:04:27 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-problems-with-game-bar-on-windows-74a718a1-2fbf-2ce3-5fbe-e959be352277</link>
+      <title>Fix problems with Game Bar on Windows - Microsoft Support</title>
+      <description>Get troubleshooting steps to fix problems with Game Bar on Windows.</description>
+      <pubDate>Wed, 20 Dec 2023 23:33:02 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-turn-on-spatial-sound-in-windows-10-ca2700a0-6519-448d-5434-56f499d59c96</link>
+      <title>How to turn on spatial sound in Windows 10 - Microsoft Support</title>
+      <description>Turn on spatial sound in Windows 10.</description>
+      <pubDate>Wed, 20 Dec 2023 00:30:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-open-msconfig-in-windows-10-a9509199-ae06-ee0d-e351-254b43071034</link>
+      <title>How to open MSConfig in Windows 10 - Microsoft Support</title>
+      <description>How to open MSConfig in Windows 10</description>
+      <pubDate>Tue, 19 Dec 2023 22:23:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/which-version-of-directx-is-on-your-pc-3c688307-6c44-2ff5-9df7-d90d92bf5239</link>
+      <title>Which version of DirectX is on your PC? - Microsoft Support</title>
+      <description>Find out which version of DirectX is on your computer so you can help your game
+        or multimedia software to work properly.</description>
+      <pubDate>Tue, 19 Dec 2023 00:37:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/what-to-try-if-your-touchscreen-doesn-t-work-f159b366-b3ef-99ad-24a4-31a4c62ab46d</link>
+      <title>What to try if your touchscreen doesn't work - Microsoft Support</title>
+      <description>Get tips for what to do if your touchscreen doesn't work.</description>
+      <pubDate>Mon, 18 Dec 2023 23:05:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-play-mp4-files-in-windows-10-e0c8d4ae-84bf-85d6-2e0c-686a80f54207</link>
+      <title>How to play MP4 files in Windows 10 - Microsoft Support</title>
+      <description>Play MP4 files in Windows 10 by right-clicking the file and choosing what
+        application to open it with.</description>
+      <pubDate>Mon, 18 Dec 2023 22:24:11 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/record-a-game-clip-on-your-pc-with-game-bar-2f477001-54d4-1276-9144-b0416a307f3c</link>
+      <title>Record a game clip on your PC with Game Bar - Microsoft Support</title>
+      <description>Use the Game Bar in Windows to capture video and screenshots while playing PC
+        games.</description>
+      <pubDate>Thu, 14 Dec 2023 00:12:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/make-start-full-screen-13bc1e29-65dd-ba38-e3ec-7959b8d770dc</link>
+      <title>Make Start full screen - Microsoft Support</title>
+      <description>Learn how to change the size of the Start menu in Windows to show more of your
+        apps, and even make it full-screen.</description>
+      <pubDate>Wed, 13 Dec 2023 00:33:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/clear-the-delivery-optimization-cache-c0e93802-5800-5554-7380-594014a6089b</link>
+      <title>Clear the Delivery Optimization cache - Microsoft Support</title>
+      <description>Manually clear the Delivery Optimization cache in Windows 10.</description>
+      <pubDate>Wed, 13 Dec 2023 00:26:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/dvd-playback-options-for-windows-927ebe85-7837-4149-4323-f55a9e3c4e36</link>
+      <title>DVD playback options for Windows - Microsoft Support</title>
+      <description>Find out how to get a DVD player app, add-on, or plug-in, or whether you can
+        upgrade your edition of Windows to add DVD playback.</description>
+      <pubDate>Tue, 12 Dec 2023 23:25:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-12-2023-kb5033379-os-build-10240-20345-03a11f29-fc6c-47ca-8143-af8e2641033f</link>
+      <title>December 12, 2023—KB5033379 (OS Build 10240.20345) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 12 Dec 2023 18:15:47 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-12-2023-kb5033373-os-build-14393-6529-29226794-12f4-45c5-a92e-ac1ab570e41d</link>
+      <title>December 12, 2023—KB5033373 (OS Build 14393.6529) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 12 Dec 2023 18:04:16 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-12-2023-kb5033372-os-builds-19044-3803-and-19045-3803-9cea61c6-072b-41f1-8cf2-7c7bfdd12d5c</link>
+      <title>December 12, 2023—KB5033372 (OS Builds 19044.3803 and 19045.3803) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 12 Dec 2023 18:02:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-12-2023-kb5033371-os-build-17763-5206-aeb26a0a-536b-4bf8-9f5a-2749f4ba71fc</link>
+      <title>December 12, 2023—KB5033371 (OS Build 17763.5206) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 12 Dec 2023 18:01:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/microsoft-basic-display-adapter-on-windows-10-fd1c777c-d4d5-f05a-edb1-0dc7031fd677</link>
+      <title>Microsoft Basic Display Adapter on Windows 10 - Microsoft Support</title>
+      <description>Microsoft Basic Display Adapter on Windows 10</description>
+      <pubDate>Fri, 08 Dec 2023 23:24:15 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-graphics-device-problems-with-error-code-43-6f6ae1ec-0bbe-a848-142e-0c6190502842</link>
+      <title>Fix graphics device problems with error code 43 - Microsoft Support</title>
+      <description>Learn how to fix graphics device driver error code 43 in Windows 10.</description>
+      <pubDate>Fri, 08 Dec 2023 23:16:47 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/restart-reboot-your-pc-110262aa-fc79-1c33-7b00-c140ae3a6dac</link>
+      <title>Restart (reboot) your PC - Microsoft Support</title>
+      <description>Select the Start button, then Power &gt; Restart.</description>
+      <pubDate>Fri, 08 Dec 2023 23:00:11 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/what-bluetooth-version-is-on-my-pc-f5d4cff7-c00d-337b-a642-d2d23b082793</link>
+      <title>What Bluetooth version is on my PC? - Microsoft Support</title>
+      <description>Here's how to find out which Bluetooth version you have on your device.</description>
+      <pubDate>Fri, 08 Dec 2023 22:25:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-problems-signing-in-to-the-xbox-app-40db5c71-aa95-a508-5651-8eb5b56f5c60</link>
+      <title>Fix problems signing in to the Xbox app - Microsoft Support</title>
+      <description>Get troubleshooting steps for when you can't sign in to the Xbox app.</description>
+      <pubDate>Thu, 07 Dec 2023 23:27:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-use-voice-recorder-6fbb53d5-0539-abda-a9a4-0bcb84a778e7</link>
+      <title>How to use Voice Recorder - Microsoft Support</title>
+      <description>Voice Recorder has lots of options like adding markers to identify key moments,
+        and the ability to trim, rename, and share your recordings.</description>
+      <pubDate>Thu, 07 Dec 2023 22:46:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/add-the-battery-icon-to-the-taskbar-in-windows-10-df5599da-5f1f-c1f8-d9df-a5c8dd991cdf</link>
+      <title>Add the battery icon to the taskbar in Windows 10 - Microsoft Support</title>
+      <description>Add the battery icon to the taskbar in Windows 10.</description>
+      <pubDate>Thu, 07 Dec 2023 00:18:57 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/find-your-mouse-pointer-fast-dbc1d222-778c-da15-5218-cb8336074554</link>
+      <title>Find your mouse pointer fast - Microsoft Support</title>
+      <description>How to find your mouse pointer fast by using the CTRL key.</description>
+      <pubDate>Wed, 06 Dec 2023 22:40:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/some-versions-of-windows-10-display-a-notification-to-install-the-latest-version-57f35816-2e6f-1718-4a1e-529aa5cc53de</link>
+      <title>Some versions of Windows 10 display a notification to install the latest version -
+        Microsoft Support</title>
+      <description>Discusses the reasons that some versions of Windows 10 display a notification to
+        install the latest Windows version.</description>
+      <pubDate>Wed, 06 Dec 2023 21:42:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-use-the-pc-health-check-app-9c8abd9b-03ba-4e67-81ef-36f37caa7844</link>
+      <title>How to use the PC Health Check app - Microsoft Support</title>
+      <description>Learn how to use the PC Health Check app to help you improve your device
+        performance.</description>
+      <pubDate>Wed, 06 Dec 2023 20:20:53 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/find-action-center-in-windows-10-eda89d84-0676-1fad-36e9-e9aa0c5cc937</link>
+      <title>Find action center in Windows 10 - Microsoft Support</title>
+      <description>Windows 10 has a new action center where you'll find app notifications and quick
+        actions. Look for it on the taskbar.</description>
+      <pubDate>Wed, 06 Dec 2023 20:17:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-fix-error-0xa-irql-not-less-or-equal-fd19c7fc-89d2-67a5-4fb0-a1f8bd1f0202</link>
+      <title>How to fix Error 0xA: IRQL_not_less_or_equal - Microsoft Support</title>
+      <description>Check that your device has the latest updates by going to Start &gt; Settings
+        &gt; Update &amp; Security &gt; Windows Update &gt; Check for updates.</description>
+      <pubDate>Wed, 06 Dec 2023 19:54:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/rename-your-windows-10-pc-750bc75d-8ff8-e99a-b9dc-04dff566ae74</link>
+      <title>Rename your Windows 10 PC - Microsoft Support</title>
+      <description>Rename your device to make it easier to identify if if you use multiple computers
+        with your Microsoft account.</description>
+      <pubDate>Tue, 05 Dec 2023 00:57:28 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/-there-was-a-problem-when-resetting-your-pc-no-changes-were-made-error-after-attempting-to-reset-this-pc-365f1c42-6928-63ed-dd84-bb264cdad5a8</link>
+      <title>"There was a problem when resetting your PC. No changes were made." error after
+        attempting to Reset this PC - Microsoft Support</title>
+      <description>What to do when you receive the cited error when atempting to Reset this PC.</description>
+      <pubDate>Mon, 04 Dec 2023 22:39:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/find-safe-mode-and-other-startup-settings-in-windows-10-7551aac3-21b5-c646-06ee-31e0e6a5e4dc</link>
+      <title>Find safe mode and other startup settings in Windows 10 - Microsoft Support</title>
+      <description>Find out how to boot into safe mode in Windows 10 from Settings and the sign-in
+        screen, as well as how to exit safe mode.</description>
+      <pubDate>Thu, 30 Nov 2023 23:58:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-use-alarms-and-timers-in-the-clock-app-in-windows-10-d7e4bddb-85f3-ef88-1ee6-f322d8dbc793</link>
+      <title>How to use alarms and timers in the Clock app in Windows 10 - Microsoft Support</title>
+      <description>Learn how to use the Clock app in Windows 10</description>
+      <pubDate>Thu, 30 Nov 2023 23:16:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/how-to-get-copilot-in-windows-in-preview-on-windows-10-570514d1-add9-4bc4-9add-c75ea4496949</link>
+      <title>How to get Copilot in Windows (in preview) on Windows 10 - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 30 Nov 2023 22:05:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-30-2023-kb5032278-os-build-19045-3758-preview-0ae14f06-577e-4eb3-8fcb-c722f3f9dc29</link>
+      <title>November 30, 2023—KB5032278 (OS Build 19045.3758) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 30 Nov 2023 22:00:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-14-2023-kb5032189-os-builds-19044-3693-and-19045-3693-fe81e7e5-06bd-4e13-8233-4f7c07b1c512</link>
+      <title>November 14, 2023—KB5032189 (OS Builds 19044.3693 and 19045.3693) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 30 Nov 2023 20:58:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/turn-on-app-permissions-for-your-microphone-in-windows-10-94991183-f69d-b4cf-4679-c98ca45f577a</link>
+      <title>Turn on app permissions for your microphone in Windows 10 - Microsoft Support</title>
+      <description>Learn how to give your Windows 10 PC to permission to access your microphone.</description>
+      <pubDate>Thu, 30 Nov 2023 00:25:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/why-can-t-i-activate-windows-73ea9956-a4cd-9bc6-17c2-255ec26db204</link>
+      <title>Why can't I activate Windows? - Microsoft Support</title>
+      <description>Learn how to troubleshoot and resolve 'Windows can't be activated' error message.</description>
+      <pubDate>Thu, 30 Nov 2023 00:02:00 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/receive-files-over-bluetooth-d8da2667-e79b-744c-c135-f58af38fc3ba</link>
+      <title>Receive files over Bluetooth - Microsoft Support</title>
+      <description>Use the Settings app in Windows 10 to receive files over Bluetooth.</description>
+      <pubDate>Wed, 29 Nov 2023 00:14:09 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/find-out-how-much-storage-your-pc-has-c7cbe6ef-267b-6b8a-32d9-01161623ba5a</link>
+      <title>Find out how much storage your PC has - Microsoft Support</title>
+      <description>Select the Start button &gt; Settings &gt; System &gt; Storage.</description>
+      <pubDate>Tue, 28 Nov 2023 23:25:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-your-screen-saver-settings-a9dc2a0c-dc8e-9161-d270-aaccc252082a</link>
+      <title>Change your screen saver settings - Microsoft Support</title>
+      <description>Change your screen saver settings</description>
+      <pubDate>Tue, 28 Nov 2023 22:20:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/surface/fix-common-surface-problems-using-the-surface-app-and-surface-diagnostic-toolkit-f61d8d18-37a9-863d-f8d0-1982eb16f7b5</link>
+      <title>Fix common Surface problems using the Surface app and Surface Diagnostic Toolkit -
+        Microsoft Support</title>
+      <description>Access, download, or run the Surface app and the Surface Diagnostic Toolkit to
+        help find and solve Surface problems.</description>
+      <pubDate>Tue, 28 Nov 2023 02:48:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/common-file-name-extensions-in-windows-da4a4430-8e76-89c5-59f7-1cdbbc75cb01</link>
+      <title>Common file name extensions in Windows - Microsoft Support</title>
+      <description>Learn what file name extensions are, which extensions are common in Windows, and
+        how to view them in File Explorer.</description>
+      <pubDate>Tue, 28 Nov 2023 00:17:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/show-hidden-files-0320fe58-0117-fd59-6851-9b7f9840fdb2</link>
+      <title>Show hidden files - Microsoft Support</title>
+      <description>Learn how to display hidden files, folders, and drives.</description>
+      <pubDate>Mon, 27 Nov 2023 23:08:53 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/show-or-hide-the-recycle-bin-0d4d40aa-be23-91ec-96ab-338818d5e5fb</link>
+      <title>Show or hide the Recycle Bin - Microsoft Support</title>
+      <description>Here's how to get the Recycle Bin on your desktop: Select the Start button in the
+        lower-left corner of the taskbar, then Settings.</description>
+      <pubDate>Mon, 27 Nov 2023 22:24:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/upgrade-windows-home-to-windows-pro-ef34d520-e73f-3198-c525-d1a218cc2818</link>
+      <title>Upgrade Windows Home to Windows Pro - Microsoft Support</title>
+      <description>Learn how to upgrade from Windows 10 Home to Windows 10 Pro or Windows 11 Home to
+        Windows 11 Pro, including how to use a valid product key or the Microsoft Store.</description>
+      <pubDate>Mon, 27 Nov 2023 21:53:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/switching-out-of-s-mode-in-windows-4f56d9be-99ec-6983-119f-031bfb28a307</link>
+      <title>Switching out of S mode in Windows - Microsoft Support</title>
+      <description>Learn how to switch out of S mode to install apps from outside of the Microsoft
+        Store or to upgrade to Windows 11.</description>
+      <pubDate>Mon, 27 Nov 2023 21:02:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/open-and-run-dxdiag-exe-dad7792c-2ad5-f6cd-5a37-bf92228dfd85</link>
+      <title>Open and run DxDiag.exe - Microsoft Support</title>
+      <description>Open and run DxDiag.exe</description>
+      <pubDate>Thu, 16 Nov 2023 23:11:15 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/pin-remove-and-customize-in-quick-access-7344ff13-bdf4-9f40-7f76-0b1092d2495b</link>
+      <title>Pin, remove, and customize in Quick access - Microsoft Support</title>
+      <description>Pin, remove, and customize in Quick access.</description>
+      <pubDate>Thu, 16 Nov 2023 22:46:02 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-fix-it-tool-with-windows-10-cc3cb85b-91d7-7e56-8ce1-db50b4d18d0b</link>
+      <title>Use a fix-it tool with Windows 10 - Microsoft Support</title>
+      <description>Fix-it tools aren’t used in Windows 10. Instead, use a troubleshooter to help
+        solve problems with your PC.</description>
+      <pubDate>Thu, 16 Nov 2023 22:23:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-windows-updates-as-soon-as-they-re-available-for-your-device-4911c7af-2644-41f7-a800-6660f9212448</link>
+      <title>Get Windows updates as soon as they're available for your device - Microsoft Support</title>
+      <description>Learn how you can get the latest non-security updates if you have Windows 10.</description>
+      <pubDate>Thu, 16 Nov 2023 18:34:27 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/how-we-are-maximizing-value-in-windows-10-7dca25fa-be2f-492d-b99c-bf3342be7037</link>
+      <title>How we are maximizing value in Windows 10 - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 16 Nov 2023 18:00:28 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/create-a-system-restore-point-77e02e2a-3298-c869-9974-ef5658ea3be9</link>
+      <title>Create a system restore point - Microsoft Support</title>
+      <description>Create a system restore point</description>
+      <pubDate>Thu, 16 Nov 2023 00:48:00 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/find-my-downloads-in-windows-10-de903ee9-7d37-256b-9145-f0f016c5aed8</link>
+      <title>Find my downloads in Windows 10 - Microsoft Support</title>
+      <description>See how to find things you've downloaded on your PC.</description>
+      <pubDate>Wed, 15 Nov 2023 22:12:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/open-device-manager-a7f2db46-faaf-24f0-8b7b-9e4a6032fc8c</link>
+      <title>Open Device Manager - Microsoft Support</title>
+      <description>Open Device Manager</description>
+      <pubDate>Wed, 15 Nov 2023 21:31:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5032390-servicing-stack-update-for-windows-10-november-14-2023-51843a62-2c4c-4dea-ac8e-290180c317ad</link>
+      <title>KB5032390: Servicing stack update for Windows 10: November 14, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 14 Nov 2023 18:12:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-14-2023-kb5032199-os-build-10240-20308-ae103d5c-6d34-4ac7-a4a4-85e37cdb389b</link>
+      <title>November 14, 2023—KB5032199 (OS Build 10240.20308) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 14 Nov 2023 18:08:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-14-2023-kb5032197-os-build-14393-6452-7eff4948-a9bb-46ba-aa91-ce3047cac846</link>
+      <title>November 14, 2023—KB5032197 (OS Build 14393.6452) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 14 Nov 2023 18:08:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5032906-setup-dynamic-update-for-windows-10-version-21h2-and-22h2-november-14-2023-b16f033f-b818-473d-aa2d-72b7f24d2ed1</link>
+      <title>KB5032906: Setup Dynamic Update for Windows 10, version 21H2 and 22H2: November 14,
+        2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 14 Nov 2023 18:07:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5032391-servicing-stack-update-for-windows-server-2016-november-14-2023-2f98b245-4e9c-4b3e-8ef8-1268a8e36324</link>
+      <title>KB5032391: Servicing stack update for Windows Server 2016: November 14, 2023 -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 14 Nov 2023 18:07:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-apps-that-appear-blurry-in-windows-10-e9fe34ab-e7e7-bc6f-6695-cb169b51de0f</link>
+      <title>Fix apps that appear blurry in Windows 10 - Microsoft Support</title>
+      <description>Learn how Windows can help fix desktop apps that appear blurry on your main
+        display when you're using multiple monitors.</description>
+      <pubDate>Tue, 14 Nov 2023 00:31:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/search-indexing-in-windows-10-faq-da061c83-af6b-095c-0f7a-4dfecda4d15a</link>
+      <title>Search indexing in Windows 10: FAQ - Microsoft Support</title>
+      <description>Get answers to questions about how indexing affects searches in Windows 10.</description>
+      <pubDate>Mon, 13 Nov 2023 23:48:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/find-the-recycle-bin-885cf298-0f98-a548-9427-a1248fce4315</link>
+      <title>Find the Recycle Bin - Microsoft Support</title>
+      <description>Find the Recycle Bin</description>
+      <pubDate>Mon, 13 Nov 2023 23:37:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/troubleshoot-external-monitor-connections-in-windows-10-5b46f4a4-9634-06bb-7622-f960facdfd49</link>
+      <title>Troubleshoot external monitor connections in Windows 10 - Microsoft Support</title>
+      <description>How to set up and troubleshoot one or more external monitors.</description>
+      <pubDate>Mon, 13 Nov 2023 23:23:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/switch-to-microsoft-edge-for-a-better-browsing-experience-160fa918-d581-4932-9e4e-1075c4713595</link>
+      <title>Switch to Microsoft Edge for a better browsing experience - Microsoft Support</title>
+      <description>Try Microsoft Edge to experience the web in a whole new way. Learn how to move
+        all your favorites, passwords and preferences from Internet Explorer to Microsoft Edge.</description>
+      <pubDate>Mon, 13 Nov 2023 18:47:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/enable-and-disable-your-touchscreen-in-windows-b774e29d-be94-990f-c20f-e02892e572fc</link>
+      <title>Enable and disable your touchscreen in Windows - Microsoft Support</title>
+      <description>Enable and disable your touchscreen in Windows 10</description>
+      <pubDate>Sat, 11 Nov 2023 00:10:28 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-set-your-time-and-time-zone-dfaa7122-479f-5b98-2a7b-fa0b6e01b261</link>
+      <title>How to set your time and time zone - Microsoft Support</title>
+      <description>How to set your time and time zone</description>
+      <pubDate>Fri, 10 Nov 2023 23:42:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/create-an-iso-file-for-windows-10-38547366-1dcb-7afd-1726-9eb222d72705</link>
+      <title>Create an ISO file for Windows 10 - Microsoft Support</title>
+      <description>Create an ISO file for Windows 10</description>
+      <pubDate>Fri, 10 Nov 2023 22:42:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/choose-a-backup-solution-in-windows-10-31495e5d-370e-3631-c773-44de4301e070</link>
+      <title>Choose a backup solution in Windows 10 - Microsoft Support</title>
+      <description>Learn about Windows 10 backup solutions to protect your important files and
+        photos.</description>
+      <pubDate>Fri, 10 Nov 2023 22:28:15 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/share-your-network-printer-c9a152b5-59f3-b6f3-c99f-f39e5bf664c3</link>
+      <title>Share your network printer - Microsoft Support</title>
+      <description>Learn how to share a printer between a primary PC and secondary PCs on your
+        network.</description>
+      <pubDate>Fri, 10 Nov 2023 00:37:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/open-control-panel-in-windows-e8d6e3d8-4743-422c-7cf8-0b41f8f079a1</link>
+      <title>Open Control Panel in Windows - Microsoft Support</title>
+      <description>Open Control Panel in Windows</description>
+      <pubDate>Thu, 09 Nov 2023 23:12:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-10-2023-kb5031356-os-builds-19044-3570-and-19045-3570-951fac64-5bf8-4eba-ba18-a9448920df1a</link>
+      <title>October 10, 2023—KB5031356 (OS Builds 19044.3570 and 19045.3570) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 09 Nov 2023 18:06:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-10-2023-kb5031377-os-build-10240-20232-537f318a-fcbc-49d7-8197-75bd42121244</link>
+      <title>October 10, 2023—KB5031377 (OS Build 10240.20232) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 09 Nov 2023 18:00:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-10-2023-kb5031362-os-build-14393-6351-0c6e713e-3d6a-4593-8a75-af0a605f249c</link>
+      <title>October 10, 2023—KB5031362 (OS Build 14393.6351) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 09 Nov 2023 17:57:47 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-10-2023-kb5031361-os-build-17763-4974-766593db-b47a-4b18-a698-906426860313</link>
+      <title>October 10, 2023—KB5031361 (OS Build 17763.4974) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 09 Nov 2023 17:55:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-26-2023-kb5031445-os-build-19045-3636-preview-03f350cb-57f9-45e6-bfd7-438895d3c7fa</link>
+      <title>October 26, 2023—KB5031445 (OS Build 19045.3636) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 08 Nov 2023 21:00:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/risks-of-allowing-apps-through-windows-defender-firewall-654559af-3f54-3dcf-349f-71ccd90bcc5c</link>
+      <title>Risks of allowing apps through Windows Defender Firewall - Microsoft Support</title>
+      <description>Find out the risks of allowing apps through Windows Defender Firewall and how to
+        add or remove apps from the list of approved apps.</description>
+      <pubDate>Wed, 08 Nov 2023 00:19:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-the-latest-windows-update-7d20e88c-0568-483a-37bc-c3885390d212</link>
+      <title>Get the latest Windows update - Microsoft Support</title>
+      <description>When the latest Windows update is ready for your device, it will be available to
+        download from the Windows Update page in Settings.</description>
+      <pubDate>Tue, 07 Nov 2023 21:22:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/zip-and-unzip-files-8d28fa72-f2f9-712f-67df-f80cf89fd4e5</link>
+      <title>Zip and unzip files - Microsoft Support</title>
+      <description>Combine several files into a single compressed folder to save storage space or to
+        share them more easily.</description>
+      <pubDate>Fri, 03 Nov 2023 21:43:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/find-your-wi-fi-network-password-in-windows-2ec74b2e-d9ec-ade1-cc9b-bef1429cb678</link>
+      <title>Find your Wi-Fi network password in Windows - Microsoft Support</title>
+      <description>Find your Wi-Fi network password in Windows, so you can connect to your Wi-Fi
+        network on other devices.</description>
+      <pubDate>Fri, 03 Nov 2023 15:27:11 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/serviced-versions-of-windows-10-frequently-asked-questions-0543e712-b23e-b6c0-034a-45d7b559ae88</link>
+      <title>Serviced versions of Windows 10: Frequently asked questions - Microsoft Support</title>
+      <description>Get end-of-service info for Windows 10 and find out what you need to know to
+        upgrade your Windows 10 device to the latest version.</description>
+      <pubDate>Wed, 01 Nov 2023 23:25:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/create-installation-media-for-windows-99a58364-8c02-206f-aa6f-40c3b507420d</link>
+      <title>Create installation media for Windows - Microsoft Support</title>
+      <description>Learn how to create installation media for installing or reinstalling Windows 7,
+        Windows 8.1, or Windows 10.</description>
+      <pubDate>Wed, 01 Nov 2023 21:47:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb4093836-summary-of-intel-microcode-updates-08c99af2-075a-4e16-1ef1-5f6e4d8637c4</link>
+      <title>KB4093836: Summary of Intel Microcode Updates - Microsoft Support</title>
+      <description>Provides a summary of the articles related to the Intel Microcode Updates.</description>
+      <pubDate>Tue, 31 Oct 2023 12:20:40 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb4457951-windows-guidance-to-protect-against-speculative-execution-side-channel-vulnerabilities-ae9b7bcd-e8e9-7304-2c40-f047a0ab3385</link>
+      <title>KB4457951: Windows guidance to protect against speculative execution side-channel
+        vulnerabilities - Microsoft Support</title>
+      <description>Provides guidance for Windows Server to protect against an L1 terminal fault
+        (LITF) attack.</description>
+      <pubDate>Fri, 27 Oct 2023 14:55:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb4023057-update-health-tools-windows-update-service-components-fccad0ca-dc10-2e46-9ed1-7e392450fb3a</link>
+      <title>KB4023057: Update Health Tools—Windows Update Service components - Microsoft Support</title>
+      <description>Describes this reliability update, including improvements and fixes, known
+        issues, and how to get the update.</description>
+      <pubDate>Thu, 26 Oct 2023 17:00:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/pair-a-bluetooth-device-in-windows-2be7b51f-6ae9-b757-a3b9-95ee40c3e242</link>
+      <title>Pair a Bluetooth device in Windows - Microsoft Support</title>
+      <description>Learn how to connect a Bluetooth device in Windows and adjust Bluetooth pairing
+        settings.</description>
+      <pubDate>Wed, 25 Oct 2023 22:31:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/file-drag-drop-in-link-to-windows-pre-installed-8ce092c3-a466-25fd-9ef2-de60f8335a52</link>
+      <title>File drag &amp; drop in Link to Windows (pre-installed) - Microsoft Support</title>
+      <description>Setup and troubleshooting steps for the file drag &amp; drop feature in the Link
+        to Windows app.</description>
+      <pubDate>Fri, 20 Oct 2023 16:00:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/camera-app-shows-error-0xa00f4244-nocamerasareattached-05d738b3-b1fd-06f2-f5fc-c0437ff8db32</link>
+      <title>Camera app shows error "0xA00F4244 NoCamerasAreAttached" - Microsoft Support</title>
+      <description>Get help when Windows can't find the camera</description>
+      <pubDate>Wed, 18 Oct 2023 16:19:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5032314-how-to-manage-the-ole-object-conversion-vulnerability-associated-with-cve-2023-36563-98d95ae9-2f9e-4f65-9231-46363c31cf07</link>
+      <title>KB5032314: How to manage the OLE object conversion vulnerability associated with
+        CVE-2023-36563 - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 12 Oct 2023 19:27:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-26-2023-kb5030300-os-build-19045-3516-preview-9d43fdfb-71a1-4a40-b217-4a43d4bd84db</link>
+      <title>September 26, 2023—KB5030300 (OS Build 19045.3516) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 12 Oct 2023 16:45:41 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-12-2023-kb5030211-os-builds-19044-3448-and-19045-3448-c0dee353-f025-4f03-bcc1-336f74fb992c</link>
+      <title>September 12, 2023—KB5030211 (OS Builds 19044.3448 and 19045.3448) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 12 Oct 2023 16:43:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-22-2023-kb5029331-os-build-19045-3393-preview-9f6c1dbd-0ee6-469b-af24-f9d0bf35ca18</link>
+      <title>August 22, 2023—KB5029331 (OS Build 19045.3393) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 12 Oct 2023 16:41:41 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-8-2023-kb5029244-os-builds-19044-3324-and-19045-3324-46087102-62c2-4911-9896-da3c6f4d8b5c</link>
+      <title>August 8, 2023—KB5029244 (OS Builds 19044.3324 and 19045.3324) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 12 Oct 2023 16:39:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-25-2023-kb5028244-os-build-19045-3271-preview-8cf92c9b-3a60-4c6a-8f4c-fc41fe8f4f2c</link>
+      <title>July 25, 2023—KB5028244 (OS Build 19045.3271) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 12 Oct 2023 16:37:41 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-11-2023-kb5028166-os-builds-19044-3208-and-19045-3208-eab49ea6-3133-41c8-845f-a14a329c6c20</link>
+      <title>July 11, 2023—KB5028166 (OS Builds 19044.3208 and 19045.3208) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 12 Oct 2023 16:36:02 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-12-2023-kb5030214-os-build-17763-4851-e6ae7551-49f4-428e-b2d4-caa73078fb06</link>
+      <title>September 12, 2023—KB5030214 (OS Build 17763.4851) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 11 Oct 2023 17:58:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-8-2023-kb5029247-os-build-17763-4737-9f99a6da-ef38-4744-aef2-df38365f9203</link>
+      <title>August 8, 2023—KB5029247 (OS Build 17763.4737) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 11 Oct 2023 17:55:47 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-11-2023-kb5028168-os-build-17763-4645-eff2d1e1-5f91-4d9a-aef1-ae26bdf51321</link>
+      <title>July 11, 2023—KB5028168 (OS Build 17763.4645) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 11 Oct 2023 17:48:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5031466-servicing-stack-update-for-windows-10-october-10-2023-2f9a76a1-396d-421c-add5-aba0038b737c</link>
+      <title>KB5031466: Servicing stack update for Windows 10: October 10, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 10 Oct 2023 17:16:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5031471-compatibility-update-for-installing-and-recovering-windows-server-2016-october-10-2023-b5feca0d-91b0-4be4-aee2-9ab4a9ca0fe8</link>
+      <title>KB5031471: Compatibility update for installing and recovering Windows Server 2016:
+        October 10, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 10 Oct 2023 17:15:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5031470-compatibility-update-for-installing-and-recovering-windows-10-version-1507-october-10-2023-7e3b8136-8329-406e-8e64-1c1d4ca72852</link>
+      <title>KB5031470: Compatibility update for installing and recovering Windows 10, version 1507:
+        October 10, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 10 Oct 2023 17:13:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/activate-windows-c39005d4-95ee-b91e-b399-2820fda32227</link>
+      <title>Activate Windows - Microsoft Support</title>
+      <description>Learn how to activate Windows using a product key or digital license, check your
+        activation status, and link your Microsoft account.</description>
+      <pubDate>Tue, 10 Oct 2023 17:09:15 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5031474-compatibility-update-for-installing-and-recovering-windows-10-version-21h2-and-22h2-october-10-2023-b6032383-f223-4bb2-aa51-c032b0d4f632</link>
+      <title>KB5031474: Compatibility update for installing and recovering Windows 10, version 21H2
+        and 22H2: October 10, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 10 Oct 2023 17:03:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5031472-compatibility-update-for-installing-and-recovering-windows-10-version-1809-enterprise-and-windows-server-2019-october-10-2023-b551c57a-b4a5-4cc9-aaef-122a62a10825</link>
+      <title>KB5031472: Compatibility update for installing and recovering Windows 10, version 1809
+        Enterprise and Windows Server 2019: October 10, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 10 Oct 2023 17:03:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-wi-fi-connection-issues-in-windows-9424a1f7-6a3b-65a6-4d78-7f07eee84d2c</link>
+      <title>Fix Wi-Fi connection issues in Windows - Microsoft Support</title>
+      <description>Learn about different things you can try to fix network connection problems in
+        Windows.</description>
+      <pubDate>Fri, 06 Oct 2023 19:49:16 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-8-2021-kb5003638-os-build-14393-4467-expired-d9dfce91-b425-483a-8280-f54d7005b231</link>
+      <title>June 8, 2021—KB5003638 (OS Build 14393.4467) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 04 Oct 2023 21:26:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/find-and-open-file-explorer-ef370130-1cca-9dc5-e0df-2f7416fe1cb1</link>
+      <title>Find and open File Explorer - Microsoft Support</title>
+      <description>Find and open File Explorer in Windows 10 and Windows 11, and customize Quick
+        access by pinning and removing files and folders.</description>
+      <pubDate>Thu, 28 Sep 2023 21:00:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-share-files-in-file-explorer-on-windows-dcf7d3dc-40f7-111a-0c9e-a8981c4bbc32</link>
+      <title>How to share files in File Explorer on Windows - Microsoft Support</title>
+      <description>Learn how to share files in File Explorer on Windows 11 or Windows 10 using
+        OneDrive, email, or nearby device.</description>
+      <pubDate>Thu, 28 Sep 2023 21:00:00 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-file-explorer-if-it-won-t-open-or-start-ce614e06-be97-fe4a-a7ce-d6bf13a8cb98</link>
+      <title>Fix File Explorer if it won't open or start - Microsoft Support</title>
+      <description>Learn how to troubleshoot File Explorer problems in Windows.</description>
+      <pubDate>Thu, 28 Sep 2023 20:59:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/set-file-explorer-to-open-to-this-pc-instead-of-quick-access-b2c7d271-027b-b35f-917e-897f66e68e5c</link>
+      <title>Set File Explorer to open to This PC instead of Quick Access - Microsoft Support</title>
+      <description>You can change how File Explorer opens. It can open to This PC instead of Quick
+        Access.</description>
+      <pubDate>Thu, 28 Sep 2023 20:57:40 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/help-in-file-explorer-a2d33543-5242-788d-8994-b0be10ae5bca</link>
+      <title>Help in File Explorer - Microsoft Support</title>
+      <description>Learn how to open and navigate File Explorer in Windows. Get answers to common
+        questions about File Explorer.</description>
+      <pubDate>Thu, 28 Sep 2023 20:57:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/view-hidden-files-and-folders-in-windows-97fbc472-c603-9d90-91d0-1166d1d9f4b5</link>
+      <title>View hidden files and folders in Windows - Microsoft Support</title>
+      <description>Learn how to show hidden files, folders, and drives in Windows.</description>
+      <pubDate>Thu, 28 Sep 2023 20:54:40 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/reset-your-windows-local-account-password-86912508-e584-37cc-86eb-6e9b0542b5ba</link>
+      <title>Reset your Windows local account password - Microsoft Support</title>
+      <description>Learn how to reset your local account password for Windows or sign back in using
+        security questions.</description>
+      <pubDate>Thu, 28 Sep 2023 20:47:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-switch-users-accounts-in-windows-660d4dcd-fa8d-7467-10b3-fee0e70e11d4</link>
+      <title>How to switch users (accounts) in Windows - Microsoft Support</title>
+      <description>Learn how to switch between different users (accounts) in Windows.</description>
+      <pubDate>Thu, 28 Sep 2023 20:47:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/hide-windows-updates-or-driver-updates-5df410a1-90f7-b744-0682-43be9c8fa17c</link>
+      <title>Hide Windows Updates or driver updates - Microsoft Support</title>
+      <description>Learn how to prevent a Windows update from reinstalling automatically.</description>
+      <pubDate>Thu, 28 Sep 2023 20:47:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/keyboard-shortcuts-for-game-bar-85d97243-c89b-1ae1-6402-0faf35d6489d</link>
+      <title>Keyboard shortcuts for Game Bar - Microsoft Support</title>
+      <description>Find the common Windows keyboard shortcuts for Game Bar.</description>
+      <pubDate>Thu, 28 Sep 2023 17:13:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/appendix-c-supported-braille-displays-65c40265-8aa6-9b53-9bc8-8a7a87e5dd8a</link>
+      <title>Appendix C: Supported braille displays - Microsoft Support</title>
+      <description>Learn which braille displays Narrator supports in the latest version of Windows.</description>
+      <pubDate>Wed, 27 Sep 2023 04:51:02 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/appendix-b-narrator-keyboard-commands-and-touch-gestures-8bdab3f4-b3e9-4554-7f28-8b15bd37410a</link>
+      <title>Appendix B: Narrator keyboard commands and touch gestures - Microsoft Support</title>
+      <description>Learn about Narrator keyboard commands and touch gestures in Windows.</description>
+      <pubDate>Wed, 27 Sep 2023 04:50:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/chapter-8-using-narrator-with-braille-3e5f065b-1c9d-6eb2-ec6d-1d07c9e94b20</link>
+      <title>Chapter 8: Using Narrator with braille - Microsoft Support</title>
+      <description>Learn about how to use Narrator with a refreshable braille display</description>
+      <pubDate>Wed, 27 Sep 2023 04:50:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/chapter-6-using-narrator-with-touch-60f8f38b-23fa-ebe2-4345-c900d1b2e22f</link>
+      <title>Chapter 6: Using Narrator with touch - Microsoft Support</title>
+      <description>Learn about how to use Narrator with touch in Windows, include basic gestures and
+        typing by touch.</description>
+      <pubDate>Wed, 27 Sep 2023 04:48:47 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/chapter-5-navigation-68941680-3245-6ef5-5012-0674b8b6fc59</link>
+      <title>Chapter 5: Navigation - Microsoft Support</title>
+      <description>Describes views in Narrator in the latest version of Windows.</description>
+      <pubDate>Wed, 27 Sep 2023 04:48:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/chapter-4-reading-text-8054c6cd-dccf-5070-e405-953f036e4a15</link>
+      <title>Chapter 4: Reading text - Microsoft Support</title>
+      <description>Learn about how to read text using Narrator in Windows, including how to get info
+        about text, such as font text color, and punctuation.</description>
+      <pubDate>Wed, 27 Sep 2023 04:48:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/set-your-data-limit-031dcc15-fa0f-ad39-8e60-634500585630</link>
+      <title>Set your data limit - Microsoft Support</title>
+      <description>Use the Settings app in Window to set your data plan limit and look for ways to
+        reduce data usage.</description>
+      <pubDate>Tue, 26 Sep 2023 20:51:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/zip-and-unzip-files-f6dde0a7-0fec-8294-e1d3-703ed85e7ebc</link>
+      <title>Zip and unzip files - Microsoft Support</title>
+      <description>This article explains how to zip and unzip files.</description>
+      <pubDate>Tue, 26 Sep 2023 17:17:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/troubleshoot-problems-updating-windows-188c2b0f-10a7-d72f-65b8-32d177eb136c</link>
+      <title>Troubleshoot problems updating Windows - Microsoft Support</title>
+      <description>Learn how to troubleshoot problems updating Windows. Find answers to common
+        questions and issues installing Windows updates.</description>
+      <pubDate>Mon, 25 Sep 2023 23:01:02 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5013438-recovery-discs-created-by-using-the-backup-and-restore-windows-7-app-in-control-panel-are-unable-to-start-78e6d004-39df-4446-bcf8-20a45ffe8b70</link>
+      <title>KB5013438: Recovery discs created by using the "Backup and Restore (Windows 7)” app in
+        Control Panel are unable to start - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 25 Sep 2023 22:45:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/getting-the-most-out-of-your-pc-backup-71839239-55bf-40b5-a523-8a8486bd3dea</link>
+      <title>Getting the most out of your PC backup - Microsoft Support</title>
+      <description>Learn why it's important to have a backup, and how Windows Backup can help you
+        keep your files and settings safe.</description>
+      <pubDate>Mon, 25 Sep 2023 22:24:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-9-2022-kb5016616-os-builds-19042-1889-19043-1889-and-19044-1889-67412989-3b5f-4443-89b4-f743382ab970</link>
+      <title>August 9, 2022—KB5016616 (OS Builds 19042.1889, 19043.1889, and 19044.1889) - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Fri, 22 Sep 2023 00:06:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-10-2022-kb5013942-os-builds-19042-1706-19043-1706-and-19044-1706-60b51119-85be-4a34-9e21-8954f6749504</link>
+      <title>May 10, 2022—KB5013942 (OS Builds 19042.1706, 19043.1706, and 19044.1706) - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Fri, 22 Sep 2023 00:01:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-12-2022-kb5012599-os-builds-19042-1645-19043-1645-and-19044-1645-548cc67c-7f12-46fd-878e-589ba81ac2f5</link>
+      <title>April 12, 2022—KB5012599 (OS Builds 19042.1645, 19043.1645, and 19044.1645) - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:58:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-8-2022-kb5011487-os-builds-19042-1586-19043-1586-and-19044-1586-8297eadb-3b8b-4ca5-9083-ca41a91c1c56</link>
+      <title>March 8, 2022—KB5011487 (OS Builds 19042.1586, 19043.1586, and 19044.1586) - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:55:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-10-2021-kb5005033-os-builds-19041-1165-19042-1165-and-19043-1165-b4c77d08-435a-4833-b9f7-e092372079a4</link>
+      <title>August 10, 2021—KB5005033 (OS Builds 19041.1165, 19042.1165, and 19043.1165) -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:50:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-12-2021-kb4598242-os-builds-19041-746-and-19042-746-ab18a1a1-d572-598f-4d86-7137aad34056</link>
+      <title>January 12, 2021—KB4598242 (OS Builds 19041.746 and 19042.746) - Microsoft Support</title>
+      <description>Learn more about update KB4598242, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Thu, 21 Sep 2023 23:45:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-9-2021-kb4601319-os-builds-19041-804-and-19042-804-87fc8417-4a81-0ebb-5baa-40cfab2fbfde</link>
+      <title>February 9, 2021—KB4601319 (OS Builds 19041.804 and 19042.804) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:43:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-9-2021-kb5000802-os-builds-19041-867-and-19042-867-63552d64-fe44-4132-8813-ef56d3626e14</link>
+      <title>March 9, 2021—KB5000802 (OS Builds 19041.867 and 19042.867) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:41:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-13-2021-kb5001330-os-builds-19041-928-and-19042-928-cead30cd-f284-4115-a42f-d67fec538490</link>
+      <title>April 13, 2021—KB5001330 (OS Builds 19041.928 and 19042.928) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:39:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-11-2021-kb5003173-os-builds-19041-985-19042-985-and-19043-985-2824ace2-eabe-4c3c-8a49-06e249f52527</link>
+      <title>May 11, 2021—KB5003173 (OS Builds 19041.985, 19042.985, and 19043.985) - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:34:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-8-2021-kb5003637-os-builds-19041-1052-19042-1052-and-19043-1052-fd782405-7736-478e-b8d0-b08f735f7e54</link>
+      <title>June 8, 2021—KB5003637 (OS Builds 19041.1052, 19042.1052, and 19043.1052)
+        - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:32:53 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-6-2021-kb5004945-os-builds-19041-1083-19042-1083-and-19043-1083-out-of-band-44b34928-0a71-4473-aa22-ecf3b83eed0e</link>
+      <title>July 6, 2021—KB5004945 (OS Builds 19041.1083, 19042.1083, and 19043.1083) Out-of-band -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:30:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-13-2021-kb5004237-os-builds-19041-1110-19042-1110-and-19043-1110-ae798d3c-3de3-4c1f-b9d9-7391b71da889</link>
+      <title>July 13, 2021—KB5004237 (OS Builds 19041.1110, 19042.1110, and 19043.1110) - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:29:27 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-14-2021-kb5005565-os-builds-19041-1237-19042-1237-and-19043-1237-292cf8ed-f97b-4cd8-9883-32b71e3e6b44</link>
+      <title>September 14, 2021—KB5005565 (OS Builds 19041.1237, 19042.1237, and 19043.1237) -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:25:40 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-12-2021-kb5006670-os-builds-19041-1288-19042-1288-and-19043-1288-8902fc49-af79-4b1a-99c4-f74ca886cd95</link>
+      <title>October 12, 2021—KB5006670 (OS Builds 19041.1288, 19042.1288, and 19043.1288) -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:24:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-9-2021-kb5007186-os-builds-19041-1348-19042-1348-and-19043-1348-033ee59c-e9b7-4eaf-8ee7-b3512bb1a0aa</link>
+      <title>November 9, 2021—KB5007186 (OS Builds 19041.1348, 19042.1348, and 19043.1348) -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:20:15 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-14-2021-kb5008212-os-builds-19041-1415-19042-1415-19043-1415-and-19044-1415-b46200db-74c3-450e-b200-51013957312a</link>
+      <title>December 14, 2021—KB5008212 (OS Builds 19041.1415, 19042.1415, 19043.1415, and
+        19044.1415) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:16:28 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-11-2022-kb5009543-os-builds-19042-1466-19043-1466-and-19044-1466-b763552f-73bd-435a-b220-fc3e0bc9765b</link>
+      <title>January 11, 2022—KB5009543 (OS Builds 19042.1466, 19043.1466, and 19044.1466) -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:13:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-8-2022-kb5010342-os-builds-19042-1526-19043-1526-and-19044-1526-bd5c4434-bec4-42e9-991d-5810d4ec52d9</link>
+      <title>February 8, 2022—KB5010342 (OS Builds 19042.1526, 19043.1526, and 19044.1526) -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 23:11:00 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-14-2022-kb5014699-os-builds-19042-1766-19043-1766-and-19044-1766-5c81d49d-0b6e-4808-9485-1f54e5d1bb15</link>
+      <title>June 14, 2022—KB5014699 (OS Builds 19042.1766, 19043.1766, and 19044.1766) - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 22:37:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-20-2022-kb5016139-os-builds-19042-1767-19043-1767-and-19044-1767-out-of-band-f23f8abf-fa86-4e9c-8dad-6aadec51d51c</link>
+      <title>June 20, 2022—KB5016139 (OS Builds 19042.1767, 19043.1767, and 19044.1767) Out-of-band
+        - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 22:34:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-12-2022-kb5015807-os-builds-19042-1826-19043-1826-and-19044-1826-8c8ea8fe-ec83-467d-86fb-a2f48a85eb41</link>
+      <title>July 12, 2022—KB5015807 (OS Builds 19042.1826, 19043.1826, and 19044.1826) - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 22:30:28 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-13-2022-kb5017308-os-builds-19042-2006-19043-2006-and-19044-2006-e4ea187e-28e8-4d4b-808b-2794babdce4c</link>
+      <title>September 13, 2022—KB5017308 (OS Builds 19042.2006, 19043.2006, and 19044.2006) -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 22:27:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-11-2022-kb5018410-os-builds-19042-2130-19043-2130-and-19044-2130-6390f057-28ca-43d3-92ce-f4b79a8378fd</link>
+      <title>October 11, 2022—KB5018410 (OS Builds 19042.2130, 19043.2130, and 19044.2130) -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 22:23:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-8-2022-kb5019959-os-builds-19042-2251-19043-2251-19044-2251-and-19045-2251-f65e0600-2135-4efd-a979-08d1df34dce8</link>
+      <title>November 8, 2022—KB5019959 (OS Builds 19042.2251, 19043.2251, 19044.2251, and
+        19045.2251) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 22:21:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-13-2022-kb5021233-os-builds-19042-2364-19043-2364-19044-2364-and-19045-2364-44e774aa-60c4-4e38-b7e7-c886d210db3b</link>
+      <title>December 13, 2022—KB5021233 (OS Builds 19042.2364, 19043.2364, 19044.2364, and
+        19045.2364) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 22:18:16 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-10-2023-kb5022282-os-builds-19042-2486-19044-2486-and-19045-2486-9587e4e3-c2d7-48a6-86e2-8cd9146b47fd</link>
+      <title>January 10, 2023—KB5022282 (OS Builds 19042.2486, 19044.2486, and 19045.2486) -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 21:43:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-14-2023-kb5022834-os-builds-19042-2604-19044-2604-and-19045-2604-ffb56254-3fee-44f1-9574-b8a0c19bde77</link>
+      <title>February 14, 2023—KB5022834 (OS Builds 19042.2604, 19044.2604, and 19045.2604) -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 21:40:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-14-2023-kb5023696-os-builds-19042-2728-19044-2728-and-19045-2728-9a6dafce-d387-410d-a1bc-9ff5a9cafdc1</link>
+      <title>March 14, 2023—KB5023696 (OS Builds 19042.2728, 19044.2728, and 19045.2728) - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 21:37:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-11-2021-kb5003172-os-build-10240-18932-expired-fae14719-b805-40ad-9b90-19b26a65c0b2</link>
+      <title>May 11, 2021—KB5003172 (OS Build 10240.18932) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 19:35:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-8-2021-kb5003687-os-build-10240-18967-expired-890ab8f9-882b-4aca-9166-a5de6c60e987</link>
+      <title>June 8, 2021—KB5003687 (OS Build 10240.18967) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 19:32:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-13-2021-kb5004249-os-build-10240-19003-expired-bcd2edd4-76bb-4e33-8d30-e231057cb1d1</link>
+      <title>July 13, 2021—KB5004249 (OS Build 10240.19003) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 19:29:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-6-2021-kb5004950-os-build-10240-18969-out-of-band-expired-7f900b36-b3cb-4f5e-8eca-107cc0d91c50</link>
+      <title>July 6, 2021—KB5004950 (OS Build 10240.18969) Out-of-band - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 19:25:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-10-2021-kb5005040-os-build-10240-19022-expired-e8bbfa7a-1012-4e18-a2d7-8ae6a8acf8fb</link>
+      <title>August 10, 2021—KB5005040 (OS Build 10240.19022) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 19:20:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-14-2021-kb5005569-os-build-10240-19060-expired-0de156d8-d616-49bb-ad8d-3cf352611ca4</link>
+      <title>September 14, 2021—KB5005569 (OS Build 10240.19060) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 19:17:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-12-2021-kb5006675-os-build-10240-19086-expired-3940d2b7-139d-4389-be73-1a5ab37a464e</link>
+      <title>October 12, 2021—KB5006675 (OS Build 10240.19086) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 19:14:00 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-9-2021-kb5007207-os-build-10240-19119-expired-a4f38fc0-4824-43b4-a50f-2ac57963b25b</link>
+      <title>November 9, 2021—KB5007207 (OS Build 10240.19119) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 18:47:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-14-2021-kb5008230-os-build-10240-19145-expired-b2a0c6e2-fc24-4242-aab7-4f97f95cbdaa</link>
+      <title>December 14, 2021—KB5008230 (OS Build 10240.19145) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 18:42:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-11-2022-kb5009585-os-build-10240-19177-expired-c56dd31a-42be-4214-b661-10faaa3f24a8</link>
+      <title>January 11, 2022—KB5009585 (OS Build 10240.19177) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 18:38:53 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-8-2022-kb5010358-os-build-10240-19204-expired-7879b7ce-2c01-4a84-9784-28c4f0e34950</link>
+      <title>February 8, 2022—KB5010358 (OS Build 10240.19204) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 18:33:27 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-8-2022-kb5011491-os-build-10240-19235-expired-57d6683f-fdbb-4e7d-a0f0-e28e85fb85f5</link>
+      <title>March 8, 2022—KB5011491 (OS Build 10240.19235) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 18:29:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-12-2022-kb5012653-os-build-10240-19265-expired-935b794b-840b-47b6-b905-3b41f1990de8</link>
+      <title>April 12, 2022—KB5012653 (OS Build 10240.19265) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 18:25:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-10-2022-kb5013963-os-build-10240-19297-expired-5a090ec6-9852-4ca1-b3a6-b2539dfc1eeb</link>
+      <title>May 10, 2022—KB5013963 (OS Build 10240.19297) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 18:22:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-14-2022-kb5014710-os-build-10240-19325-expired-4e04a4e1-f560-4131-b676-0238c28f5e5a</link>
+      <title>June 14, 2022—KB5014710 (OS Build 10240.19325) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 18:19:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-12-2022-kb5015832-os-build-10240-19360-expired-80ed3963-176e-425e-b81c-fd44d5b007d4</link>
+      <title>July 12, 2022—KB5015832 (OS Build 10240.19360) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 18:15:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-9-2022-kb5016639-os-build-10240-19387-expired-e91da780-e973-4388-97af-04f456f20a68</link>
+      <title>August 9, 2022—KB5016639 (OS Build 10240.19387) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 16:25:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/cellular-settings-in-windows-905568ff-7f31-3013-efc7-3f396ac92cd7</link>
+      <title>Cellular settings in Windows - Microsoft Support</title>
+      <description>Learn how to find cellular settings on your Windows PC and change them if you
+        need to.</description>
+      <pubDate>Thu, 21 Sep 2023 15:29:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-8-2021-kb5003635-os-build-18363-1621-2cc248e5-ca5f-4f51-bce4-004d6863e4cd</link>
+      <title>June 8, 2021—KB5003635 (OS Build 18363.1621) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 15:01:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-10-2022-kb5013945-os-build-18363-2274-2b351461-a751-42a1-940a-6057d504137e</link>
+      <title>May 10, 2022—KB5013945 (OS Build 18363.2274) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 01:26:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-12-2022-kb5012591-os-build-18363-2212-bdef80dc-6550-4e63-8f10-a34787d898e7</link>
+      <title>April 12, 2022—KB5012591 (OS Build 18363.2212) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 01:21:02 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-11-2021-kb5001028-os-build-18363-1379-out-of-band-42c34ace-7ae8-4b66-bdf9-94a5a5589659</link>
+      <title>February 11, 2021—KB5001028 (OS Build 18363.1379) Out-of-band
+        - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 01:15:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-9-2021-kb5000808-os-build-18363-1440-6989940a-252d-48f3-a2a7-a42bf19fa2c8</link>
+      <title>March 9, 2021—KB5000808 (OS Build 18363.1440) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 01:10:28 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-6-2021-kb5004946-os-build-18363-1646-out-of-band-18c5ffac-6015-4b3a-ba53-a73c3d3ed505</link>
+      <title>July 6, 2021—KB5004946 (OS Build 18363.1646) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 00:59:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-13-2021-kb5004245-os-build-18363-1679-fe157ce5-49c1-4146-b948-c5aef1f0293b</link>
+      <title>July 13, 2021—KB5004245 (OS Build 18363.1679) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 00:54:57 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-10-2021-kb5005031-os-build-18363-1734-8af726da-a39b-417d-a5fb-670c42d69e78</link>
+      <title>August 10, 2021—KB5005031 (OS Build 18363.1734) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 00:50:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-14-2021-kb5005566-os-build-18363-1801-c2535eb5-9e8a-4127-a923-0c6a643bba1d</link>
+      <title>September 14, 2021—KB5005566 (OS Build 18363.1801) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 00:46:09 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-12-2021-kb5006667-os-build-18363-1854-65fdfe31-3790-4e10-ae8d-829754fe5d8f</link>
+      <title>October 12, 2021—KB5006667 (OS Build 18363.1854) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 00:41:27 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-9-2021-kb5007189-os-build-18363-1916-91b4647c-9979-4d84-8e64-efc8674e8c1f</link>
+      <title>November 9, 2021—KB5007189 (OS Build 18363.1916) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Sep 2023 00:36:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-14-2021-kb5008206-os-build-18363-1977-e54dfc3e-7d16-4d88-a4a3-59efbf0633f1</link>
+      <title>December 14, 2021—KB5008206 (OS Build 18363.1977) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 23:58:25 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-11-2022-kb5009545-os-build-18363-2037-585a5a21-b1a9-43e8-b720-90719d35615e</link>
+      <title>January 11, 2022—KB5009545 (OS Build 18363.2037) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 23:52:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-8-2022-kb5010345-os-build-18363-2094-38410b86-990b-4afa-a4bb-adbc35ed14dd</link>
+      <title>February 8, 2022—KB5010345 (OS Build 18363.2094) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 23:46:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-8-2022-kb5011485-os-build-18363-2158-ae8accde-7a32-4ca2-a888-54bb7e57fdde</link>
+      <title>March 8, 2022—KB5011485 (OS Build 18363.2158) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 23:33:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-9-2021-kb5000803-os-build-14393-4283-expired-711d10dd-adcb-490b-a640-aaa25009cfed</link>
+      <title>March 9, 2021—KB5000803 (OS Build 14393.4283) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 14:23:53 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-13-2021-kb5001347-os-build-14393-4350-expired-ee0e6301-3428-4a14-8e67-d69c5b31c66a</link>
+      <title>April 13, 2021—KB5001347 (OS Build 14393.4350) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 14:17:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-11-2021-kb5003197-os-build-14393-4402-expired-672e4557-b496-4ec7-bf26-3268aaf16697</link>
+      <title>May 11, 2021—KB5003197 (OS Build 14393.4402) - EXPIRED
+        - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 14:10:20 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-13-2021-kb5004238-os-build-14393-4530-expired-69c72ccc-299a-412a-b219-b78c2fd37021</link>
+      <title>July 13, 2021—KB5004238 (OS Build 14393.4530) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 13:55:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-7-2021-kb5004948-os-build-14393-4470-out-of-band-expired-fb676642-a3fe-4304-a79c-9d651d2f6550</link>
+      <title>July 7, 2021—KB5004948 (OS Build 14393.4470) Out-of-band - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 13:46:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-10-2021-kb5005043-os-build-14393-4583-expired-709d481e-b02a-4eb9-80d9-75c4b8170240</link>
+      <title>August 10, 2021—KB5005043 (OS Build 14393.4583) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 13:38:53 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-14-2021-kb5005573-os-build-14393-4651-expired-48853795-3857-4485-a2bf-f15b39464b41</link>
+      <title>September 14, 2021—KB5005573 (OS Build 14393.4651) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 13:31:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-12-2021-kb5006669-os-build-14393-4704-expired-bcc95546-0768-49ae-bec9-240cc59df384</link>
+      <title>October 12, 2021—KB5006669 (OS Build 14393.4704) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 13:25:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-9-2021-kb5007192-os-build-14393-4770-expired-f534a33a-ed00-4bd2-8248-9424c53e9bde</link>
+      <title>November 9, 2021—KB5007192 (OS Build 14393.4770) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 13:18:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-14-2021-kb5008207-os-build-14393-4825-expired-35421e45-96b3-4585-9faa-02576d813e7a</link>
+      <title>December 14, 2021—KB5008207 (OS Build 14393.4825) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 13:10:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-11-2022-kb5009546-os-build-14393-4886-expired-0c2cac57-13b6-42e6-b318-41ca32428f91</link>
+      <title>January 11, 2022—KB5009546 (OS Build 14393.4886) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 13:02:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-8-2022-kb5010359-os-build-14393-4946-expired-e47d743b-9026-4390-bca6-5ad4ddb40ca8</link>
+      <title>February 8, 2022—KB5010359 (OS Build 14393.4946) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 12:52:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-8-2022-kb5011495-os-build-14393-5006-expired-fd1dddb5-7ec0-4d1c-9f19-2986cadc8eb9</link>
+      <title>March 8, 2022—KB5011495 (OS Build 14393.5006) - EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Sep 2023 12:23:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/delete-cookies-in-microsoft-edge-63947406-40ac-c3b8-57b9-2a946a29ae09</link>
+      <title>Delete cookies in Microsoft Edge - Microsoft Support</title>
+      <description>Learn how to delete cookies in Microsoft Edge. Clear all cookies, cookies from a
+        specific site, or every time you close the browser.</description>
+      <pubDate>Fri, 15 Sep 2023 16:16:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/resolving-blue-screen-errors-in-windows-60b01860-58f2-be66-7516-5c45a66ae3c6</link>
+      <title>Resolving Blue Screen errors in Windows - Microsoft Support</title>
+      <description>Resolve Windows blue screen errors with tips and resources to do your own
+        troubleshooting, or contact the Microsoft support if you need more help.</description>
+      <pubDate>Fri, 15 Sep 2023 13:50:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-keyboard-shortcuts-for-accessibility-021bcb62-45c8-e4ef-1e4f-41b8c1fc87fd</link>
+      <title>Windows keyboard shortcuts for accessibility - Microsoft Support</title>
+      <description>Learn more about keyboard shortcuts for accessibility in Windows, including
+        shortcuts for Narrator, Magnifier, and more.</description>
+      <pubDate>Wed, 13 Sep 2023 17:33:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/keyboard-shortcuts-in-apps-139014e7-177b-d1f3-eb2e-7298b2599a34</link>
+      <title>Keyboard shortcuts in apps - Microsoft Support</title>
+      <description>A list of keyboard shortcuts in apps like Microsoft Edge, Maps, Photos, Groove,
+        Calculator, Paint, Game bar, Movies &amp; TV, and Voice Recorder.</description>
+      <pubDate>Wed, 13 Sep 2023 17:20:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-12-2023-kb5030213-os-build-14393-6252-c9d9f24c-3728-4eeb-a017-dd0cd2b106cb</link>
+      <title>September 12, 2023—KB5030213 (OS Build 14393.6252) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 13 Sep 2023 16:37:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-12-2023-kb5030220-os-build-10240-20162-193b8827-810b-4903-be0e-dfedb300971a</link>
+      <title>September 12, 2023—KB5030220 (OS Build 10240.20162) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 12 Sep 2023 17:01:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5030503-servicing-stack-update-for-windows-10-september-12-2023-9d96add7-bbb2-4f47-b2bd-ce8c9b8b7dd1</link>
+      <title>KB5030503: Servicing stack update for Windows 10: September 12, 2023 - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Tue, 12 Sep 2023 17:00:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5030504-servicing-stack-update-for-windows-server-2016-september-12-2023-a5e51acd-6687-41e9-b4a0-5a2d4ab31e40</link>
+      <title>KB5030504: Servicing stack update for Windows Server 2016: September 12, 2023 -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 12 Sep 2023 17:00:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5029778-how-to-manage-the-vulnerability-associated-with-cve-2022-40982-d461157c-0411-4a91-9fc5-9b29e0fe2782</link>
+      <title>KB5029778: How to manage the vulnerability associated with CVE-2022-40982 - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Tue, 12 Sep 2023 17:00:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/installing-the-windows-365-app-cbb0d4d5-69d4-4f00-b050-6dc7a02d02d0</link>
+      <title>Installing the Windows 365 app - Microsoft Support</title>
+      <description>An introduction to installing the Windows 365 app and the hardware requirements
+        to run the software.</description>
+      <pubDate>Tue, 22 Aug 2023 18:37:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5028407-how-to-manage-the-vulnerability-associated-with-cve-2023-32019-bd6ed35f-48b1-41f6-bd19-d2d97270f080</link>
+      <title>KB5028407: How to manage the vulnerability associated with CVE-2023-32019 - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Sat, 19 Aug 2023 20:33:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/windows-10-and-windows-server-2019-update-history-725fc2e1-4443-6831-a5ca-51ff5cbcb059</link>
+      <title>Windows 10 and Windows Server 2019 update history - Microsoft Support</title>
+      <description>Learn more about updates for Windows 10 version 1809, including improvement and
+        fixes, any known issues, and how to get the update.</description>
+      <pubDate>Wed, 16 Aug 2023 23:04:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/manage-devices-used-with-your-microsoft-account-d4044995-81db-b24b-757e-1102d148f441</link>
+      <title>Manage devices used with your Microsoft account - Microsoft Support</title>
+      <description>Learn how to manage your Microsoft devices. Add, remove, register, or rename a
+        device on your Microsoft account.</description>
+      <pubDate>Wed, 16 Aug 2023 18:57:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/cortana-can-t-hear-me-4320735b-c9b0-d2e6-4759-900ad63f3c18</link>
+      <title>Cortana can't hear me - Microsoft Support</title>
+      <description>How to troubleshoot when Cortana does not respond to voice commands or cannot
+        hear me</description>
+      <pubDate>Tue, 15 Aug 2023 19:29:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/what-is-cortana-953e648d-5668-e017-1341-7f26f7d0f825</link>
+      <title>What is Cortana? - Microsoft Support</title>
+      <description>Learn about Cortana, the personal assistant for Windows 10, and get started with
+        some basic tasks.</description>
+      <pubDate>Tue, 15 Aug 2023 19:19:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-24-2022-kb5014022-os-build-17763-2989-preview-08f88943-2fc8-4fdb-a13b-ba89af313d06</link>
+      <title>May 24, 2022—KB5014022 (OS Build 17763.2989) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 11 Aug 2023 18:29:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-11-2023-kb5028169-os-build-14393-6085-fa5b6c30-1ac8-4b99-b58b-9c434d8a8b98</link>
+      <title>July 11, 2023—KB5028169 (OS Build 14393.6085) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 11 Aug 2023 18:26:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-8-2023-kb5029242-os-build-14393-6167-1faba2e0-792e-4fd1-91df-212a11ad0eda</link>
+      <title>August 8, 2023—KB5029242 (OS Build 14393.6167) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 08 Aug 2023 17:08:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-8-2023-kb5029259-os-build-10240-20107-8f0e808c-5c70-4fba-9e57-120932446f38</link>
+      <title>August 8, 2023—KB5029259 (OS Build 10240.20107) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 08 Aug 2023 17:02:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/map-a-network-drive-in-windows-29ce55d1-34e3-a7e2-4801-131475f9557d</link>
+      <title>Map a network drive in Windows - Microsoft Support</title>
+      <description>Map a network drive to get to it from File Explorer in Windows without having to
+        look for it or type its network address each time.</description>
+      <pubDate>Fri, 04 Aug 2023 21:21:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/a-driver-can-t-load-on-this-device-8eea34e5-ff4b-16ec-870d-61a4a43b3dd5</link>
+      <title>A driver can't load on this device - Microsoft Support</title>
+      <description>Find out the steps you can take if you receive a message telling you a driver
+        can't load on your device.</description>
+      <pubDate>Thu, 03 Aug 2023 00:09:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5009763-efs-security-hardening-changes-in-cve-2021-43217-719fbc9d-ad9b-4f90-a964-0afe40338002</link>
+      <title>KB5009763: EFS security hardening changes in CVE-2021-43217 - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 28 Jul 2023 19:29:11 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb4074629-understanding-speculationcontrol-powershell-script-output-fd70a80a-a63f-e539-cda5-5be4c9e67c04</link>
+      <title>KB4074629: Understanding SpeculationControl PowerShell script output - Microsoft
+        Support</title>
+      <description>Explains output of the Microsoft Get-SpeculationControlSettings PowerShell
+        script.</description>
+      <pubDate>Mon, 17 Jul 2023 20:54:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb4034879-use-the-ldapenforcechannelbinding-registry-entry-to-make-ldap-authentication-over-ssl-tls-more-secure-e9ecfa27-5e57-8519-6ba3-d2c06b21812e</link>
+      <title>KB4034879: Use the LdapEnforceChannelBinding registry entry to make LDAP authentication
+        over SSL/TLS more secure - Microsoft Support</title>
+      <description>Describes the LdapEnforceChannelBinding registry setting that is used to enable
+        the fix decribed in CVE-2017-8563</description>
+      <pubDate>Wed, 12 Jul 2023 18:46:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5029033-notice-of-additions-to-the-windows-driver-stl-revocation-list-d330efa5-3fb7-4903-9f0b-3230d31fca38</link>
+      <title>KB5029033: Notice of additions to the Windows Driver.STL revocation list - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Tue, 11 Jul 2023 17:16:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5028311-setup-dynamic-update-for-windows-10-version-20h2-21h2-and-22h2-july-11-2023-dde0058c-cbb3-4dff-aff7-eb467afbc809</link>
+      <title>KB5028311: Setup Dynamic Update for Windows 10, version 20H2, 21H2, and 22H2: July 11,
+        2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 11 Jul 2023 17:01:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5029029-compatibility-update-for-installing-and-recovering-windows-10-enterprise-version-1809-and-windows-server-2019-july-11-2023-c45d2306-3203-4b4f-9b0e-f3cdfe900ff5</link>
+      <title>KB5029029: Compatibility update for installing and recovering Windows 10 Enterprise,
+        version 1809 and Windows Server 2019: July 11, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 11 Jul 2023 17:01:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5028310-setup-dynamic-update-for-windows-10-enterprise-version-1809-and-windows-server-2019-july-11-2023-f72435f6-4c39-4ac8-b2fa-05a05d6cce6e</link>
+      <title>KB5028310: Setup Dynamic Update for Windows 10 Enterprise version 1809 and Windows
+        Server 2019: July 11, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 11 Jul 2023 17:01:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-11-2023-kb5028186-os-build-10240-20048-fbe56207-ae74-4229-a066-28ba1bc0f69d</link>
+      <title>July 11, 2023—KB5028186 (OS Build 10240.20048) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 11 Jul 2023 17:01:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/check-or-change-language-settings-d594c982-8151-24b9-e25d-54c986b22f6d</link>
+      <title>Check or change language settings - Microsoft Support</title>
+      <description>Set the region, device language, and spoken language for your products and
+        services.</description>
+      <pubDate>Mon, 03 Jul 2023 23:48:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5028723-users-who-log-on-using-a-local-user-account-receive-a-notice-after-june-27-2023-windows-updates-are-installed-62d3a11a-358f-47f5-9cc2-53d124e23804</link>
+      <title>KB5028723: Users who log on using a local user account receive a notice after June 27,
+        2023 Windows updates are installed - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 28 Jun 2023 21:16:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5026964-users-who-log-on-using-a-local-user-account-receive-a-notice-after-april-11-2023-windows-updates-are-installed-cbaf97b4-471e-4b0c-ba61-a42238810fa0</link>
+      <title>KB5026964: Users who log on using a local user account receive a notice after April 11,
+        2023 Windows updates are installed - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 28 Jun 2023 21:16:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-27-2023-kb5027293-os-build-19045-3155-preview-1c50b938-6a65-4e7e-9fdd-967f391c846f</link>
+      <title>June 27, 2023—KB5027293 (OS Build 19045.3155) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 27 Jun 2023 17:00:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-23-2023-kb5028623-os-build-14393-5996-out-of-band-5fe97283-3caa-4037-a916-ff363073c1e1</link>
+      <title>June 23, 2023—KB5028623 (OS Build 14393.5996) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 23 Jun 2023 21:00:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-23-2023-kb5028622-os-build-10240-19986-out-of-band-de9af49b-9cf4-42f7-acf1-fe995ba75e9f</link>
+      <title>June 23, 2023—KB5028622 (OS Build 10240.19986) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 23 Jun 2023 21:00:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5028763-you-are-asked-to-choose-if-you-want-to-keep-signing-in-with-your-face-or-fingerprint-c9edc1bb-9da8-4caa-b0cb-0ec4d87c2b97</link>
+      <title>KB5028763: You are asked to “Choose if you want to keep signing in with your face or
+        fingerprint” - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 21 Jun 2023 23:54:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/finding-your-bitlocker-recovery-key-in-windows-6b71ad27-0b89-ea08-f143-056f5ab347d6</link>
+      <title>Finding your BitLocker recovery key in Windows - Microsoft Support</title>
+      <description>Learn different ways to locate your BitLocker recovery key in Windows, and learn
+        about how BitLocker might have been activated on your system.</description>
+      <pubDate>Tue, 20 Jun 2023 20:04:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/snap-your-windows-885a9b1e-a983-a3b1-16cd-c531795e6241</link>
+      <title>Snap your windows - Microsoft Support</title>
+      <description>See how to arrange all your open windows using the mouse, keyboard, or the Snap
+        Assist feature in Windows.</description>
+      <pubDate>Tue, 20 Jun 2023 18:28:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/wi-fi-network-not-secure-in-windows-9170b675-921b-3aa5-7e43-fcb2059d159c</link>
+      <title>Wi-Fi network not secure in Windows - Microsoft Support</title>
+      <description>Learn about the message "Wi-Fi isn't secure" that appears in Windows when you're
+        connected to a Wi-Fi network that's not secure.</description>
+      <pubDate>Mon, 19 Jun 2023 18:20:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-your-windows-pc-as-a-mobile-hotspot-c89b0fad-72d5-41e8-f7ea-406ad9036b85</link>
+      <title>Use your Windows PC as a mobile hotspot - Microsoft Support</title>
+      <description>Learn how to use your Windows PC as a mobile hotspot.</description>
+      <pubDate>Mon, 19 Jun 2023 18:20:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/calibrate-your-built-in-display-for-hdr-content-in-windows-de1c66fa-6cc0-b327-e73a-1bac6bd46bc0</link>
+      <title>Calibrate your built-in display for HDR content in Windows - Microsoft Support</title>
+      <description>Learn how to calibrate Windows built-in display settings for HDR video content.</description>
+      <pubDate>Mon, 19 Jun 2023 18:20:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/media-feature-pack-for-windows-10-11-n-february-2023-2aaf89b8-f9d3-4322-98d0-612c9bea9c01</link>
+      <title>Media Feature Pack for Windows 10/11 N (February 2023) - Microsoft Support</title>
+      <description>Learn how to get the update, additional steps, effects on other features, and
+        more.</description>
+      <pubDate>Mon, 19 Jun 2023 18:20:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-15-2022-kb5010415-os-builds-19042-1566-19043-1566-and-19044-1566-preview-5a644b82-83f4-4cc2-a0e7-85f643252386</link>
+      <title>February 15, 2022—KB5010415 (OS Builds 19042.1566, 19043.1566, and 19044.1566) Preview
+        - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 15 Jun 2023 21:28:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/microsoft-net-framework-4-7-2-offline-installer-for-windows-05a72734-2127-a15d-50cf-daf56d5faec2</link>
+      <title>Microsoft .NET Framework 4.7.2 offline installer for Windows - Microsoft Support</title>
+      <description>Description of Microsoft .NET Framework 4.7.2 offline installer for Windows</description>
+      <pubDate>Thu, 15 Jun 2023 20:49:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/move-the-microsoft-edge-sidebar-to-your-windows-10-desktop-5e0d590d-af6e-4872-b3db-245b9a8cca53</link>
+      <title>Move the Microsoft Edge sidebar to your Windows 10 desktop - Microsoft Support</title>
+      <description>Learn how to move your Microsoft Edge sidebar to your Windows 10 desktop to
+        access apps and sites from anywhere on your device.</description>
+      <pubDate>Tue, 13 Jun 2023 20:57:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-use-the-taskbar-in-windows-0657a50f-0cc7-dbfd-ae6b-05020b195b07</link>
+      <title>How to use the taskbar in Windows - Microsoft Support</title>
+      <description>Learn how to use the taskbar features in Windows. Hide the taskbar, pin an app,
+        change the location, and more with taskbar settings.</description>
+      <pubDate>Tue, 13 Jun 2023 17:24:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/search-for-anything-anywhere-b14cc5bf-c92a-1e73-ea18-2845891e6cc8</link>
+      <title>Search for anything, anywhere - Microsoft Support</title>
+      <description>Search Windows and the web on the taskbar, and search for answers, apps, files,
+        and settings from the web and your PC.</description>
+      <pubDate>Tue, 13 Jun 2023 17:23:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5027385-compatibility-update-for-installing-and-recovering-windows-10-version-1507-june-13-2023-65c4241b-008c-4d63-8c14-5fec02ecd993</link>
+      <title>KB5027385: Compatibility update for installing and recovering Windows 10, version 1507:
+        June 13, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 13 Jun 2023 17:03:25 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-13-2023-kb5027222-os-build-17763-4499-8aa0687f-06aa-4789-ab4e-6bff4897a33e</link>
+      <title>June 13, 2023—KB5027222 (OS Build 17763.4499) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 13 Jun 2023 17:03:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-13-2023-kb5027215-os-builds-19044-3086-and-19045-3086-079f9f02-fe49-4b25-99a6-c02a16b1f208</link>
+      <title>June 13, 2023—KB5027215 (OS Builds 19044.3086 and 19045.3086) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 13 Jun 2023 17:03:09 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-13-2023-kb5027219-os-build-14393-5989-e99f2865-6f1a-41e4-9583-c0d00be7468d</link>
+      <title>June 13, 2023—KB5027219 (OS Build 14393.5989) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 13 Jun 2023 17:03:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-13-2023-kb5027230-os-build-10240-19983-4f2fffba-9ded-4325-932b-82edec3727a5</link>
+      <title>June 13, 2023—KB5027230 (OS Build 10240.19983) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 13 Jun 2023 17:02:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5027389-compatibility-update-for-installing-and-recovering-windows-10-version-20h2-21h2-and-22h2-june-13-2023-72541ebd-5342-40af-a9f5-56db8d647a58</link>
+      <title>KB5027389: Compatibility update for installing and recovering Windows 10, version 20H2,
+        21H2, and 22H2: June 13, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 13 Jun 2023 17:02:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-started-with-eye-control-in-windows-1a170a20-1083-2452-8f42-17a7d4fe89a9</link>
+      <title>Get started with eye control in Windows - Microsoft Support</title>
+      <description>Learn how to use eye control in Windows to type with an on-screen keyboard,
+        communicate with people, and control the mouse with your eyes.</description>
+      <pubDate>Mon, 12 Jun 2023 10:02:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-sound-or-audio-problems-in-windows-73025246-b61c-40fb-671a-2535c7cd56c8</link>
+      <title>Fix sound or audio problems in Windows - Microsoft Support</title>
+      <description>Find out how to fix sound or audio problems in Windows.</description>
+      <pubDate>Wed, 07 Jun 2023 15:03:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/move-your-files-to-a-new-windows-pc-using-an-external-storage-device-dd139b2e-bc73-4431-8e6e-c96e10dffdf5</link>
+      <title>Move your files to a new Windows PC using an external storage device - Microsoft
+        Support</title>
+      <description>Learn how to move files to a new Windows PC using an external storage device like
+        a USB drive, SD, card, or external hard drive.</description>
+      <pubDate>Mon, 05 Jun 2023 17:29:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-printer-connection-and-printing-problems-in-windows-fb830bff-7702-6349-33cd-9443fe987f73</link>
+      <title>Fix printer connection and printing problems in Windows - Microsoft Support</title>
+      <description>Learn ways to fix common printing problems in Windows 10.</description>
+      <pubDate>Wed, 31 May 2023 16:46:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/add-your-windows-pc-to-your-mobile-account-to-get-online-31a6ab0f-f751-369c-5b48-a5a4df0edf8c</link>
+      <title>Add your Windows PC to your mobile account to get online - Microsoft Support</title>
+      <description>Use the eSIM in your Windows PC and the Mobile Plans app to add your device to
+        your current mobile account.</description>
+      <pubDate>Thu, 25 May 2023 22:56:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-23-2023-kb5026435-os-build-19045-3031-preview-2751b693-5544-4110-bc0c-feb8dd7336b3</link>
+      <title>May 23, 2023—KB5026435 (OS Build 19045.3031) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 24 May 2023 23:11:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-9-2023-kb5026361-os-builds-19042-2965-19044-2965-and-19045-2965-3edafffe-c3cc-4010-af43-2097c84c9437</link>
+      <title>May 9, 2023—KB5026361 (OS Builds 19042.2965, 19044.2965, and 19045.2965) - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Wed, 24 May 2023 23:09:49 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-25-2023-kb5025297-os-build-19045-2913-preview-a5e3f0ce-b9f1-40b9-a3fa-42b8093f3873</link>
+      <title>April 25, 2023—KB5025297 (OS Build 19045.2913) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 24 May 2023 23:07:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-11-2023-kb5025221-os-builds-19042-2846-19044-2846-and-19045-2846-b00c3356-baac-4a41-8342-7f97ec83445a</link>
+      <title>April 11, 2023—KB5025221 (OS Builds 19042.2846, 19044.2846, and 19045.2846) - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Wed, 24 May 2023 23:06:09 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-21-2023-kb5023773-os-builds-19042-2788-19044-2788-and-19045-2788-preview-5850ac11-dd43-4550-89ec-9e63353fef23</link>
+      <title>March 21, 2023—KB5023773 (OS Builds 19042.2788, 19044.2788, and 19045.2788) Preview -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 24 May 2023 23:04:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-to-know-the-touch-keyboard-004f3d67-855b-27f0-6f7c-d5145f691181</link>
+      <title>Get to know the touch keyboard - Microsoft Support</title>
+      <description>Discover how to open the touch keyboard and learn about the different layouts.</description>
+      <pubDate>Tue, 23 May 2023 15:00:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/prevent-the-touch-keyboard-from-appearing-e2b05375-908d-45ec-b7f7-729349a10c7a</link>
+      <title>Prevent the touch keyboard from appearing - Microsoft Support</title>
+      <description>Methods by which you can stop the touch keyboard from appearing if it is in your
+        way.</description>
+      <pubDate>Tue, 23 May 2023 15:00:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/connect-to-a-vpn-in-windows-3d29aeb1-f497-f6b7-7633-115722c1009c</link>
+      <title>Connect to a VPN in Windows - Microsoft Support</title>
+      <description>Learn how to create a VPN connection profile in Windows, and then use it to
+        connect to a VPN.</description>
+      <pubDate>Tue, 23 May 2023 15:00:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/wi-fi-connection-icons-and-what-they-mean-in-windows-35f58c75-bd23-4b8b-dd1a-009fe53f86b3</link>
+      <title>Wi-Fi connection icons and what they mean in Windows - Microsoft Support</title>
+      <description>Find out what the different Wi-Fi icons in Windows tell you about your connection
+        state, and how they can help you troubleshoot and fix Wi-Fi.</description>
+      <pubDate>Tue, 23 May 2023 14:59:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-10-support-on-intel-clover-trail-chipsets-ended-on-january-10-2023-f56584eb-84f4-4ded-aa4c-59a8168fe4bb</link>
+      <title>Windows 10 support on Intel Clover Trail chipsets ended on January 10, 2023 - Microsoft
+        Support</title>
+      <description>Support for Windows 10 on Intel Atom Clover Trail chipsets ended on January 10,
+        2023. Learn what it means for you and how to move to a supported version of Windows.</description>
+      <pubDate>Tue, 23 May 2023 01:44:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/disk-cleanup-for-windows-10-cumulative-updates-0f7110e0-b350-8b74-a84b-0ce523e77e28</link>
+      <title>Disk cleanup for Windows 10 cumulative updates - Microsoft Support</title>
+      <description>Provides a disk cleanup tool for Windows 10 cumulative updates.</description>
+      <pubDate>Mon, 22 May 2023 23:39:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-started-with-tips-in-windows-ec3633e4-e2b6-87ce-156c-c3c2ed76c499</link>
+      <title>Get started with Tips in Windows - Microsoft Support</title>
+      <description>Use Tips to discover surprising and little-known tricks in Windows.</description>
+      <pubDate>Thu, 18 May 2023 23:25:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-help-with-xbox-on-windows-10-860102b7-1e8c-bce8-0672-bfdceaf87492</link>
+      <title>Get help with Xbox on Windows 10 - Microsoft Support</title>
+      <description>To get answers from Bing, type your question in the search box on the taskbar.</description>
+      <pubDate>Thu, 18 May 2023 23:21:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/internal-sata-drives-show-up-as-removeable-media-1f806a64-8661-95a6-adc7-ce65a976c8dd</link>
+      <title>Internal SATA Drives show up as removeable media - Microsoft Support</title>
+      <description>How to update your BIOS to recognize SATA drives as internal.</description>
+      <pubDate>Wed, 17 May 2023 18:50:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/give-your-pc-a-fresh-start-0ef73740-b927-549b-b7c9-e6f2b48d275e</link>
+      <title>Give your PC a Fresh Start - Microsoft Support</title>
+      <description>Fresh Start in Windows 10 lets you perform a clean reinstallation and update of
+        Windows while keeping your personal data and most Windows settings intact.</description>
+      <pubDate>Mon, 15 May 2023 20:21:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-9-2023-kb5026362-os-build-17763-4377-b0133287-05dd-4bc5-b1c3-5edaca650afd</link>
+      <title>May 9, 2023—KB5026362 (OS Build 17763.4377) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 May 2023 17:03:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-9-2023-kb5026382-os-build-10240-19926-39a0709f-6bf3-47ee-98f7-8189369ce9d9</link>
+      <title>May 9, 2023—KB5026382 (OS Build 10240.19926) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 May 2023 17:03:49 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-9-2023-kb5026363-os-build-14393-5921-e5c7bc74-7bac-4d82-bce3-676f30f7a701</link>
+      <title>May 9, 2023—KB5026363 (OS Build 14393.5921) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 May 2023 17:03:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/error-0x74-bad-system-config-info-c0918f16-c812-2916-00d9-4387a3839f7c</link>
+      <title>Error 0x74: Bad_system_config_info - Microsoft Support</title>
+      <description>Error 0x74: Bad_system_config_info</description>
+      <pubDate>Tue, 02 May 2023 22:17:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/my-computer-is-now-this-pc-ddb34f0e-85f2-1cdd-6327-02879f2360f5</link>
+      <title>My Computer is now This PC - Microsoft Support</title>
+      <description>My Computer is now This PC</description>
+      <pubDate>Mon, 01 May 2023 20:44:27 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-eye-tracking-and-privacy-62623324-36cf-04a3-6992-8f329081f20b</link>
+      <title>Windows eye tracking and privacy - Microsoft Support</title>
+      <description>Learn how eye tracking technology works in Windows, and find out how to use the
+        eye tracker to unlock new experiences on your device.</description>
+      <pubDate>Fri, 21 Apr 2023 21:00:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5019179-security-vulnerabilities-exist-in-memory-mapped-i-o-for-some-intel-processors-for-windows-10-version-1507-ceb55285-eaed-4e2d-854c-1e6c968ca726</link>
+      <title>KB5019179: Security vulnerabilities exist in Memory Mapped I/O for some Intel
+        processors for Windows 10, version 1507 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 18 Apr 2023 22:17:49 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/moving-to-a-windows-10-pc-294fb3cb-7f2d-fd5a-5683-76aa499c8459</link>
+      <title>Moving to a Windows 10 PC - Microsoft Support</title>
+      <description>Learn about the best features of Windows 10 and get information on how to
+        transfer photos, music, and files to a new Windows 10 PC.</description>
+      <pubDate>Tue, 18 Apr 2023 02:55:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/computer-that-has-vpn-software-installed-can-t-detect-wireless-network-after-upgrading-to-windows-10-90730779-f7f7-009f-c32d-f64b98463448</link>
+      <title>Computer that has VPN software installed can't detect wireless network after upgrading
+        to Windows 10 - Microsoft Support</title>
+      <description>Describes an issue in which old VPN software causes your device to lose wireless
+        connections after an upgrade to Windows 10.</description>
+      <pubDate>Wed, 12 Apr 2023 09:43:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5012170-security-update-for-secure-boot-dbx-72ff5eed-25b4-47c7-be28-c42bd211bb15</link>
+      <title>KB5012170: Security update for Secure Boot DBX - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 11 Apr 2023 17:17:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-11-2023-kb5025229-os-build-17763-4252-e8ead788-2cd3-4c9b-8c77-d677e2d8744f</link>
+      <title>April 11, 2023—KB5025229 (OS Build 17763.4252) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 11 Apr 2023 17:03:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5026037-out-of-box-experience-update-for-windows-10-version-20h2-21h2-and-22h2-april-11-2023-772bd8eb-50d9-465d-8bc3-6e0e116c55f6</link>
+      <title>KB5026037: Out of Box Experience update for Windows 10, version 20H2, 21H2, and 22H2:
+        April 11, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 11 Apr 2023 17:03:18 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-11-2023-kb5025234-os-build-10240-19869-c3f83fbd-6194-4e6b-9276-1b0033d0c4d4</link>
+      <title>April 11, 2023—KB5025234 (OS Build 10240.19869) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 11 Apr 2023 17:02:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-11-2023-kb5025228-os-build-14393-5850-23f04722-1b4f-4786-8c06-67e73de414d5</link>
+      <title>April 11, 2023—KB5025228 (OS Build 14393.5850) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 11 Apr 2023 17:02:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/move-internet-explorer-favorites-to-a-new-pc-a03f02c7-e0b9-5d8b-1857-51dd70954e47</link>
+      <title>Move Internet Explorer favorites to a new PC - Microsoft Support</title>
+      <description>Find out how to move Internet Explorer favorites on a Windows 7 PC to Microsoft
+        Edge on a Windows 10 PC.</description>
+      <pubDate>Mon, 10 Apr 2023 18:38:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/free-up-drive-space-in-windows-a18fae02-a0fa-8df9-9838-8970f9939de4</link>
+      <title>Free up drive space in Windows - Microsoft Support</title>
+      <description>Find out how to free up space on your device by deleting unnecessary files,
+        uninstalling apps, and moving files to other drives.</description>
+      <pubDate>Thu, 06 Apr 2023 10:03:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/free-up-drive-space-in-windows-85529ccb-c365-490d-b548-831022bc9b32</link>
+      <title>Free up drive space in Windows - Microsoft Support</title>
+      <description>Learn how you can free up drive space in Windows. Keep your PC running smoothly
+        and up to date by increasing the disk space.</description>
+      <pubDate>Thu, 06 Apr 2023 10:03:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/media-feature-pack-for-windows-n-8622b390-4ce6-43c9-9b42-549e5328e407</link>
+      <title>Media Feature Pack for Windows N - Microsoft Support</title>
+      <description>Learn how to install the Media Feature Pack on Windows 10/11 N.</description>
+      <pubDate>Wed, 29 Mar 2023 08:11:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/what-s-new-in-windows-security-08fdadd0-2649-375d-38d2-8df149746e21</link>
+      <title>What's new in Windows Security - Microsoft Support</title>
+      <description>Learn about the latest features in Windows Security.</description>
+      <pubDate>Fri, 24 Mar 2023 18:18:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/camera-doesn-t-work-in-windows-32adb016-b29c-a928-0073-53d31da0dad5</link>
+      <title>Camera doesn't work in Windows - Microsoft Support</title>
+      <description>Learn how to troubleshoot when the camera is not working in Windows or you see
+        errors 0xA00F4244 or 0x200F4244.</description>
+      <pubDate>Thu, 23 Mar 2023 16:24:30 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5023847-setup-dynamic-update-for-windows-10-version-20h2-21h2-and-22h2-march-21-2023-fb9e3ffa-09b9-43c9-946a-701f11e15df8</link>
+      <title>KB5023847: Setup Dynamic Update for Windows 10, version 20H2, 21H2, and 22H2: March 21,
+        2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 21 Mar 2023 21:01:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5025801-out-of-box-experience-update-for-windows-10-version-20h2-21h2-and-22h2-march-21-2023-4a049584-4c34-4d3d-b771-fb32e77d5baa</link>
+      <title>KB5025801: Out of Box Experience update for Windows 10, version 20H2, 21H2, and 22H2:
+        March 21, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 21 Mar 2023 21:00:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5004442-manage-changes-for-windows-dcom-server-security-feature-bypass-cve-2021-26414-f1400b52-c141-43d2-941e-37ed901c769c</link>
+      <title>KB5004442—Manage changes for Windows DCOM Server Security Feature Bypass
+        (CVE-2021-26414) - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 20 Mar 2023 18:05:15 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-voyager-braille-display-with-narrator-7d555190-c395-075f-5867-8dfb12963991</link>
+      <title>Use a Voyager braille display with Narrator - Microsoft Support</title>
+      <description>Voyager braille displays work with Narrator, a free screen reader that’s built in
+        to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 08:52:18 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-seika-braille-display-with-narrator-1e9461c1-02ef-0493-190f-4c8a4100f129</link>
+      <title>Use a Seika braille display with Narrator - Microsoft Support</title>
+      <description>Seika braille displays work with Narrator, a free screen reader that’s built in
+        to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 08:36:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-papenmeier-braille-display-with-narrator-36431f9c-859e-5b38-173d-032d0d857f6c</link>
+      <title>Use a Papenmeier braille display with Narrator - Microsoft Support</title>
+      <description>Papenmeier braille displays work with Narrator, a free screen reader that’s built
+        in to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 08:36:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-minibraille-braille-display-with-narrator-6f9f3961-6529-283c-5b2f-236f145fda49</link>
+      <title>Use a MiniBraille braille display with Narrator - Microsoft Support</title>
+      <description>MiniBraille braille displays work with Narrator, a free screen reader that’s
+        built in to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 08:28:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-an-mdv-braille-display-with-narrator-bc588e22-ca81-fbe8-839e-6a10c162bcc6</link>
+      <title>Use an MDV braille display with Narrator - Microsoft Support</title>
+      <description>MDV braille displays work with Narrator, a free screen reader that’s built in to
+        Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 08:25:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-an-iris-braille-display-with-narrator-6c8fbbfc-d3e1-378a-d945-3bb0b02515c5</link>
+      <title>Use an Iris braille display with Narrator - Microsoft Support</title>
+      <description>Iris braille displays work with Narrator, a free screen reader that’s built in to
+        Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 08:04:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-humanware-braille-display-with-narrator-8130e6f9-46af-7e77-6b46-912a7622fe13</link>
+      <title>Use a HumanWare braille display with Narrator - Microsoft Support</title>
+      <description>HumanWare braille displays work with Narrator, a free screen reader that’s built
+        in to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 08:04:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-hims-braille-display-with-narrator-e4253c64-58b9-c95b-788e-cc544aad6548</link>
+      <title>Use a HIMS braille display with Narrator - Microsoft Support</title>
+      <description>HIMS braille displays work with Narrator, a free screen reader that’s built in to
+        Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 07:52:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-hedo-braille-display-with-narrator-fe50cb6e-d2b8-7fa4-6231-a5345ac69d68</link>
+      <title>Use a Hedo braille display with Narrator - Microsoft Support</title>
+      <description>Hedo braille displays work with Narrator, a free screen reader that’s built in to
+        Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 07:51:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-combibraille-braille-display-with-narrator-5ccf7097-c2a0-b9a3-e570-42061830065a</link>
+      <title>Use a CombiBraille braille display with Narrator - Microsoft Support</title>
+      <description>CombiBraille braille displays work with Narrator, a free screen reader that’s
+        built in to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 07:35:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-cebra-braille-display-with-narrator-4ca61944-e858-18a0-c7ad-93bc5607f673</link>
+      <title>Use a Cebra braille display with Narrator - Microsoft Support</title>
+      <description>Cebra braille displays work with Narrator, a free screen reader that’s built in
+        to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 07:31:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-braillenote-braille-display-with-narrator-399ce97e-82f7-0c02-49df-3feed0b1db71</link>
+      <title>Use a BrailleNote braille display with Narrator - Microsoft Support</title>
+      <description>BrailleNote braille displays work with Narrator, a free screen reader that’s
+        built in to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 07:19:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-baum-braille-display-with-narrator-74a00869-f880-09bc-e9ec-8e3211ec535a</link>
+      <title>Use a Baum braille display with Narrator - Microsoft Support</title>
+      <description>Baum braille displays work with Narrator, a free screen reader that’s built in to
+        Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 07:08:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-b2g-braille-display-with-narrator-ed124b99-7fb8-7359-269a-1d607d2aeec5</link>
+      <title>Use a B2G braille display with Narrator - Microsoft Support</title>
+      <description>B2G braille displays work with Narrator, a free screen reader that’s built in to
+        Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 07:03:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-an-alva-braille-display-with-narrator-4868541d-d081-ef5e-3302-6a88048c690c</link>
+      <title>Use an Alva braille display with Narrator - Microsoft Support</title>
+      <description>Alva braille displays work with Narrator, a free screen reader that’s built in to
+        Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 06:58:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-an-albatross-braille-display-with-narrator-55300060-526d-5834-77da-e9d6b2968fec</link>
+      <title>Use an Albatross braille display with Narrator - Microsoft Support</title>
+      <description>Albatross braille displays work with Narrator, a free screen reader that’s built
+        in to Windows. Learn how to use device specific keys to interact with your PC.</description>
+      <pubDate>Mon, 20 Mar 2023 06:51:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-braillememo-braille-display-with-narrator-068618a1-5d83-fe10-ae2f-a135fb517be8</link>
+      <title>Use a BrailleMemo braille display with Narrator - Microsoft Support</title>
+      <description>BrailleMemo braille displays work with Narrator, a free screen reader that’s
+        built in to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Fri, 17 Mar 2023 11:43:30 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-braillelite-braille-display-with-narrator-9e08746a-4dbd-134b-bff9-8befdc3bb6de</link>
+      <title>Use a BrailleLite braille display with Narrator - Microsoft Support</title>
+      <description>BrailleLite braille displays work with Narrator, a free screen reader that’s
+        built in to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Fri, 17 Mar 2023 11:42:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-an-innovision-braille-display-with-narrator-d6cd7668-4799-12a6-7e8b-61f35177742c</link>
+      <title>Use an Innovision braille display with Narrator - Microsoft Support</title>
+      <description>Innovision braille displays work with Narrator, a free screen reader that’s built
+        into Windows 10. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Fri, 17 Mar 2023 11:30:00 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-an-ecobraille-braille-display-with-narrator-f0d9e778-7c86-ebdc-e338-80b0b26db886</link>
+      <title>Use an EcoBraille braille display with Narrator - Microsoft Support</title>
+      <description>EcoBraille braille displays work with Narrator. Learn how to use device-specific
+        keys to interact with your PC.</description>
+      <pubDate>Fri, 17 Mar 2023 11:29:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-tsi-braille-display-with-narrator-1230240a-d9a3-52a2-50c9-5768647b07b7</link>
+      <title>Use a TSI braille display with Narrator - Microsoft Support</title>
+      <description>TSI braille displays work with Narrator, a free screen reader that’s built in to
+        Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Fri, 17 Mar 2023 11:13:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-pegasus-braille-display-with-narrator-2082ed3f-2c66-9a6b-140d-8039c215eb11</link>
+      <title>Use a Pegasus braille display with Narrator - Microsoft Support</title>
+      <description>Pegasus braille displays work with Narrator, a free screen reader that’s built in
+        to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Fri, 17 Mar 2023 11:09:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-ninepoint-braille-display-with-narrator-61e6d6f9-1922-8261-5109-467f8cf6ce06</link>
+      <title>Use a NinePoint braille display with Narrator - Microsoft Support</title>
+      <description>NinePoint braille displays work with Narrator, a free screen reader that’s built
+        in to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Fri, 17 Mar 2023 11:06:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-multibraille-braille-display-with-narrator-b96bc5bf-2e92-0292-e374-5c8e66169a7c</link>
+      <title>Use a MultiBraille braille display with Narrator - Microsoft Support</title>
+      <description>MultiBraille braille displays work with Narrator, a free screen reader that’s
+        built in to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Fri, 17 Mar 2023 11:04:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-metec-braille-display-with-narrator-fc131961-ae24-0ddc-ab08-d1046c08a31a</link>
+      <title>Use a Metec braille display with Narrator - Microsoft Support</title>
+      <description>Metec braille displays work with Narrator, a free screen reader that’s built in
+        to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Fri, 17 Mar 2023 11:00:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-handytech-braille-display-with-narrator-ac9d7874-58e7-f6d7-54ba-1496798f4570</link>
+      <title>Use a HandyTech braille display with Narrator - Microsoft Support</title>
+      <description>HandyTech braille displays work with Narrator, a free screen reader that’s built
+        in to Windows. Learn how to use device-specific keys to interact with your PC.</description>
+      <pubDate>Fri, 17 Mar 2023 10:53:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-freedom-scientific-braille-display-with-narrator-9bf2c5e2-d41e-fffd-d983-7e3492e7d7a3</link>
+      <title>Use a Freedom Scientific braille display with Narrator - Microsoft Support</title>
+      <description>Freedom Scientific braille displays work with Narrator. Learn how to use
+        device-specific keys to interact with your PC.</description>
+      <pubDate>Fri, 17 Mar 2023 10:51:49 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-eurobraille-braille-display-with-narrator-602023c9-5be6-2890-cb14-9da9bda70a40</link>
+      <title>Use a EuroBraille braille display with Narrator - Microsoft Support</title>
+      <description>EuroBraille braille displays work with Narrator. Learn how to use device-specific
+        keys to interact with your PC.</description>
+      <pubDate>Fri, 17 Mar 2023 10:50:10 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5025175-updating-the-winre-partition-on-deployed-devices-to-address-security-vulnerabilities-in-cve-2022-41099-ba6621fa-5a9f-48f1-9ca3-e13eb56fb589</link>
+      <title>KB5025175: Updating the WinRE partition on deployed devices to address security
+        vulnerabilities in CVE-2022-41099 - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 16 Mar 2023 21:12:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-21-2023-kb5022906-os-builds-19042-2673-19044-2673-and-19045-2673-preview-bf72fc27-6222-4f6a-991a-f472b3f9d3fd</link>
+      <title>February 21, 2023—KB5022906 (OS Builds 19042.2673, 19044.2673, and 19045.2673) Preview
+        - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 16 Mar 2023 17:25:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-19-2023-kb5019275-os-builds-19042-2546-19044-2546-and-19045-2546-preview-8ae1b678-d38c-4249-848d-06b722e7c0ad</link>
+      <title>January 19, 2023—KB5019275 (OS Builds 19042.2546, 19044.2546, and 19045.2546) Preview -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 16 Mar 2023 17:21:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-14-2023-kb5023702-os-build-17763-4131-f3e27d13-7dcc-4d32-826b-8d57e1600ccf</link>
+      <title>March 14, 2023—KB5023702 (OS Build 17763.4131) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 16 Mar 2023 17:02:53 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-14-2023-kb5022840-os-build-17763-4010-e914539f-d2bc-4af9-bc01-5964c0ab3903</link>
+      <title>February 14, 2023—KB5022840 (OS Build 17763.4010) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 16 Mar 2023 17:00:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-10-2023-kb5022286-os-build-17763-3887-48683103-7b22-4f36-aa98-0049c7a6e579</link>
+      <title>January 10, 2023—KB5022286 (OS Build 17763.3887) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 16 Mar 2023 16:58:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-14-2023-kb5023697-os-build-14393-5786-d8c0d93c-c58b-4398-9fee-59183e52b20c</link>
+      <title>March 14, 2023—KB5023697 (OS Build 14393.5786) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 14 Mar 2023 17:04:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-14-2023-kb5023713-os-build-10240-19805-da29aa6a-dbd7-424c-87d0-87b66fe700e0</link>
+      <title>March 14, 2023—KB5023713 (OS Build 10240.19805) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 14 Mar 2023 17:03:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5023787-servicing-stack-update-for-windows-10-march-14-2023-55efa9a5-1d06-4936-b893-c2b8e5a881d3</link>
+      <title>KB5023787: Servicing stack update for Windows 10: March 14, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 14 Mar 2023 17:02:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/how-to-back-up-and-restore-the-registry-in-windows-855140ad-e318-2a13-2829-d428a2ab0692</link>
+      <title>How to back up and restore the registry in Windows - Microsoft Support</title>
+      <description>Explains how to back up the registry for restoration in case it gets corrupted in
+        Windows 10, Windows 8.1, Windows 8, or Windows 7.</description>
+      <pubDate>Mon, 13 Mar 2023 15:11:15 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/fix-family-features-after-windows-10-11-upgrade-f9bf0438-f32d-b260-52a4-3180009510c7</link>
+      <title>Fix family features after Windows 10/11 upgrade - Microsoft Support</title>
+      <description>Fix family features that may have turned off after upgrading Windows 10.</description>
+      <pubDate>Mon, 13 Mar 2023 11:16:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5019180-security-vulnerabilities-exist-in-memory-mapped-i-o-for-some-intel-processors-for-windows-10-version-20h2-21h2-and-22h2-march-2-2023-f8c174f1-ce5c-469f-9eac-21f8af66b8ea</link>
+      <title>KB5019180: Security vulnerabilities exist in Memory Mapped I/O for some Intel
+        processors for Windows 10, version 20H2, 21H2, and 22H2: March 2, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 02 Mar 2023 22:01:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/make-a-wi-fi-network-public-or-private-in-windows-0460117d-8d3e-a7ac-f003-7a0da607448d</link>
+      <title>Make a Wi-Fi network public or private in Windows - Microsoft Support</title>
+      <description>Learn how to set a Wi-Fi network profile as public or private in Windows.</description>
+      <pubDate>Tue, 28 Feb 2023 18:19:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/media-feature-pack-list-for-windows-n-editions-c1c6fffa-d052-8338-7a79-a4bb980a700a</link>
+      <title>Media Feature Pack list for Windows N editions - Microsoft Support</title>
+      <description>Lists the Media Feature Pack releases for Windows N editions.</description>
+      <pubDate>Tue, 28 Feb 2023 14:03:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-the-on-screen-keyboard-osk-to-type-ecbb5e08-5b4e-d8c8-f794-81dbf896267a</link>
+      <title>Use the On-Screen Keyboard (OSK) to type - Microsoft Support</title>
+      <description>Learn how to use the On-Screen Keyboard (OSK) instead of a physical keyboard to
+        type and enter text on your PC.</description>
+      <pubDate>Tue, 28 Feb 2023 13:57:25 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-color-contrast-in-windows-fedc744c-90ac-69df-aed5-c8a90125e696</link>
+      <title>Change color contrast in Windows - Microsoft Support</title>
+      <description>Learn how to make objects on the screen easier to see by setting up and using a
+        high-contrast color scheme.</description>
+      <pubDate>Tue, 28 Feb 2023 12:31:41 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-colors-in-windows-d26ef4d6-819a-581c-1581-493cfcc005fe</link>
+      <title>Change colors in Windows - Microsoft Support</title>
+      <description>Find out how to change the color of the Start menu, taskbar, and action center
+        with dark and custom mode personalization settings.</description>
+      <pubDate>Tue, 28 Feb 2023 12:17:49 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/eye-control-troubleshooting-guide-83352d28-688a-e29c-4b5f-e91aee324259</link>
+      <title>Eye control troubleshooting guide - Microsoft Support</title>
+      <description>Common troubleshooting tips for working with the Windows eye control.</description>
+      <pubDate>Tue, 28 Feb 2023 07:19:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/automatic-file-download-notifications-in-windows-dc73c9c9-1b4c-a8b7-8d8b-b471736bb5a0</link>
+      <title>Automatic file download notifications in Windows - Microsoft Support</title>
+      <description>Learn how to manage automatic file downloads from your Windows apps when you use
+        an online storage provider, such as OneDrive Files On-Demand.</description>
+      <pubDate>Mon, 27 Feb 2023 19:08:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/find-your-windows-product-key-aaa2bf69-7b2b-9f13-f581-a806abf0a886</link>
+      <title>Find your Windows product key - Microsoft Support</title>
+      <description>Learn how to find a Windows product key for activation, and when you'll use a
+        digital license instead.</description>
+      <pubDate>Fri, 24 Feb 2023 01:32:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5024351-removal-of-windows-edition-checks-for-applocker-e3a763c9-6a3e-4d9c-8623-0ffe69046470</link>
+      <title>KB5024351—Removal of Windows edition checks for AppLocker - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 22 Feb 2023 23:31:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/cortana-and-privacy-47e5856e-3680-d930-22e1-71ec6cdde231</link>
+      <title>Cortana and privacy - Microsoft Support</title>
+      <description>Find out how Cortana uses your personal data to personalize your experiences and
+        assistance, and how to control which data is collected.</description>
+      <pubDate>Wed, 22 Feb 2023 00:09:15 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-14-2023-kb5022838-os-build-14393-5717-1b9a609e-7ae7-4102-bad5-5994eddf154b</link>
+      <title>February 14, 2023—KB5022838 (OS Build 14393.5717) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 21 Feb 2023 17:27:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/personalize-your-pc-6104282d-29b0-4113-23f1-f1a356e176b1</link>
+      <title>Personalize your PC - Microsoft Support</title>
+      <description>Learn how to personalize your Windows PC with themes, desktop backgrounds
+        (wallpaper), and language packs.</description>
+      <pubDate>Fri, 17 Feb 2023 00:43:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-get-windows-10-5ba924f8-09fa-e1fa-e803-d6bb4c971415</link>
+      <title>How to get Windows 10 - Microsoft Support</title>
+      <description>Learn how to get Windows 10</description>
+      <pubDate>Thu, 16 Feb 2023 20:30:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/upgrade-to-windows-10-faq-cce52341-7943-594e-72ce-e1cf00382445</link>
+      <title>Upgrade to Windows 10: FAQ - Microsoft Support</title>
+      <description>Learn how to upgrade your existing device to Windows 10 or buy a new PC. Get
+        answers to common questions about upgrading to Windows 10.</description>
+      <pubDate>Thu, 16 Feb 2023 20:22:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/learn-about-tracking-prevention-in-microsoft-edge-5ac125e8-9b90-8d59-fa2c-7f2e9a44d869</link>
+      <title>Learn about tracking prevention in Microsoft Edge - Microsoft Support</title>
+      <description>Learn about how tracking prevention works in Microsoft Edge. Adjust your tracking
+        prevention setting to detect and block known trackers.</description>
+      <pubDate>Wed, 15 Feb 2023 00:03:53 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-a-corrupted-user-profile-in-windows-1cf41c18-7ce3-12f9-8e1d-95896661c5c9</link>
+      <title>Fix a corrupted user profile in Windows - Microsoft Support</title>
+      <description>Learn what to do if you get a message telling you that your user profile is
+        corrupted.</description>
+      <pubDate>Tue, 14 Feb 2023 18:11:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/which-version-of-windows-operating-system-am-i-running-628bec99-476a-2c13-5296-9dd081cdd808</link>
+      <title>Which version of Windows operating system am I running? - Microsoft Support</title>
+      <description>Learn how to find which version of Windows operating system your PC is running
+        and device specifications.</description>
+      <pubDate>Tue, 14 Feb 2023 18:11:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/desktop-themes-94880287-6046-1d35-6d2f-35dee759701e</link>
+      <title>Desktop Themes - Microsoft Support</title>
+      <description>Get free Windows themes from Microsoft to personalize background, colors and
+        sounds for your PC.</description>
+      <pubDate>Tue, 14 Feb 2023 18:11:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/homegroup-from-start-to-finish-9f802c8c-900f-60fb-826f-6fe06add8fe9</link>
+      <title>HomeGroup from start to finish - Microsoft Support</title>
+      <description>Learn how to create, join, and use a homegroup, and how to change homegroup
+        settings.</description>
+      <pubDate>Tue, 14 Feb 2023 18:11:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/language-packs-for-windows-a5094319-a92d-18de-5b53-1cfc697cfca8</link>
+      <title>Language packs for Windows - Microsoft Support</title>
+      <description>Learn how to download, install, and configure additional language packs for your
+        version of Windows.</description>
+      <pubDate>Tue, 14 Feb 2023 18:11:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-tcp-ip-settings-bd0a07af-15f5-cd6a-363f-ca2b6f391ace</link>
+      <title>Change TCP/IP settings - Microsoft Support</title>
+      <description>Learn how to change the IP address or DNS settings for Windows PCs on your
+        network.</description>
+      <pubDate>Tue, 14 Feb 2023 18:11:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/which-version-of-internet-explorer-am-i-using-86e0ab5e-c60b-bc44-655d-cb4c69f5a3c2</link>
+      <title>Which version of Internet Explorer am I using? - Microsoft Support</title>
+      <description>Learn how to find out which version of Internet Explorer you're using and how to
+        turn on automatic upgrades.</description>
+      <pubDate>Tue, 14 Feb 2023 18:10:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/internet-explorer-downloads-d49e1f0d-571c-9a7b-d97e-be248806ca70</link>
+      <title>Internet Explorer Downloads - Microsoft Support</title>
+      <description>Get the latest internet browser recommended by Microsoft.</description>
+      <pubDate>Tue, 14 Feb 2023 18:10:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-magnifier-to-make-things-on-the-screen-easier-to-see-414948ba-8b1c-d3bd-8615-0e5e32204198</link>
+      <title>Use Magnifier to make things on the screen easier to see - Microsoft Support</title>
+      <description>Learn how to make items on the screen appear larger by using Magnifier in
+        Windows.</description>
+      <pubDate>Tue, 14 Feb 2023 18:09:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/accessibility-features-in-microsoft-edge-4c696192-338e-9465-b2cd-bd9b698ad19a</link>
+      <title>Accessibility features in Microsoft Edge - Microsoft Support</title>
+      <description>Microsoft Edge comes with built-in accessibility options such as making text
+        larger, having the web read aloud to you, keyboard shortcuts, and more.</description>
+      <pubDate>Tue, 14 Feb 2023 18:09:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-text-or-visual-alternative-to-sounds-a3647644-1e14-27b1-71bd-889d6d4e1bdb</link>
+      <title>Use text or visual alternative to sounds - Microsoft Support</title>
+      <description>Learn how to change your PC settings to replace audio alerts with visual
+        notifications and use captions to describe activities.</description>
+      <pubDate>Tue, 14 Feb 2023 18:09:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-14-2023-kb5022858-os-build-10240-19747-e4b2872f-3490-45f4-ad5e-85fdad758bbc</link>
+      <title>February 14, 2023—KB5022858 (OS Build 10240.19747) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 14 Feb 2023 18:04:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-internet-explorer-in-windows-10-7248a101-d5dd-bded-d843-d9427c42d60f</link>
+      <title>Use Internet Explorer in Windows 10 - Microsoft Support</title>
+      <description>Internet Explorer 11 support ended on June 15, 2022. We recommend you use
+        Microsoft Edge for a faster, more secure and more modern web browsing experience.</description>
+      <pubDate>Tue, 14 Feb 2023 16:13:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/run-the-latest-version-of-internet-explorer-11-ea628df4-50ce-8019-f9f4-468e39685cea</link>
+      <title>Run the latest version of Internet Explorer 11 - Microsoft Support</title>
+      <description>Internet Explorer 11 support ended on June 15, 2022. Switch to Microsoft Edge for
+        a faster, more secure and more modern web browsing experience.</description>
+      <pubDate>Tue, 14 Feb 2023 16:13:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/microsoft-easy-fix-solutions-have-been-discontinued-b0f4b5f9-3b5a-bd9e-d75d-d45e2f12e16c</link>
+      <title>Microsoft Easy Fix solutions have been discontinued - Microsoft Support</title>
+      <description>Describes Microsoft easy fix solutions and how to use them. "Microsoft easy fix"
+        was formerly known as "Microsoft Fix it."</description>
+      <pubDate>Mon, 13 Feb 2023 22:04:09 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5023152-this-app-can-t-open-error-message-after-running-system-restore-and-then-starting-a-windows-app-in-windows-10-and-later-versions-52d63063-a912-4b2b-b0b8-a934d18625bf</link>
+      <title>KB5023152: “This app can’t open” error message after running system restore and then
+        starting a Windows app in Windows 10 and later versions - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 08 Feb 2023 23:30:47 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5023290-out-of-band-compatibility-update-for-installing-and-recovering-windows-10-version-1507-january-31-2023-74cb29bc-89b3-413a-ae03-bcfcfdd86b9a</link>
+      <title>KB5023290: Out of band Compatibility update for installing and recovering Windows 10,
+        version 1507: January 31, 2023 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 31 Jan 2023 22:00:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/what-s-imported-to-microsoft-edge-ab7d9fa1-4586-23ce-8116-e46f44987ac2</link>
+      <title>What's imported to Microsoft Edge - Microsoft Support</title>
+      <description>Learn more about what items get imported from Google Chrome and other browsers to
+        Microsoft Edge and how to import Third-Party Passwords to Microsoft Edge. </description>
+      <pubDate>Tue, 31 Jan 2023 20:58:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/fix-family-activity-reporting-for-windows-4e58c3ec-9a2a-8a98-5a35-352b7c234341</link>
+      <title>Fix family activity reporting for Windows - Microsoft Support</title>
+      <description>Try these steps to fix family activity reporting issues in Windows.</description>
+      <pubDate>Tue, 31 Jan 2023 04:23:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-and-automatically-initiated-feature-updates-84915307-beb0-4a58-ac44-181e61c5a51d</link>
+      <title>Windows and automatically initiated feature updates - Microsoft Support</title>
+      <description>Windows Update automatically initiates a feature update for devices as they are
+        approaching end of service.</description>
+      <pubDate>Thu, 26 Jan 2023 21:55:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/why-use-random-hardware-addresses-060ad2e9-526e-4f1c-9f3d-fe6a842640ed</link>
+      <title>Why use random hardware addresses? - Microsoft Support</title>
+      <description>An explanation about why you might want to use random hardware addresses.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/what-the-what-needs-your-attention-windows-setup-notification-means-0cedddaf-0198-8fe8-3b75-5f83dc7a4c77</link>
+      <title>What the "What needs your attention" Windows setup notification means - Microsoft
+        Support</title>
+      <description>Learn how to fix "What needs your attention" and other common messages related to
+        Windows setup.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/make-it-easier-to-focus-on-tasks-0d259fd9-e9d0-702c-c027-007f0e78eaf2</link>
+      <title>Make it easier to focus on tasks - Microsoft Support</title>
+      <description>Use Windows accessibility features, such as Focus assist, to help improve focus
+        on tasks and minimize distractions.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/set-your-display-for-night-time-in-windows-18fe903a-e0a1-8326-4c68-fd23d7aaf136</link>
+      <title>Set your display for night time in Windows - Microsoft Support</title>
+      <description>Turn on the night light setting in Windows to show warmer colors that are easier
+        on your eyes.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/connect-to-a-wi-fi-network-in-windows-1f881677-b569-0cd5-010d-e3cd3579d263</link>
+      <title>Connect to a Wi-Fi network in Windows - Microsoft Support</title>
+      <description>Learn how to connect to a Wi-fi network in Windows and manage your current
+        network connections.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-use-multiple-monitors-in-windows-329c6962-5a4d-b481-7baa-bec9671f728a</link>
+      <title>How to use multiple monitors in Windows - Microsoft Support</title>
+      <description>Learn how to connect your Windows PC to external monitors and adjust the display
+        settings.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/backup-and-restore-in-windows-352091d2-bb9d-3ea3-ed18-52ef2b88cbef</link>
+      <title>Backup and Restore in Windows - Microsoft Support</title>
+      <description>Learn how to restore files with backup and restore or file history in Windows.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/using-system-file-checker-in-windows-365e0031-36b1-6031-f804-8fd86e0ef4ca</link>
+      <title>Using System File Checker in Windows - Microsoft Support</title>
+      <description>Learn how to run System File Checker in Windows to check if your computer has
+        problems with files.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-reserved-storage-works-in-windows-5bc98443-0711-8038-4621-6a18ddc904f2</link>
+      <title>How reserved storage works in Windows - Microsoft Support</title>
+      <description>Learn how reserved storage works in Windows to conserve disk space for temporary
+        files, caches, and other files.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/manage-drive-space-with-storage-sense-654f6ada-7bfc-45e5-966b-e24aded96ad5</link>
+      <title>Manage drive space with Storage Sense - Microsoft Support</title>
+      <description>How to use Storage Sense to free up hard drive space on your Windows device.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/connect-to-a-projector-or-pc-7e170c39-58dc-c866-7d55-be2372632892</link>
+      <title>Connect to a projector or PC - Microsoft Support</title>
+      <description>Learn how to connect to a projector or to another PC in Windows using the
+        keyboard shortcut "Windows logo key + P", the Connect app (for Windows 10), or the Wireless
+        Display app (for Windows 11).</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/turn-off-notifications-in-windows-during-certain-times-81ed1b25-809b-741d-549c-7696474d15d3</link>
+      <title>Turn off notifications in Windows during certain times - Microsoft Support</title>
+      <description>Learn how to manage focus settings for Windows 10/11.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/touch-gestures-for-windows-a9d28305-4818-a5df-4e2b-e5590f850741</link>
+      <title>Touch gestures for Windows - Microsoft Support</title>
+      <description>See the common touchpad gestures for your Windows 10/11 device.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/tips-to-improve-pc-performance-in-windows-b3b3ef5b-5953-fb6a-2528-4bbed82fba96</link>
+      <title>Tips to improve PC performance in Windows - Microsoft Support</title>
+      <description>Learn how to improve Windows PC performance if your device is running slowly.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/about-windows-backup-and-sync-settings-deebcba2-5bc0-4e63-279a-329926955708</link>
+      <title>About Windows backup and sync settings - Microsoft Support</title>
+      <description>Windows backup and sync settings sync the settings you choose across all your
+        Windows devices that you've signed in to with your Microsoft account.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/turn-airplane-mode-on-or-off-f2c2e0a1-706f-ff26-c4b2-4a37f9796df1</link>
+      <title>Turn airplane mode on or off - Microsoft Support</title>
+      <description>Turn airplane mode on or off in Windows.</description>
+      <pubDate>Thu, 26 Jan 2023 01:28:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/which-devices-are-supported-by-microsoft-mouse-and-keyboard-center-61ac6d03-9cc1-d7c6-ca9b-c9c8ce4cb303</link>
+      <title>Which devices are supported by Microsoft Mouse and Keyboard Center? - Microsoft Support</title>
+      <description>Find out if your device is or is not supported by Microsoft Mouse and Keyboard
+        Center software, and what to do if it is not supported.</description>
+      <pubDate>Thu, 26 Jan 2023 01:04:40 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/speech-voice-activation-inking-typing-and-privacy-149e0e60-7c93-dedd-a0d8-5731b71a4fef</link>
+      <title>Speech, voice activation, inking, typing, and privacy - Microsoft Support</title>
+      <description>Learn more about the privacy settings for speech, voice activation, inking, and
+        typing in Windows.</description>
+      <pubDate>Thu, 26 Jan 2023 00:28:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-location-service-and-privacy-3a8eee0a-5b0b-dc07-eede-2a5ca1c49088</link>
+      <title>Windows location service and privacy - Microsoft Support</title>
+      <description>Find out how the Windows location service works and how to change the location
+        privacy settings.</description>
+      <pubDate>Thu, 26 Jan 2023 00:28:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/appendix-d-user-guides-for-previous-versions-of-narrator-e25deec6-1ddb-a25d-04dd-8a7227b29149</link>
+      <title>Appendix D: User guides for previous versions of Narrator - Microsoft Support</title>
+      <description>Get user guides for previous versions of Narrator</description>
+      <pubDate>Thu, 26 Jan 2023 00:28:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-20-2020-kb4580390-os-build-17763-1554-preview-ac4799c9-838f-8665-a968-0f19b6cb1049</link>
+      <title>October 20, 2020—KB4580390 (OS Build 17763.1554) Preview - Microsoft Support</title>
+      <description>Learn more about update KB4580390, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Wed, 25 Jan 2023 18:25:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-10-2023-kb5022297-os-build-10240-19685-a7a8a2b8-dab9-4dcc-8df9-b1ae63fcf00f</link>
+      <title>January 10, 2023—KB5022297 (OS Build 10240.19685) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 20 Jan 2023 18:29:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-10-2023-kb5022289-os-build-14393-5648-36de3673-55d0-4e0f-8b77-d06326b58456</link>
+      <title>January 10, 2023—KB5022289 (OS Build 14393.5648) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 20 Jan 2023 18:27:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb4535680-security-update-for-secure-boot-dbx-january-12-2021-f08c6b00-a850-e595-6147-d0c32ead81e2</link>
+      <title>KB4535680: Security update for Secure Boot DBX: January 12, 2021 - Microsoft Support</title>
+      <description>Learn about this security update, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Wed, 18 Jan 2023 17:24:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/security-update-for-windows-10-version-1607-1703-1709-1803-1809-1903-1909-windows-server-2016-and-windows-server-2019-february-11-2020-755ab061-817d-144b-e4de-2c4ee4f1d596</link>
+      <title>Security update for Windows 10, version 1607, 1703, 1709, 1803, 1809, 1903, 1909,
+        Windows Server 2016 and Windows Server 2019: February 11, 2020 - Microsoft Support</title>
+      <description>Learn about security update KB4524244, including improvements and fixes, any
+        known issues, and how to get the update.</description>
+      <pubDate>Wed, 18 Jan 2023 17:23:28 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/send-feedback-to-microsoft-with-the-feedback-hub-app-f59187f8-8739-22d6-ba93-f66612949332</link>
+      <title>Send feedback to Microsoft with the Feedback Hub app - Microsoft Support</title>
+      <description>Learn how to use Feedback Hub to report problems or send suggestions to
+        Microsoft.</description>
+      <pubDate>Tue, 17 Jan 2023 18:35:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/groove-music-help-470c06e5-9a83-b6e5-2a32-7be0310f7981</link>
+      <title>Groove Music help - Microsoft Support</title>
+      <description>Get help with your questions about playing music with the Groove Music app from
+        our selection of how-to articles, tutorials, and support content.</description>
+      <pubDate>Fri, 13 Jan 2023 23:25:20 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/compatibility-update-for-upgrading-to-windows-10-version-1803-october-16-2018-ff6c1388-4b69-7595-8d9d-a68a8cf6e8ff</link>
+      <title>Compatibility update for upgrading to Windows 10, version 1803: October 16, 2018 -
+        Microsoft Support</title>
+      <description>Fixes some compatibility issues that occur when you upgrade to Windows 10 Version
+        1803.</description>
+      <pubDate>Fri, 13 Jan 2023 01:12:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/compatibility-update-for-installing-windows-10-version-1809-march-10-2020-ff543800-1f22-98d2-b2a6-1a43b1f06b97</link>
+      <title>Compatibility update for installing Windows 10, version 1809: March 10, 2020 -
+        Microsoft Support</title>
+      <description>Learn more about update KB4538460, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 13 Jan 2023 01:09:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/ms15-093-security-update-for-internet-explorer-august-18-2015-feba4de3-8189-3218-bd77-0725de01ae17</link>
+      <title>MS15-093: Security update for Internet Explorer: August 18, 2015 - Microsoft Support</title>
+      <description>Resolves a vulnerability in Internet Explorer that could allow remote code
+        execution if a user views a specially crafted webpage using Internet Explorer.</description>
+      <pubDate>Fri, 13 Jan 2023 01:04:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/compatibility-update-for-upgrading-to-windows-10-version-1709-march-27-2018-fda25751-2b4c-a84d-839b-50dbf22a782c</link>
+      <title>Compatibility update for upgrading to Windows 10, version 1709: March 27,2018 -
+        Microsoft Support</title>
+      <description>Compatibility update for upgrading to Windows 10, version 1709: March 27,2018</description>
+      <pubDate>Fri, 13 Jan 2023 00:56:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/product-activation-for-windows-online-support-telephone-numbers-35f6a805-1259-88b4-f5e9-b52cccef91a0</link>
+      <title>Product activation for Windows – online &amp; support telephone numbers - Microsoft
+        Support</title>
+      <description>Learn how to activate Windows using an internet connection, automated system, or
+        live support advocate.</description>
+      <pubDate>Wed, 11 Jan 2023 18:10:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/go-back-to-windows-8-1-40e2d7dc-f640-b0e5-56e1-b41a27e28533</link>
+      <title>Go back to Windows 8.1 - Microsoft Support</title>
+      <description>Get help going back to a previous version of Windows such as Windows 8.1.</description>
+      <pubDate>Wed, 11 Jan 2023 17:52:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5022725-the-october-2022-and-later-security-updates-implement-a-change-of-behavior-for-the-internet-explorer-event-log-access-permissions-df3572e7-dd80-4c61-9c38-be7a88f424ca</link>
+      <title>KB5022725: The October 2022 and later security updates implement a change of behavior
+        for the Internet Explorer event log access permissions - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 06 Jan 2023 03:05:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-15-2022-kb5020030-os-builds-19042-2311-19043-2311-19044-2311-and-19045-2311-preview-237a9048-f853-4e29-a3a2-62efdbea95e2</link>
+      <title>November 15, 2022—KB5020030 (OS Builds 19042.2311, 19043.2311, 19044.2311, and
+        19045.2311) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 04 Jan 2023 01:16:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/start-your-pc-in-safe-mode-in-windows-92c27cff-db89-8644-1ce4-b3e5e56fe234</link>
+      <title>Start your PC in safe mode in Windows - Microsoft Support</title>
+      <description>Find out how to boot into safe mode in Windows from Settings, the sign-in screen,
+        and a black or blank screen.</description>
+      <pubDate>Fri, 30 Dec 2022 20:49:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/make-older-apps-or-programs-compatible-with-windows-783d6dd7-b439-bdb0-0490-54eea0f45938</link>
+      <title>Make older apps or programs compatible with Windows - Microsoft Support</title>
+      <description>Learn how to get older apps or programs to run on Windows 10 or Windows 11 by
+        adjusting compatibility settings.</description>
+      <pubDate>Tue, 27 Dec 2022 20:17:27 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-13-2022-kb5021237-os-build-17763-3770-8c1506cc-e030-4cf1-8cd6-774091f46f34</link>
+      <title>December 13, 2022—KB5021237 (OS Build 17763.3770) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 20 Dec 2022 22:05:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/make-text-and-apps-bigger-c3095a80-6edd-4779-9282-623c4d721d64</link>
+      <title>Make text and apps bigger - Microsoft Support</title>
+      <description>Make text, images, and apps bigger on the screen of your Windows computer.</description>
+      <pubDate>Mon, 19 Dec 2022 13:41:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-use-the-world-time-clock-in-the-clock-app-in-windows-57d8574f-dd5d-a3e8-18b9-1a1098189b27</link>
+      <title>How to use the world time clock in the Clock app in Windows - Microsoft Support</title>
+      <description>Learn how to use the world time clock in the Alarms &amp; Clock app in Windows.</description>
+      <pubDate>Tue, 13 Dec 2022 23:09:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/manage-the-input-and-display-language-settings-in-windows-12a10cb4-8626-9b77-0ccb-5013e0c7c7a2</link>
+      <title>Manage the input and display language settings in Windows - Microsoft Support</title>
+      <description>Learn how to change Windows display language and keyboard layout settings for
+        websites and apps.</description>
+      <pubDate>Tue, 13 Dec 2022 18:24:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-13-2022-kb5021243-os-build-10240-19624-15ce9bfc-7db1-4262-a01e-a233e4956b30</link>
+      <title>December 13, 2022—KB5021243 (OS Build 10240.19624) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 13 Dec 2022 18:04:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-13-2022-kb5021235-os-build-14393-5582-de1179ba-57c5-4594-82a6-d2ba12f2758e</link>
+      <title>December 13, 2022—KB5021235 (OS Build 14393.5582) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 13 Dec 2022 18:03:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/office/outlook-express-move-your-email-to-outlook-com-afa90000-6b8b-c99c-e41f-53322a8b8cf1</link>
+      <title>Outlook Express: Move your email to Outlook.com - Microsoft Support</title>
+      <description>Outlook Express: Move your email to Outlook.com.</description>
+      <pubDate>Tue, 13 Dec 2022 16:43:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/microsoft-edge-browsing-activity-for-personalized-advertising-and-experiences-37aa831e-6372-238e-f33f-7cd3f0e53679</link>
+      <title>Microsoft Edge browsing activity for personalized advertising and experiences -
+        Microsoft Support</title>
+      <description>Learn how Microsoft uses the information from your Microsoft Edge browsing
+        history.</description>
+      <pubDate>Mon, 12 Dec 2022 22:09:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/back-up-your-bitlocker-recovery-key-e63607b4-77fb-4ad3-8022-d6dc428fbd0d</link>
+      <title>Back up your BitLocker recovery key - Microsoft Support</title>
+      <description>Having a backup copy of your BitLocker recovery key helps to prevent serious
+        issues later. It takes less than a minute to back up your key and this article will show you
+        how.</description>
+      <pubDate>Mon, 12 Dec 2022 18:21:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5017811-manage-transport-layer-security-tls-1-0-and-1-1-after-default-behavior-change-on-september-20-2022-e95b1b47-9c7c-4d64-9baf-610604a64c3e</link>
+      <title>KB5017811—Manage Transport Layer Security (TLS) 1.0 and 1.1 after default behavior
+        change on September 20, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 08 Dec 2022 17:05:18 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/why-do-incompatible-drivers-prevent-using-memory-integrity-0b7ae567-74de-ee03-1030-9e6fe0d6f4b6</link>
+      <title>Why do incompatible drivers prevent using Memory integrity? - Microsoft Support</title>
+      <description>Find out what steps you can take if an incompatible driver in preventing you from
+        turning on the Memory integrity setting in Windows Security.</description>
+      <pubDate>Thu, 08 Dec 2022 00:42:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5021989-extended-protection-for-authentication-1b6ea84d-377b-4677-a0b8-af74efbb243f</link>
+      <title>KB5021989: Extended Protection for Authentication - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 07 Dec 2022 00:23:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-10-and-windows-11-in-s-mode-faq-851057d6-1ee9-b9e5-c30b-93baebeebc85</link>
+      <title>Windows 10 and Windows 11 in S mode FAQ - Microsoft Support</title>
+      <description>Get answers to common questions about Windows 11 and Windows 10 in S mode.</description>
+      <pubDate>Tue, 06 Dec 2022 21:26:02 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-11-2022-kb5018419-os-build-17763-3532-ca62cca7-b599-44c4-a2a6-347996662623</link>
+      <title>October 11, 2022—KB5018419 (OS Build 17763.3532) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 06 Dec 2022 19:22:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-11-2022-kb5018411-os-build-14393-5427-a59be55a-b368-4284-a643-28fc0b9b8314</link>
+      <title>October 11, 2022—KB5018411 (OS Build 14393.5427) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 06 Dec 2022 19:17:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-11-2022-kb5018425-os-build-10240-19507-15982c8b-992d-4b46-8ae9-0b3e825c1257</link>
+      <title>October 11, 2022—KB5018425 (OS Build 10240.19507) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 06 Dec 2022 19:13:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-8-2022-kb5019970-os-build-10240-19567-1f8a9622-880a-49cd-9ad0-5febd302a82f</link>
+      <title>November 8, 2022—KB5019970 (OS Build 10240.19567) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 06 Dec 2022 18:44:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-17-2022-kb5021654-os-build-14393-5502-out-of-band-3bccb4df-bfa1-4c70-9ce3-d5842e3af467</link>
+      <title>November 17, 2022—KB5021654 (OS Build 14393.5502) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 06 Dec 2022 18:38:57 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-8-2022-kb5019964-os-build-14393-5501-5c195bd1-91d5-402e-a973-813373ba4357</link>
+      <title>November 8, 2022—KB5019964 (OS Build 14393.5501) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 06 Dec 2022 18:37:41 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-17-2022-kb5021655-os-build-17763-3653-out-of-band-8e0c94f1-0a7d-4602-a47b-1f086434bb16</link>
+      <title>November 17, 2022—KB5021655 (OS Build 17763.3653) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 06 Dec 2022 18:33:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-8-2022-kb5019966-os-build-17763-3650-b09dad62-5cd7-47cd-992f-b7d01f2956c1</link>
+      <title>November 8, 2022—KB5019966 (OS Build 17763.3650) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 06 Dec 2022 18:32:28 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/the-wallpaper-might-not-correctly-fit-the-screen-after-connecting-an-external-display-in-windows-6fdc245b-28f5-4333-a205-7e51a2eec593</link>
+      <title>The wallpaper might not correctly fit the screen after connecting an external display
+        in Windows - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 05 Dec 2022 00:03:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5020683-out-of-box-experience-update-for-windows-10-version-2004-20h2-21h1-21h2-and-22h2-november-30-2022-5937bf6e-4da4-4914-8fc0-bd520359e494</link>
+      <title>KB5020683: Out of Box Experience update for Windows 10, version 2004, 20H2, 21H1, 21H2,
+        and 22H2: November 30, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 01 Dec 2022 20:03:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/install-a-printer-in-windows-cc0724cf-793e-3542-d1ff-727e4978638b</link>
+      <title>Install a printer in Windows - Microsoft Support</title>
+      <description>Learn about installing and adding printers in Windows.</description>
+      <pubDate>Wed, 16 Nov 2022 08:59:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/troubleshooting-offline-printer-problems-in-windows-d5a928fc-d91f-d04e-21c5-bbb475ee3a99</link>
+      <title>Troubleshooting offline printer problems in Windows - Microsoft Support</title>
+      <description>Get tips for changing your printer's status from "offline" to "online."</description>
+      <pubDate>Wed, 16 Nov 2022 08:57:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/how-to-reset-the-hosts-file-back-to-the-default-c2a43f9d-e176-c6f3-e4ef-3500277a6dae</link>
+      <title>How to reset the Hosts file back to the default - Microsoft Support</title>
+      <description>Describes how to reset the Hosts file back to the default.</description>
+      <pubDate>Tue, 15 Nov 2022 21:48:28 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5020377-setup-dynamic-update-for-windows-10-version-20h2-21h1-21h2-and-22h2-november-15-2022-a11270a3-7841-4f2c-8779-d692fc1b1d19</link>
+      <title>KB5020377: Setup Dynamic Update for Windows 10, version 20H2, 21H1, 21H2, and 22H2:
+        November 15, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 15 Nov 2022 18:03:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-28-2022-kb5020953-os-builds-19042-2194-19043-2194-19044-2194-and-19045-2194-out-of-band-5b0e9c22-6d38-4ffc-9fe1-7cd83b63f7a7</link>
+      <title>October 28, 2022—KB5020953 (OS Builds 19042.2194, 19043.2194, 19044.2194, and
+        19045.2194) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 15 Nov 2022 00:48:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-25-2022-kb5018482-os-builds-19042-2193-19043-2193-and-19044-2193-preview-42a9588e-da20-4de4-aad3-053fa32c03c1</link>
+      <title>October 25, 2022—KB5018482 (OS Builds 19042.2193, 19043.2193, and 19044.2193) Preview -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 15 Nov 2022 00:42:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-17-2022-kb5020438-os-build-17763-3534-out-of-band-cd499c1a-6d60-49a1-9a40-fad42c1d393a</link>
+      <title>October 17, 2022—KB5020438 (OS Build 17763.3534) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 09 Nov 2022 00:54:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-18-2022-kb5020439-os-build-14393-5429-out-of-band-f9840376-4f36-45c3-8dd8-f366c4b884dd</link>
+      <title>October 18, 2022—KB5020439 (OS Build 14393.5429) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 09 Nov 2022 00:49:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-18-2022-kb5020440-os-build-10240-19509-out-of-band-e706d500-c49e-45f8-96f8-59df500c2a1e</link>
+      <title>October 18, 2022—KB5020440 (OS Build 10240.19509) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 09 Nov 2022 00:35:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5021042-compatibility-update-for-installing-and-recovering-windows-10-version-1809-and-windows-server-2019-november-8-2022-026d8688-a162-44e6-96f0-5a8f7a539f14</link>
+      <title>KB5021042: Compatibility update for installing and recovering Windows 10, version 1809
+        and Windows Server 2019: November 8, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 08 Nov 2022 19:01:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5021043-compatibility-update-for-installing-and-recovering-windows-10-version-21h1-21h2-and-22h2-november-8-2022-c2d85d86-49b9-444a-ba1b-86e11ec943ff</link>
+      <title>KB5021043: Compatibility update for installing and recovering Windows 10, version 21H1,
+        21H2, and 22H2: November 8, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 08 Nov 2022 18:52:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5021039-compatibility-update-for-installing-and-recovering-windows-10-version-1607-and-windows-server-2016-november-8-2022-b2ff8ab6-1aaa-496c-944d-23092ba3793b</link>
+      <title>KB5021039: Compatibility update for installing and recovering Windows 10, version 1607
+        and Windows Server 2016: November 8, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 08 Nov 2022 18:41:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/reinstall-windows-d8369486-3e33-7d9c-dccc-859e2b022fc7</link>
+      <title>Reinstall Windows - Microsoft Support</title>
+      <description>Learn how to reinstall Windows on your PC and how activation works after it's
+        installed.</description>
+      <pubDate>Mon, 31 Oct 2022 18:29:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/windows-10-update-history-8127c2c6-6edf-4fdf-8b9f-0f7be1ef3562</link>
+      <title>Windows 10 update history - Microsoft Support</title>
+      <description>Learn more about updates for Windows 10, version 22H2, including improvements,
+        any known issues, and how to get the update.</description>
+      <pubDate>Mon, 31 Oct 2022 18:18:09 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-17-2022-kb5020435-os-builds-19042-2132-19043-2132-and-19044-2132-out-of-band-243f34de-2f44-4015-a224-1b68a4132ca5</link>
+      <title>October 17, 2022—KB5020435 (OS Builds 19042.2132, 19043.2132, and 19044.2132)
+        Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 27 Oct 2022 19:53:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5020779-the-vulnerable-driver-blocklist-after-the-october-2022-preview-release-3fcbe13a-6013-4118-b584-fcfbc6a09936</link>
+      <title>KB5020779—The vulnerable driver blocklist after the October 2022 preview release -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 27 Oct 2022 18:42:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5019422-setup-dynamic-update-for-windows-10-version-20h2-21h1-21h2-and-22h2-october-25-2022-cef84571-0183-425b-9eb5-58360e956fe8</link>
+      <title>KB5019422: Setup Dynamic Update for Windows 10, version 20H2, 21H1, 21H2, and 22H2:
+        October 25, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 25 Oct 2022 21:04:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/group-photos-by-faces-1ab09703-f0a6-5835-d27b-58672b23fdd2</link>
+      <title>Group photos by faces - Microsoft Support</title>
+      <description>Learn more about how Microsoft uses your photo and video data to give you a
+        better experience and to help improve the Photos app.</description>
+      <pubDate>Tue, 25 Oct 2022 16:43:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5020282-account-lockout-available-for-built-in-local-administrators-bce45c4d-f28d-43ad-b6fe-70156cb2dc00</link>
+      <title>KB5020282—Account lockout available for built-in local administrators - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Fri, 21 Oct 2022 23:22:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/share-things-with-nearby-devices-in-windows-0efbfe40-e3e2-581b-13f4-1a0e9936c2d9</link>
+      <title>Share things with nearby devices in Windows - Microsoft Support</title>
+      <description>Learn how to share documents, links, and pictures with nearby devices using
+        Bluetooth or Wi-Fi in Windows.</description>
+      <pubDate>Fri, 21 Oct 2022 18:00:41 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/stay-up-to-date-with-news-and-interests-a39baa08-7488-4169-9ed8-577238f46f8f</link>
+      <title>Stay up to date with news and interests - Microsoft Support</title>
+      <description>Get started with news and interests, choose how weather looks on your taskbar,
+        turn it on and off, personalize your feed and choose interests and followed publishers.</description>
+      <pubDate>Wed, 19 Oct 2022 23:44:02 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-20-2022-kb5017380-os-builds-19042-2075-19043-2075-and-19044-2075-preview-59ab550c-105e-4481-b440-c37f07bf7897</link>
+      <title>September 20, 2022—KB5017380 (OS Builds 19042.2075, 19043.2075, and 19044.2075) Preview
+        - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 19 Oct 2022 16:36:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5015684-featured-update-to-windows-10-version-22h2-by-using-an-enablement-package-09d43632-f438-47b5-985e-d6fd704eee61</link>
+      <title>KB5015684: Featured update to Windows 10, version 22H2 by using an enablement package -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 18 Oct 2022 20:08:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5016058-servicing-stack-update-for-windows-10-version-1607-and-server-2016-july-12-2022-e48fd91f-7071-4531-8d62-e2641ad9c46b</link>
+      <title>KB5016058: Servicing stack update for Windows 10, version 1607 and Server 2016: July
+        12, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 18 Oct 2022 18:24:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/find-your-documents-in-windows-5c7c8cfe-c289-fae4-f5f8-6b3fdba418d2</link>
+      <title>Find your documents in Windows - Microsoft Support</title>
+      <description>Search from the taskbar or File Explorer to find your documents.</description>
+      <pubDate>Tue, 18 Oct 2022 17:34:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/windows-journal-application-for-windows-02fee094-5ad4-13db-0ead-e6135d7d0550</link>
+      <title>Windows Journal Application for Windows - Microsoft Support</title>
+      <description>Provides an update for Windows Journal to add the application to systems from
+        which it was removed.</description>
+      <pubDate>Tue, 18 Oct 2022 07:05:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/description-of-the-windows-update-standalone-installer-in-windows-799ba3df-ec7e-b05e-ee13-1cdae8f23b19</link>
+      <title>Description of the Windows Update Standalone Installer in Windows - Microsoft Support</title>
+      <description>Describes how use Wusa.exe to install and uninstall update packages in Windows
+        Vista, Windows Server 2008, Windows 7, Windows Server 2008 R2, Windows 8, Windows Server
+        2012, Windows 8.1, Windows Server 2012 R2, Windows 10, and Windows Server 2016 Technical
+        Preview.</description>
+      <pubDate>Tue, 18 Oct 2022 07:05:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5005645-compatibility-update-for-installing-and-recovering-windows-10-version-2004-20h2-and-21h1-september-30-2021-6584ed93-fe11-4456-88b6-d37c806da78f</link>
+      <title>KB5005645: Compatibility update for installing and recovering Windows 10, version 2004,
+        20H2, and 21H1: September 30, 2021 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 18 Oct 2022 07:05:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5006966-setup-dynamic-update-for-windows-10-version-1909-october-12-2021-987af134-4668-493e-b199-62658bb53f53</link>
+      <title>KB5006966: Setup Dynamic Update for Windows 10, version 1909: October 12, 2021 -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 18 Oct 2022 07:05:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/windows-pe-boot-images-don-t-initialize-in-system-center-configuration-manager-6795eb23-0162-1eaa-2e22-de3a9e09ecfb</link>
+      <title>Windows PE boot images don't initialize in System Center Configuration Manager -
+        Microsoft Support</title>
+      <description>Fixes an issue that prevents Windows PE boot images from initializing in System
+        Center Configuration Manager.</description>
+      <pubDate>Mon, 17 Oct 2022 06:40:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-uninstall-a-windows-update-c77b8f9b-e4dc-4e9f-a803-fdec12e59fb0</link>
+      <title>How to uninstall a Windows update - Microsoft Support</title>
+      <description>Learn how to uninstall a Windows update, if for example that update is causing
+        your system to have errors or other problems.</description>
+      <pubDate>Thu, 13 Oct 2022 22:22:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/find-out-which-version-of-microsoft-edge-you-have-c726bee8-c42e-e472-e954-4cf5123497eb</link>
+      <title>Find out which version of Microsoft Edge you have - Microsoft Support</title>
+      <description>Open Microsoft Edge, select Settings and more (...), and then select Settings.
+        Look for your version under About Microsoft Edge.</description>
+      <pubDate>Wed, 12 Oct 2022 19:18:41 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/microsoft-accessory-center-download-c960b3f5-639b-444f-8b9e-a176ad583c9d</link>
+      <title>Microsoft Accessory Center download - Microsoft Support</title>
+      <description>Learn how to get the Microsoft Accessory Center app for your Microsoft
+        accessories.</description>
+      <pubDate>Wed, 12 Oct 2022 14:59:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-your-default-browser-in-windows-020c58c6-7d77-797a-b74e-8f07946c5db6</link>
+      <title>Change your default browser in Windows - Microsoft Support</title>
+      <description>Use the Windows Settings app to change your default browser.</description>
+      <pubDate>Tue, 11 Oct 2022 17:28:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5019420-setup-dynamic-update-for-windows-10-version-20h2-21h1-21h2-and-22h2-october-11-2022-04e7707a-cf3b-420c-bc9c-3e46c621a1a6</link>
+      <title>KB5019420: Setup Dynamic Update for Windows 10, version 20H2, 21H1, 21H2, and 22H2:
+        October 11, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 11 Oct 2022 16:59:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-26-2022-kb5016688-os-builds-19042-1949-19043-1949-and-19044-1949-preview-ec31ebdc-067d-44dd-beb0-eabcc984d843</link>
+      <title>August 26, 2022—KB5016688 (OS Builds 19042.1949, 19043.1949, and 19044.1949) Preview -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 26 Sep 2022 22:41:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-13-2022-kb5017315-os-build-17763-3406-926525b2-750e-42e2-9845-49924d97281c</link>
+      <title>September 13, 2022—KB5017315 (OS Build 17763.3406) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 23 Sep 2022 17:06:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-13-2022-kb5017305-os-build-14393-5356-ba44c079-8baf-4460-baea-ebc054be71ea</link>
+      <title>September 13, 2022—KB5017305 (OS Build 14393.5356) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 23 Sep 2022 17:03:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-20-2022-kb5017379-os-build-17763-3469-preview-50a9b9e2-745d-49df-aaae-19190e10d307</link>
+      <title>September 20, 2022—KB5017379 (OS Build 17763.3469) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 23 Sep 2022 16:59:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-13-2022-kb5017327-os-build-10240-19444-15f82f82-533f-45ce-8708-eab89c3f303f</link>
+      <title>September 13, 2022—KB5017327 (OS Build 10240.19444) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 23 Sep 2022 16:52:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5000788-suppress-the-notification-that-microsoft-edge-legacy-support-ended-4f7ae35e-3e2e-46ca-bdf9-1dd5d863b16e</link>
+      <title>KB5000788: Suppress the notification that Microsoft Edge Legacy support ended -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 22 Sep 2022 02:17:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/windows-pe-network-winpe-dot3svc-optional-component-doesn-t-work-in-windows-10-version-1607-or-version-1703-8f392d99-c248-6148-39ab-6dc05fd49622</link>
+      <title>Windows PE Network/WinPE-Dot3Svc optional component doesn’t work in Windows 10 Version
+        1607 or Version 1703 - Microsoft Support</title>
+      <description>Fixes an issue in which the Windows PE Network/WinPE-Dot3Svc optional component
+        doesn’t work in Windows 10 Version 1607 or Version 1703.</description>
+      <pubDate>Thu, 22 Sep 2022 02:16:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/open-the-start-menu-4ed57ad7-ed1f-3cc9-c9e4-f329822f5aeb</link>
+      <title>Open the Start menu - Microsoft Support</title>
+      <description>Open the Start menu. </description>
+      <pubDate>Tue, 20 Sep 2022 18:16:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/see-what-s-on-the-start-menu-a8ccb400-ad49-962b-d2b1-93f453785a13</link>
+      <title>See what's on the Start menu - Microsoft Support</title>
+      <description>Learn more about the Start menu, including how to find your files and get to your
+        apps and programs. </description>
+      <pubDate>Tue, 20 Sep 2022 18:14:28 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/stream-hdr-video-on-windows-2e98fc86-5358-d6bc-1e22-d0e416d3c704</link>
+      <title>Stream HDR video on Windows - Microsoft Support</title>
+      <description>Learn how to turn on HDR video streaming to watch high dynamic range (HDR)
+        content on your Windows PC. </description>
+      <pubDate>Tue, 20 Sep 2022 18:08:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/media-feature-pack-for-windows-10-11-n-september-2022-78cfeea5-c7d9-4aa8-b38f-ee4df1392009</link>
+      <title>Media Feature Pack for Windows 10/11 N (September 2022) - Microsoft Support</title>
+      <description>Learn how to install the Media Feature Pack for Windows 10/11 N editions
+        (September 2022).</description>
+      <pubDate>Tue, 20 Sep 2022 17:38:00 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5017404-setup-dynamic-update-for-windows-10-version-20h2-21h1-and-21h2-september-20-2022-a723c55b-7bfa-40fb-87e5-e469cad4f7cb</link>
+      <title>KB5017404: Setup Dynamic Update for Windows 10, version 20H2, 21H1, and 21H2: September
+        20, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 20 Sep 2022 17:06:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-21-2022-kb5015880-os-build-17763-3232-preview-1c984723-cdf0-4a24-9a4f-5df11d3024a1</link>
+      <title>July 21, 2022—KB5015880 (OS Build 17763.3232) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 19 Sep 2022 18:00:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-23-2022-kb5016690-os-build-17763-3346-preview-b81d1ac5-75c7-42c1-b638-f13aa4242f42</link>
+      <title>August 23, 2022—KB5016690 (OS Build 17763.3346) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 23:16:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-9-2022-kb5016623-os-build-17763-3287-c7a0bb3a-4083-4cd0-b9ad-119d9267628b</link>
+      <title>August 9, 2022—KB5016623 (OS Build 17763.3287) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 23:14:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-14-2022-kb5014692-os-build-17763-3046-62fe56c1-a8c0-40e8-a901-677ab9538bf8</link>
+      <title>June 14, 2022—KB5014692 (OS Build 17763.3046) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 23:11:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-21-2022-kb5012636-os-build-17763-2867-preview-633385f3-07ef-4112-88e7-c7c5be026639</link>
+      <title>April 21, 2022—KB5012636 (OS Build 17763.2867) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 23:07:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-15-2022-kb5010427-os-build-17763-2628-preview-d29de7d8-9646-486b-b9b1-c8e4fbe6bac0</link>
+      <title>February 15, 2022—KB5010427 (OS Build 17763.2628) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 22:39:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/february-8-2022-kb5010351-os-build-17763-2565-f895d43b-d855-4f6e-b0cc-52c079ae9056</link>
+      <title>February 8, 2022—KB5010351 (OS Build 17763.2565) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 22:35:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-25-2022-kb5009616-os-build-17763-2510-preview-d395eb9c-40e9-425c-a026-ed2e0a0d9dd3</link>
+      <title>January 25, 2022—KB5009616 (OS Build 17763.2510) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 22:32:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-22-2021-kb5007266-os-build-17763-2330-preview-c9ba0c4c-c8b7-409a-8fac-a76ffae8f94f</link>
+      <title>November 22, 2021—KB5007266 (OS Build 17763.2330) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 22:19:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-14-2021-kb5008602-os-build-17763-2305-out-of-band-8583a8a3-ebed-4829-b285-356fb5aaacd7</link>
+      <title>November 14, 2021—KB5008602(OS Build 17763.2305) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 22:17:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-9-2021-kb5007206-os-build-17763-2300-c63b76fa-a9b4-4685-b17c-7d866bb50e48</link>
+      <title>November 9, 2021—KB5007206 (OS Build 17763.2300) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 22:13:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-18-2021-kb5001638-os-build-17763-1823-out-of-band-ef7c735f-b6f6-4249-b5a6-0d11a3239b32</link>
+      <title>March 18, 2021—KB5001638 (OS Build 17763.1823) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 22:11:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-8-2021-kb5003646-os-build-17763-1999-81e2ff5a-0769-4e56-8762-059dd6e0d6bb</link>
+      <title>June 8, 2021—KB5003646 (OS Build 17763.1999) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 21:55:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-14-2021-kb5005568-os-build-17763-2183-d19b2778-204a-4c09-a0c3-23dc28d5deac</link>
+      <title>September 14, 2021—KB5005568 (OS Build 17763.2183) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 21:32:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-26-2021-kb5005102-os-build-17763-2145-preview-84c556d7-4a14-49d9-b1ba-35690209acd3</link>
+      <title>August 26, 2021—KB5005102 (OS Build 17763.2145) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 21:29:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-10-2021-kb5005030-os-build-17763-2114-cec503ed-cc09-4641-bdc1-988153e0bd9a</link>
+      <title>August 10, 2021—KB5005030 (OS Build 17763.2114) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 21:27:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-15-2021-kb5003703-os-build-17763-2028-preview-687c70f6-98ed-4440-9cc7-72c9ef735bfe</link>
+      <title>June 15, 2021—KB5003703 (OS Build 17763.2028) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 20:26:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-20-2021-kb5003217-os-build-17763-1971-preview-08687c95-0740-421b-a205-54aa2c716b46</link>
+      <title>May 20, 2021—KB5003217 (OS Build 17763.1971) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 20:22:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-25-2021-kb5000854-os-build-17763-1852-preview-082d35a7-68dd-448a-bfea-03f038669b11</link>
+      <title>March 25, 2021-KB5000854 (OS Build 17763.1852) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 20:20:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-15-2021-kb5001568-os-build-17763-1821-out-of-band-c1ce521e-5073-4800-bd1a-09378470d954</link>
+      <title>March 15, 2021—KB5001568 (OS Build 17763.1821) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 20:13:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-21-2021-kb4598296-os-build-17763-1728-preview-4c0931ff-45b7-ff59-5e00-c03b5afb363d</link>
+      <title>January 21, 2021-KB4598296 (OS Build 17763.1728) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 16 Sep 2022 19:31:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-12-2021-kb4598230-os-build-17763-1697-expired-b1a0ac13-7bf7-d87e-9fe4-ac566f87a081</link>
+      <title>January 12, 2021—KB4598230 (OS Build 17763.1697) - EXPIRED - Microsoft Support</title>
+      <description>Learn more about update KB4598230, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 19:28:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-8-2020-kb4592440-os-build-17763-1637-expired-9181daf2-e180-b711-162f-b0d1a8d38dd9</link>
+      <title>December 8, 2020—KB4592440 (OS Build 17763.1637) - EXPIRED - Microsoft Support</title>
+      <description>Learn more about update KB4592440, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 19:25:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-13-2020-kb4577668-os-build-17763-1518-expired-a035446b-2b3f-692f-3c27-afb43ec01594</link>
+      <title>October 13, 2020—KB4577668 (OS Build 17763.1518) - EXPIRED - Microsoft Support</title>
+      <description>Learn more about update KB4577668, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 19:19:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-16-2020-kb4577069-os-build-17763-1490-preview-fcc63e7f-dbf1-ab01-9a11-1f79983e8526</link>
+      <title>September 16, 2020—KB4577069 (OS Build 17763.1490) Preview - Microsoft Support</title>
+      <description>Learn more about update KB4577069, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 19:17:10 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-14-2020-kb4558998-os-build-17763-1339-ef8a3135-027e-f5ad-a79e-a41581ca842a</link>
+      <title>July 14, 2020—KB4558998 (OS Build 17763.1339) - Microsoft Support</title>
+      <description>Learn more about update KB4558998, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 19:14:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-16-2020-kb4567513-os-build-17763-1294-0ab9bada-08f3-95b8-5811-cc1224e9af29</link>
+      <title>June 16, 2020—KB4567513 (OS Build 17763.1294) - Microsoft Support</title>
+      <description>Learn more about update KB4567513, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 19:13:02 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-9-2020-kb4561608-os-build-17763-1282-437af506-e3ef-a8a1-09e7-26cc94e509c7</link>
+      <title>June 9, 2020—KB4561608 (OS Build 17763.1282) - Microsoft Support</title>
+      <description>Learn more about update KB4561608, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 19:11:09 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-30-2020-kb4554354-os-build-17763-1132-deaba49b-4b29-55b9-caee-3e2d87dd75a2</link>
+      <title>March 30, 2020—KB4554354 (OS Build 17763.1132) - Microsoft Support</title>
+      <description>Learn more about update KB4554354, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 19:09:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-17-2020-kb4541331-os-build-17763-1131-32105fd2-5343-2b2b-03f4-8c1047bc5e30</link>
+      <title>March 17, 2020—KB4541331 (OS Build 17763.1131) - Microsoft Support</title>
+      <description>Learn more about update KB4541331, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 19:05:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-10-2020-kb4538461-os-build-17763-1098-45c6729d-b8bd-5eb6-c9bf-b12caf099032</link>
+      <title>March 10, 2020—KB4538461 (OS Build 17763.1098) - Microsoft Support</title>
+      <description>Learn more about update KB4538461, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 19:00:25 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-14-2020-kb4534273-os-build-17763-973-a85c4308-eb18-4835-19dd-cbadd493e315</link>
+      <title>January 14, 2020—KB4534273 (OS Build 17763.973) - Microsoft Support</title>
+      <description>Learn more about update KB4534273, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 18:58:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-10-2019-kb4530715-os-build-17763-914-dff5924d-bc40-0a41-6ecc-5d20419a875e</link>
+      <title>December 10, 2019—KB4530715 (OS Build 17763.914) - Microsoft Support</title>
+      <description>Learn more about update KB4530715, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 18:54:20 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-12-2019-kb4523205-os-build-17763-864-100bc05a-c300-a329-94ea-9767f1266176</link>
+      <title>November 12, 2019—KB4523205 (OS Build 17763.864) - Microsoft Support</title>
+      <description>Learn more about update KB4523205, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 18:52:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-24-2019-kb4516077-os-build-17763-774-c5368b0c-82d0-e9cd-8283-a9ca11cc3298</link>
+      <title>September 24, 2019—KB4516077 (OS Build 17763.774) - Microsoft Support</title>
+      <description>Learn more about update KB4516077, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 18:50:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-10-2019-kb4512578-os-build-17763-737-695c1350-93dc-40dc-72c3-5af9743c6340</link>
+      <title>September 10, 2019—KB4512578 (OS Build 17763.737) - Microsoft Support</title>
+      <description>Learn more about update KB4512578, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 18:48:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-17-2019-kb4512534-os-build-17763-720-0b45b181-5c48-75b4-8b44-aed65f56edc5</link>
+      <title>August 17, 2019—KB4512534 (OS Build 17763.720) - Microsoft Support</title>
+      <description>Learn more about update KB4512534, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 18:47:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-26-2019-kb4509479-os-build-17763-593-cf3c9959-db87-63aa-197a-e92ef965dfee</link>
+      <title>June 26, 2019—KB4509479 (OS Build 17763.593) - Microsoft Support</title>
+      <description>Learn more about update KB4509479, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 18:43:47 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-18-2019-kb4501371-os-build-17763-592-f718648f-9c92-3058-b447-d31f4a9cb497</link>
+      <title>June 18, 2019—KB4501371 (OS Build 17763.592) - Microsoft Support</title>
+      <description>Learn more about update KB4501371, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 18:41:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-11-2019-kb4503327-os-build-17763-557-bf6a83cd-41c8-07f8-60f0-11cc2dafd016</link>
+      <title>June 11, 2019—KB4503327 (OS Build 17763.557) - Microsoft Support</title>
+      <description>Learn more about update KB4503327, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 18:37:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-3-2019-kb4495667-os-build-17763-475-cad1f813-0014-e92e-0bee-f9b77ea44fad</link>
+      <title>May 3, 2019—KB4495667 (OS Build 17763.475) - Microsoft Support</title>
+      <description>Learn more about update KB4495667, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 18:27:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-1-2019-kb4501835-os-build-17763-439-8d411ec6-73be-420b-924a-a8de290c6917</link>
+      <title>May 1, 2019—KB4501835 (OS Build 17763.439) - Microsoft Support</title>
+      <description>Learn more about update KB4501835, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 18:13:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-9-2019-kb4493509-os-build-17763-437-3009e91f-261d-7cdc-4f7e-b00a3fde5991</link>
+      <title>April 9, 2019—KB4493509 (OS Build 17763.437) - Microsoft Support</title>
+      <description>Learn more about update KB4493509, including improvements and fixes, any known
+        issues, and how to get the update.</description>
+      <pubDate>Fri, 16 Sep 2022 18:10:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5017396-servicing-stack-update-for-windows-10-version-1607-and-server-2016-september-13-2022-5e6c9af3-c9ae-4648-84a4-096009e49733</link>
+      <title>KB5017396: Servicing stack update for Windows 10, version 1607 and Server 2016:
+        September 13, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 13 Sep 2022 17:36:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/delete-your-previous-version-of-windows-f8b26680-e083-c710-b757-7567d69dbb74</link>
+      <title>Delete your previous version of Windows - Microsoft Support</title>
+      <description>Delete your previous version of Windows</description>
+      <pubDate>Fri, 09 Sep 2022 21:09:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/keep-your-computer-secure-at-home-c348f24f-a4f0-de5d-9e4a-e0fc156ab221</link>
+      <title>Keep your computer secure at home - Microsoft Support</title>
+      <description>Get tips to help protect your home computer from scams, malware, viruses, and
+        other online threats that might try steal your personal information.</description>
+      <pubDate>Tue, 06 Sep 2022 17:40:18 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/august-9-2022-kb5016622-os-build-14393-5291-19fa46af-be4b-4717-b711-8499777e13a8</link>
+      <title>August 9, 2022—KB5016622 (OS Build 14393.5291) - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 05 Sep 2022 03:19:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-26-2022-kb5015878-os-builds-19042-1865-19043-1865-and-19044-1865-preview-549f5551-fcc5-4fee-8811-c5df12e04d40</link>
+      <title>July 26, 2022—KB5015878 (OS Builds 19042.1865, 19043.1865, and 19044.1865) Preview -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 01 Sep 2022 22:18:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/mouse-and-keyboard-problems-in-windows-94b4ca7b-4f2f-077e-4eb4-f7b4ecdf4f61</link>
+      <title>Mouse and keyboard problems in Windows - Microsoft Support</title>
+      <description>Troubleshoot problems you might be having with your mouse or keyboard, or other
+        wireless device in Windows.</description>
+      <pubDate>Thu, 01 Sep 2022 16:14:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/device-encryption-in-windows-ad5dcf4b-dbe0-2331-228f-7925c2a3012d</link>
+      <title>Device encryption in Windows - Microsoft Support</title>
+      <description>Learn about BitLocker and your encryption options for Windows.</description>
+      <pubDate>Wed, 31 Aug 2022 23:38:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/uninstall-or-remove-apps-and-programs-in-windows-4b55f974-2cc6-2d2b-d092-5905080eaf98</link>
+      <title>Uninstall or remove apps and programs in Windows - Microsoft Support</title>
+      <description>Uninstall or remove apps and programs in the Settings app.</description>
+      <pubDate>Tue, 30 Aug 2022 22:22:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-28-2022-kb5014666-os-builds-19042-1806-19043-1806-and-19044-1806-preview-4bd911df-f290-4753-bdec-a83bc8709eb6</link>
+      <title>June 28, 2022—KB5014666 (OS Builds 19042.1806, 19043.1806, and 19044.1806) Preview -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 29 Aug 2022 18:53:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-19-2022-kb5015020-os-builds-19042-1708-19043-1708-and-19044-1708-out-of-band-9b5bd38a-ab3c-4ada-96b0-b754134fcd2a</link>
+      <title>May 19, 2022—KB5015020 (OS Builds 19042.1708, 19043.1708, and 19044.1708) Out-of-band -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 29 Aug 2022 18:49:30 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-22-2022-kb5011543-os-builds-19042-1620-19043-1620-and-19044-1620-preview-4fe2d1c0-720f-47fe-9523-75339bc107a1</link>
+      <title>March 22, 2022—KB5011543 (OS Builds 19042.1620, 19043.1620, and 19044.1620) Preview -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 29 Aug 2022 18:47:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-25-2022-kb5009596-os-builds-19042-1503-19043-1503-and-19044-1503-preview-83a957c0-daae-428c-a9b9-4f0fb6efb8f8</link>
+      <title>January 25, 2022—KB5009596 (OS Builds 19042.1503, 19043.1503, and 19044.1503) Preview -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 29 Aug 2022 18:43:47 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-21-2021-kb5003690-os-builds-19041-1081-19042-1081-and-19043-1081-preview-expired-11a7581f-2a01-47d5-ba12-431709ee2248</link>
+      <title>June 21, 2021—KB5003690 (OS Builds 19041.1081, 19042.1081, and 19043.1081) Preview -
+        EXPIRED - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 29 Aug 2022 18:24:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/move-your-files-to-a-new-windows-pc-c7bb3950-cdf6-40d4-8db3-a2d4f687fa4b</link>
+      <title>Move your files to a new Windows PC - Microsoft Support</title>
+      <description>Learn your options for moving files to a new Windows PC.</description>
+      <pubDate>Fri, 26 Aug 2022 22:53:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5016775-setup-dynamic-update-for-windows-10-version-20h2-21h1-and-21h2-august-26-2022-a6ffdc28-28e2-4f9b-9156-01099e7d8465</link>
+      <title>KB5016775: Setup Dynamic Update for Windows 10, version 20H2, 21H1, and 21H2: August
+        26, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 26 Aug 2022 21:11:16 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/access-work-or-school-troubleshooter-for-restoring-access-to-m365-desktop-applications-aae546b0-ee55-49a9-9784-9fa46d8c15cf</link>
+      <title>Access work or school troubleshooter for restoring access to M365 desktop applications
+        - Microsoft Support</title>
+      <description>An explanation of the Access Work or School troubleshooter and of the issue that
+        it addresses.</description>
+      <pubDate>Fri, 26 Aug 2022 00:20:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-voice-typing-to-talk-instead-of-type-on-your-pc-fec94565-c4bd-329d-e59a-af033fa5689f</link>
+      <title>Use voice typing to talk instead of type on your PC - Microsoft Support</title>
+      <description>Use dictation to convert spoken words into text anywhere on your PC with Windows.</description>
+      <pubDate>Tue, 23 Aug 2022 19:26:53 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/search-history-on-the-privacy-dashboard-904dbfd6-adeb-4555-3e63-3ce34b6de60a</link>
+      <title>Search history on the privacy dashboard - Microsoft Support</title>
+      <description>Find out why Microsoft collects your search history, how to view and clear your
+        search history, and which search data appears on the privacy dashboard.</description>
+      <pubDate>Tue, 16 Aug 2022 23:45:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-29-2021-kb5000842-os-builds-19041-906-and-19042-906-preview-1a58a276-6a0a-47a5-aa7d-97af2d10b16d</link>
+      <title>March 29, 2021—KB5000842 (OS Builds 19041.906 and 19042.906) Preview - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Thu, 11 Aug 2022 11:39:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/find-lost-files-after-the-upgrade-to-windows-10-or-11-10af49aa-b372-b067-a334-2314401297a9</link>
+      <title>Find lost files after the upgrade to Windows 10 or 11 - Microsoft Support</title>
+      <description>Learn how to find your old files after upgrading your PC to Windows 10, including
+        search and recovery tips.</description>
+      <pubDate>Wed, 10 Aug 2022 16:47:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5017095-servicing-stack-update-for-windows-10-version-1607-and-server-2016-august-9-2022-63d110e1-abde-44ad-9170-a4ba2d1e83d2</link>
+      <title>KB5017095: Servicing stack update for Windows 10, version 1607 and Server 2016: August
+        9, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Aug 2022 17:03:53 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/location-activity-on-the-privacy-dashboard-cb8cde37-2569-1ca9-f011-2d07554912e8</link>
+      <title>Location activity on the privacy dashboard - Microsoft Support</title>
+      <description>Find out how to manage your location activity on the privacy dashboard and how to
+        choose which apps and devices can request access to your location.</description>
+      <pubDate>Thu, 04 Aug 2022 18:02:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-12-2022-kb5015811-os-build-17763-3165-f3bdb13c-d767-47dc-a077-0ea0e9421a96</link>
+      <title>July 12, 2022—KB5015811 (OS Build 17763.3165) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 27 Jul 2022 17:05:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-23-2022-kb5014669-os-build-17763-3113-preview-e9aae102-e21c-4f6d-89e0-ed0a82a793dc</link>
+      <title>June 23, 2022—KB5014669 (OS Build 17763.3113) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Jul 2022 17:18:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-14-2022-kb5014702-os-build-14393-5192-e60ac0e1-44a4-49f9-871f-7c25eb0e5bb1</link>
+      <title>June 14, 2022—KB5014702 (OS Build 14393.5192) - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 20 Jul 2022 17:12:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/how-to-perform-a-clean-boot-in-windows-da2f9573-6eec-00ad-2f8a-a97a1807f3dd</link>
+      <title>How to perform a clean boot in Windows - Microsoft Support</title>
+      <description>Describes how to use the clean boot process to troubleshoot a problem in Windows
+        8.1, Windows 8, Windows 7, or Windows Vista.</description>
+      <pubDate>Fri, 15 Jul 2022 21:06:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/the-ime-pad-might-output-incorrect-japanese-characters-in-windows-10-6cb9e0e0-e899-4ba1-845d-342310331e6b</link>
+      <title>The IME Pad might output incorrect Japanese characters in Windows 10 - Microsoft
+        Support</title>
+      <description />
+      <pubDate>Thu, 14 Jul 2022 01:29:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-12-2022-kb5015808-os-build-14393-5246-c29be220-d42d-4be7-8f9f-ee004dfe3705</link>
+      <title>July 12, 2022—KB5015808 (OS Build 14393.5246) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 12 Jul 2022 21:15:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-10-2022-kb5013941-os-build-17763-2928-e84332a3-42bb-4d3c-9f6e-89db963230db</link>
+      <title>May 10, 2022—KB5013941 (OS Build 17763.2928) - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 11 Jul 2022 18:32:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-12-2022-kb5012647-os-build-17763-2803-9a10c5c9-e65f-4ae1-a9c4-2db9a8eca4fc</link>
+      <title>April 12, 2022—KB5012647 (OS Build 17763.2803) - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 11 Jul 2022 18:30:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-8-2022-kb5011503-os-build-17763-2686-ccb25c67-8994-41c9-bff2-4903f9a4721d</link>
+      <title>March 8, 2022—KB5011503 (OS Build 17763.2686) - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 11 Jul 2022 18:28:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-11-2022-kb5009557-os-build-17763-2452-c3ee4073-1e7f-488b-86c9-d050672437ae</link>
+      <title>January 11, 2022—KB5009557 (OS Build 17763.2452) - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 11 Jul 2022 18:24:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-4-2022-kb5010196-os-build-17763-2369-out-of-band-1a7a9a37-b154-4e73-92dc-1a2f65a4c0d1</link>
+      <title>January 4, 2022—KB5010196 (OS Build 17763.2369) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 11 Jul 2022 18:22:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/december-14-2021-kb5008218-os-build-17763-2366-0d9c500d-6e71-4cb4-99e2-416655622769</link>
+      <title>December 14, 2021—KB5008218 (OS Build 17763.2366) - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 11 Jul 2022 18:20:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-12-2021-kb5006672-os-build-17763-2237-f5f567fd-950d-4db0-9d17-09435322578a</link>
+      <title>October 12, 2021—KB5006672 (OS Build 17763.2237) - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 11 Jul 2022 18:16:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5014676-setup-dynamic-update-for-windows-10-version-20h2-21h1-and-21h2-june-28-2022-9b9aee41-3bd0-4052-b09d-4693cd31b6a6</link>
+      <title>KB5014676: Setup Dynamic Update for Windows 10, version 20H2, 21H1, and 21H2: June 28,
+        2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 07 Jul 2022 17:47:30 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-2-2022-kb5014023-os-builds-19042-1741-19043-1741-and-19044-1741-preview-65ac6a5d-439a-4e88-b431-a5e2d4e2516a</link>
+      <title>June 2, 2022—KB5014023 (OS Builds 19042.1741, 19043.1741, and 19044.1741) Preview -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 27 Jun 2022 22:21:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-25-2022-kb5011831-os-builds-19042-1682-19043-1682-and-19044-1682-preview-fe4ff411-d25a-4185-aabb-8bc66e9dbb6c</link>
+      <title>April 25, 2022—KB5011831 (OS Builds 19042.1682, 19043.1682, and 19044.1682) Preview -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 23 Jun 2022 17:27:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/display-requirements-for-hdr-video-in-windows-192f362e-1245-e14d-3d3f-4b3fc606b80f</link>
+      <title>Display requirements for HDR video in Windows - Microsoft Support</title>
+      <description>Learn how to stream HDR video in Windows. Find out the display, PC, and graphics
+        card requirements for streaming HDR video.</description>
+      <pubDate>Fri, 17 Jun 2022 16:35:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/stay-protected-with-windows-security-2ae0363d-0ada-c064-8b56-6a39afb6a963</link>
+      <title>Stay protected with Windows Security - Microsoft Support</title>
+      <description>Learn how to use antivirus protection in Windows Security to protect your Windows
+        PC against malware, viruses, and other threats.</description>
+      <pubDate>Thu, 16 Jun 2022 22:34:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/a-compatibility-pack-is-available-that-adds-support-for-windows-10-to-system-center-configuration-manager-2007-service-pack-2-01743d45-4cdc-abde-31d4-c538039f4651</link>
+      <title>A compatibility pack is available that adds support for Windows 10 to System Center
+        Configuration Manager 2007 Service Pack 2 - Microsoft Support</title>
+      <description>Describes a compatibility pack that enables Configuration Manager Client
+        features, the Branch Distribution Point role, and the Administrator Console for Windows 10
+        Enterprise 2015 LTSB.</description>
+      <pubDate>Thu, 16 Jun 2022 07:50:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/how-to-disable-internet-explorer-on-windows-99c3ae27-3a7b-9185-63d1-8d0d55fe1a41</link>
+      <title>How to disable Internet Explorer on Windows - Microsoft Support</title>
+      <description>Describes how to disable Internet Explorer 11 on Windows.</description>
+      <pubDate>Wed, 15 Jun 2022 12:55:20 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-your-home-page-for-internet-explorer-11-2b6f1093-833d-7df7-bb5a-098e014fad40</link>
+      <title>Change your home page for Internet Explorer 11 - Microsoft Support</title>
+      <description>Learn how to change your home pages in Internet Explorer.</description>
+      <pubDate>Wed, 15 Jun 2022 12:18:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/see-your-favorites-bar-in-microsoft-edge-and-internet-explorer-11-566736f8-a11d-52e2-4f6f-7a713e1750d2</link>
+      <title>See your favorites bar in Microsoft Edge and Internet Explorer 11 - Microsoft Support</title>
+      <description>Get the steps for showing your favorites bar in Microsoft Edge and Internet
+        Explorer 11.</description>
+      <pubDate>Wed, 15 Jun 2022 12:14:02 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-updates-when-you-re-away-from-your-pc-with-active-hours-in-windows-09b5376c-7647-4361-1423-c29aa692a8c4</link>
+      <title>Get updates when you're away from your PC with active hours in Windows - Microsoft
+        Support</title>
+      <description>Use active hours in Windows 10 and Windows 11 to get updates when you're away
+        from your PC.</description>
+      <pubDate>Mon, 13 Jun 2022 18:39:47 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/manage-updates-in-windows-643e9ea7-3cf6-7da6-a25c-95d4f7f099fe</link>
+      <title>Manage updates in Windows - Microsoft Support</title>
+      <description>Use the Settings app in Windows to schedule updates for a more convenient time,
+        or pause them.</description>
+      <pubDate>Mon, 13 Jun 2022 18:37:25 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/keep-your-pc-up-to-date-de79813c-7919-5fed-080f-0871c7bd9bde</link>
+      <title>Keep your PC up to date - Microsoft Support</title>
+      <description>Learn how to automatically or manually install the latest Windows updates to
+        access the latest features and improvements.</description>
+      <pubDate>Mon, 13 Jun 2022 18:35:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-update-delivery-optimization-and-privacy-bf86a244-8f26-a3c7-a137-a43bfbe688e8</link>
+      <title>Windows Update Delivery Optimization and privacy - Microsoft Support</title>
+      <description>Find answers to frequently asked questions about Windows Update Delivery
+        Optimization.</description>
+      <pubDate>Fri, 10 Jun 2022 01:37:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/free-up-space-for-windows-updates-429b12ba-f514-be0b-4924-ca6d16fa1d65</link>
+      <title>Free up space for Windows updates - Microsoft Support</title>
+      <description>Learn how to free up space for Windows update including deleting nonessential
+        files, using an external hard drive, and updating your hard drive.</description>
+      <pubDate>Fri, 10 Jun 2022 01:22:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/find-the-settings-tools-internet-options-in-microsoft-edge-22a00d4e-adf3-943a-fe83-74c3cd9bca24</link>
+      <title>Find the settings/tools/internet options in Microsoft Edge - Microsoft Support</title>
+      <description>Most tools and options in Microsoft Edge are available when you select Settings
+        and more &gt; Settings.</description>
+      <pubDate>Thu, 09 Jun 2022 16:09:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-update-troubleshooter-19bc41ca-ad72-ae67-af3c-89ce169755dd</link>
+      <title>Windows Update Troubleshooter - Microsoft Support</title>
+      <description>Learn how to run Windows Update Troubleshooter to resolve errors downloading or
+        installing Windows updates.</description>
+      <pubDate>Wed, 08 Jun 2022 23:54:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-10-2022-kb5013952-os-build-14393-5125-0bb9f7e6-0360-4162-8eab-108e28d3a090</link>
+      <title>May 10, 2022—KB5013952 (OS Build 14393.5125) - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 03 Jun 2022 01:29:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/help-in-notepad-4d68c388-2ff2-0e7f-b706-35fb2ab88a8c</link>
+      <title>Help in Notepad - Microsoft Support</title>
+      <description>Get answers to common questions about Notepad.</description>
+      <pubDate>Fri, 27 May 2022 02:12:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/office/fix-onedrive-sync-issues-on-windows-8-1-or-windows-rt-8-1-ea561552-7ec3-056e-e6e4-3c8c764dbfd5</link>
+      <title>Fix OneDrive sync issues on Windows 8.1 or Windows RT 8.1 - Microsoft Support</title>
+      <description>Find solutions to fix OneDrive sync issues on Windows 8.1 or Windows RT 8.1.</description>
+      <pubDate>Thu, 26 May 2022 14:49:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/file-sharing-over-a-network-in-windows-b58704b2-f53a-4b82-7bc1-80f9994725bf</link>
+      <title>File sharing over a network in Windows - Microsoft Support</title>
+      <description>Learn about file sharing over a network in Windows.</description>
+      <pubDate>Tue, 24 May 2022 19:51:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/view-printer-queue-in-windows-71505b3a-ba6b-14b2-b7f9-fd6204675ab5</link>
+      <title>View printer queue in Windows - Microsoft Support</title>
+      <description>Find out how to view the printer queue in Windows. </description>
+      <pubDate>Tue, 24 May 2022 14:34:30 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/set-a-default-printer-in-windows-e10cf8b8-e596-b102-bf84-c41022b5036f</link>
+      <title>Set a default printer in Windows - Microsoft Support</title>
+      <description>Use the Settings app in Windows 10 to set a default printer and manage printer
+        settings.</description>
+      <pubDate>Thu, 19 May 2022 18:20:30 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/download-printer-drivers-in-windows-da9b1460-7299-4cc3-e974-33cf99d86880</link>
+      <title>Download printer drivers in Windows - Microsoft Support</title>
+      <description>Download printer drivers</description>
+      <pubDate>Thu, 19 May 2022 17:44:11 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/troubleshooting-offline-printer-problems-in-windows-9f5e98ed-0ac8-50ff-a13b-d79bf7710061</link>
+      <title>Troubleshooting offline printer problems in Windows - Microsoft Support</title>
+      <description>Find out how to change your printer's status from "offline" to "online" in
+        Windows.</description>
+      <pubDate>Thu, 19 May 2022 17:13:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/windows-activation-or-validation-fails-with-error-code-0x8004fe33-a9afe65e-230b-c1ed-3414-39acd7fddf52</link>
+      <title>Windows activation or validation fails with error code 0x8004FE33 - Microsoft Support</title>
+      <description>Provides several workarounds to the Windows activation or validation error code
+        0x8004FE33 when you connect to the Internet through a proxy server that uses Basic
+        authentication.</description>
+      <pubDate>Tue, 17 May 2022 22:27:09 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/add-a-printer-or-scanner-in-windows-14d9a442-0bcb-e11c-7a6c-63f00efae79f</link>
+      <title>Add a printer or scanner in Windows - Microsoft Support</title>
+      <description>Learn how to add a printer or scanner in Windows.</description>
+      <pubDate>Tue, 17 May 2022 18:08:25 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-proxy-server-in-windows-03096c53-0554-4ffe-b6ab-8b1deee8dae1</link>
+      <title>Use a proxy server in Windows - Microsoft Support</title>
+      <description>Learn how to set up a connection to a proxy server on your Windows PC.</description>
+      <pubDate>Thu, 12 May 2022 00:15:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5014032-servicing-stack-update-for-windows-10-version-20h2-21h1-and-21h2-may-10-2022-69a798ad-813d-4d62-bb54-2252bbb434a1</link>
+      <title>KB5014032: Servicing stack update for Windows 10, version 20H2, 21H1, and 21H2: May 10,
+        2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 10 May 2022 17:08:30 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5014026-servicing-stack-update-for-windows-10-version-1607-and-server-2016-may-10-2022-bc0ddb6d-07fb-4a24-82de-821d3c13ab62</link>
+      <title>KB5014026: Servicing stack update for Windows 10, version 1607 and Server 2016: May 10,
+        2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 10 May 2022 17:07:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5014024-servicing-stack-update-for-windows-10-may-10-2022-d2f79cab-21f6-45ce-a391-738083ef8081</link>
+      <title>KB5014024: Servicing stack update for Windows 10: May 10, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 10 May 2022 17:07:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-your-screen-resolution-in-windows-5effefe3-2eac-e306-0b5d-2073b765876b</link>
+      <title>Change your screen resolution in Windows - Microsoft Support</title>
+      <description>Learn how to improve the clarity of text and images displayed on your screen by
+        changing the screen resolution of your monitor.</description>
+      <pubDate>Tue, 03 May 2022 20:29:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/hide-and-unhide-your-search-box-in-windows-6d8252b7-864f-c1b6-6a56-3eea0cda08dc</link>
+      <title>Hide and unhide your search box in Windows - Microsoft Support</title>
+      <description>Learn how to adjust your taskbar settings to hide and unhide the search box in
+        the Windows taskbar.</description>
+      <pubDate>Mon, 02 May 2022 21:13:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-22-2021-kb5007253-os-builds-19041-1387-19042-1387-19043-1387-and-19044-1387-preview-d1847be9-46c1-49fc-bf56-1d469fc1b3af</link>
+      <title>November 22, 2021—KB5007253 (OS Builds 19041.1387, 19042.1387, 19043.1387, and
+        19044.1387) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 28 Apr 2022 22:42:30 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-use-remote-desktop-5fe128d5-8fb1-7a23-3b8a-41e636865e8c</link>
+      <title>How to use Remote Desktop - Microsoft Support</title>
+      <description>Learn how to use Remote Desktop in Windows.</description>
+      <pubDate>Thu, 28 Apr 2022 19:46:49 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-problems-with-the-start-menu-604171c1-2c65-40a6-8774-473810765950</link>
+      <title>Fix problems with the Start menu - Microsoft Support</title>
+      <description>Learn more about how to fix problems with the Windows Start menu, and what to do
+        if the Start menu won't open.</description>
+      <pubDate>Mon, 25 Apr 2022 22:49:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/troubleshoot-common-error-messages-for-audio-or-video-apps-64236c08-c610-4c56-a095-ab5a66aaa680</link>
+      <title>Troubleshoot common error messages for audio or video apps - Microsoft Support</title>
+      <description>Resolve error messages that appear when your system's audio or video DisplayPort
+        or HDMI monitor fails. </description>
+      <pubDate>Mon, 25 Apr 2022 22:49:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/update-drivers-manually-in-windows-ec62f46c-ff14-c91d-eead-d7126dc1f7b6</link>
+      <title>Update drivers manually in Windows - Microsoft Support</title>
+      <description>Learn how to update drivers in Windows using Device Manager to update or
+        reinstall a driver.</description>
+      <pubDate>Mon, 25 Apr 2022 22:41:10 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-the-size-of-your-desktop-icons-in-windows-85a9d341-2a4f-3d96-c796-ae116a187211</link>
+      <title>Change the size of your desktop icons in Windows - Microsoft Support</title>
+      <description>Change the size of your desktop icons</description>
+      <pubDate>Fri, 22 Apr 2022 20:17:20 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5005463-pc-health-check-application-e33cf4e2-49e2-4727-b913-f3c5b1ee0e56</link>
+      <title>KB5005463—PC Health Check Application - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 21 Apr 2022 22:22:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/fix-problems-with-opening-cortana-611fcfe2-1fe0-7114-e419-e8bdedae12f3</link>
+      <title>Fix problems with opening Cortana - Microsoft Support</title>
+      <description>Fix problems with opening Cortana</description>
+      <pubDate>Mon, 18 Apr 2022 18:30:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/cortana-s-regions-and-languages-ad09a301-ce3a-aee4-6364-0f0f0c2ca888</link>
+      <title>Cortana's regions and languages - Microsoft Support</title>
+      <description>Find out which regions and languages Cortana is available in.</description>
+      <pubDate>Mon, 18 Apr 2022 18:30:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/reasons-cortana-doesn-t-talk-to-me-c8996e23-4673-f7b0-0505-e0a53616633c</link>
+      <title>Reasons Cortana doesn't talk to me - Microsoft Support</title>
+      <description>Check that your mic is set up or fix sound problems with your speakers.</description>
+      <pubDate>Mon, 18 Apr 2022 18:30:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/cortana-can-t-connect-to-the-internet-d52517f3-c740-9d3d-4f05-8444fdd0f09d</link>
+      <title>Cortana can't connect to the internet - Microsoft Support</title>
+      <description>Troubleshoot internet connection issues with Cortana.</description>
+      <pubDate>Mon, 18 Apr 2022 18:30:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/surface/using-surface-with-your-android-phone-84c68a16-a8c5-46e6-1d0c-34acfdd9e551</link>
+      <title>Using Surface with your Android phone - Microsoft Support</title>
+      <description>Learn how to use your Surface and Android phone together to get to your
+        documents, pictures, music and more no matter which device you’re on.</description>
+      <pubDate>Mon, 18 Apr 2022 18:13:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/help-in-paint-d62e155a-1775-6da4-0862-62a3e9e5a511</link>
+      <title>Help in Paint - Microsoft Support</title>
+      <description>Find out how to get help with Paint.</description>
+      <pubDate>Mon, 18 Apr 2022 09:44:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/march-22-2022-kb5011551-os-build-17763-2746-preview-690a59cd-059e-40f4-87e8-e9139cc65de4</link>
+      <title>March 22, 2022—KB5011551 (OS Build 17763.2746) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Sat, 16 Apr 2022 00:04:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-18-2022-kb5010791-os-build-17763-2458-out-of-band-43697313-d8e0-4918-b6df-7f64d4d9a8cd</link>
+      <title>January 18, 2022—KB5010791 (OS Build 17763.2458) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 15 Apr 2022 23:53:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-keyboard-tips-and-tricks-588e0b72-0fff-6d3f-aeee-6e5116097942</link>
+      <title>Windows keyboard tips and tricks - Microsoft Support</title>
+      <description>An overview of some new Windows keyboard features, as well as other ways to be
+        more productive with the keyboard.</description>
+      <pubDate>Thu, 14 Apr 2022 18:35:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/use-immersive-reader-in-microsoft-edge-78a7a17d-52e1-47ee-b0ac-eff8539015e1</link>
+      <title>Use Immersive Reader in Microsoft Edge - Microsoft Support</title>
+      <description>Learn how to enter reading mode in Microsoft Edge and use Immersive Reader to
+        hear webpages and PDFs read out loud.</description>
+      <pubDate>Wed, 13 Apr 2022 19:59:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-fix-whea-uncorrectable-error-7c49d78a-2792-96cf-2268-abbe9d9eb29f</link>
+      <title>How to fix WHEA_UNCORRECTABLE_ERROR - Microsoft Support</title>
+      <description>How to fix WHEA_UNCORRECTABLE_ERROR</description>
+      <pubDate>Tue, 12 Apr 2022 23:10:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-12-2022-kb5012596-os-build-14393-5066-f77f480c-5dea-4e85-88b8-1e70b1b5fcd2</link>
+      <title>April 12, 2022—KB5012596 (OS Build 14393.5066) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 12 Apr 2022 18:30:41 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5013269-servicing-stack-update-for-windows-10-april-12-2022-37086252-b9eb-4a2c-9372-64c2fcb4578c</link>
+      <title>KB5013269: Servicing stack update for Windows 10: April 12, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 12 Apr 2022 17:04:18 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/protect-my-pc-from-viruses-b2025ed1-02d5-1e87-ba5f-71999008e026</link>
+      <title>Protect my PC from viruses - Microsoft Support</title>
+      <description>Learn how to protect your Windows devices and personal data from viruses,
+        malware, or malicious attacks.</description>
+      <pubDate>Mon, 11 Apr 2022 22:58:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/how-can-smartscreen-help-protect-me-in-microsoft-edge-1c9a874a-6826-be5e-45b1-67fa445a74c8</link>
+      <title>How can SmartScreen help protect me in Microsoft Edge? - Microsoft Support</title>
+      <description>Learn how Microsoft Defender SmartScreen safeguards your security in Microsoft
+        Edge against phishing and malware sites.</description>
+      <pubDate>Mon, 11 Apr 2022 22:41:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/manage-cortana-settings-in-windows-10-1b4db5cb-2102-3322-e59b-bb1a08f4c46c</link>
+      <title>Manage Cortana settings in Windows 10 - Microsoft Support</title>
+      <description>Manage Cortana settings in Windows 10</description>
+      <pubDate>Tue, 05 Apr 2022 20:28:18 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/control-settings-and-open-apps-with-cortana-53d692b2-0f7c-33e5-e7c6-abc134e1945d</link>
+      <title>Control Settings and open apps with Cortana - Microsoft Support</title>
+      <description>Cortana is ready to help you easily find and control your PC's settings.</description>
+      <pubDate>Mon, 04 Apr 2022 21:57:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-17-2022-kb5010790-os-build-14393-4889-out-of-band-567c392a-b10c-4dba-bed5-d3648af05164</link>
+      <title>January 17, 2022—KB5010790 (OS Build 14393.4889) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 01 Apr 2022 15:52:01 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-17-2022-kb5010793-os-builds-19042-1469-19043-1469-and-19044-1469-out-of-band-f2d4f178-5b36-49cb-a6fd-4bf9857574f9</link>
+      <title>January 17, 2022—KB5010793 (OS Builds 19042.1469, 19043.1469, and 19044.1469)
+        Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Sat, 26 Mar 2022 00:01:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-17-2022-kb5010792-os-build-18363-2039-out-of-band-631ef9bc-7b22-4932-aa7a-a0c2499bbf9a</link>
+      <title>January 17, 2022—KB5010792 (OS Build 18363.2039) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 25 Mar 2022 23:36:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-17-2022-kb5010789-os-build-10240-19179-out-of-band-e99c8948-dadf-49e2-8ba3-479b80064c5f</link>
+      <title>January 17, 2022—KB5010789 (OS Build 10240.19179) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 25 Mar 2022 22:54:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-your-app-recommendation-settings-in-windows-f21b5c60-e996-4ee4-c2cf-b4a90c0bef9b</link>
+      <title>Change your app recommendation settings in Windows - Microsoft Support</title>
+      <description>Go to Settings &gt; Apps &gt; Apps &amp; features to change whether you're shown
+        app recommendations when trying to install apps from outside the Store.</description>
+      <pubDate>Fri, 25 Mar 2022 22:29:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5012894-update-for-microsoft-application-virtualization-app-v-sequencer-tool-and-microsoft-user-experience-virtualization-ue-v-template-generator-ccc1f1dd-dac9-4dc9-8319-54deae75dba2</link>
+      <title>KB5012894: Update for Microsoft Application Virtualization (App-V) Sequencer Tool and
+        Microsoft User Experience Virtualization (UE-V) Template Generator - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 25 Mar 2022 21:19:28 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/microsoft-net-framework-4-7-2-web-installer-for-windows-dda5cddc-b85e-545d-8d4a-d213349b7775</link>
+      <title>Microsoft .NET Framework 4.7.2 web installer for Windows - Microsoft Support</title>
+      <description>Describes the Microsoft .NET Framework 4.7.2 web installer for Windows.</description>
+      <pubDate>Thu, 24 Mar 2022 01:49:18 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5011577-compatibility-update-for-installing-and-recovering-windows-10-version-20h2-21h1-and-21h2-march-22-2022-c6a5713e-a6ae-423d-9347-e77bff5df324</link>
+      <title>KB5011577: Compatibility update for installing and recovering Windows 10, version 20H2,
+        21H1, and 21H2: March 22, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 22 Mar 2022 21:32:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/open-microsoft-paint-ead1dc5c-abc4-fd2c-d81e-ebb013fbc113</link>
+      <title>Open Microsoft Paint - Microsoft Support</title>
+      <description>Open Microsoft Paint by searching for it on the taskbar.</description>
+      <pubDate>Mon, 21 Mar 2022 22:11:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/turn-off-defender-antivirus-protection-in-windows-security-99e6004f-c54c-8509-773c-a4d776b77960</link>
+      <title>Turn off Defender antivirus protection in Windows Security - Microsoft Support</title>
+      <description>Follow these steps to temporarily turn off Defender antivirus protection in
+        Windows Security. Keep in mind that if you do, your device may be vulnerable to threats.</description>
+      <pubDate>Mon, 14 Mar 2022 22:19:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/update-windows-3c5ae7fc-9fb6-9af1-1984-b5e0412c556a</link>
+      <title>Update Windows - Microsoft Support</title>
+      <description>Learn how to get the latest Windows updates to keep your device running smoothly
+        and securely.</description>
+      <pubDate>Fri, 11 Mar 2022 22:57:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/change-your-default-search-engine-in-microsoft-edge-cccaf51c-a4df-a43e-8036-d4d2c527a791</link>
+      <title>Change your default search engine in Microsoft Edge - Microsoft Support</title>
+      <description>Learn how to change your default search engine in Microsoft Edge.</description>
+      <pubDate>Fri, 11 Mar 2022 14:19:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/update-the-microsoft-wireless-display-adapter-c66e1bf6-19ca-f4f7-52f6-221fa184b7eb</link>
+      <title>Update the Microsoft Wireless Display Adapter - Microsoft Support</title>
+      <description>Describes how to get firmware and driver updates for Microsoft Wireless Display
+        Adapter.</description>
+      <pubDate>Thu, 10 Mar 2022 17:36:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5011569-servicing-stack-update-for-windows-10-march-8-2022-5d42a3cf-ab20-45f8-b4fa-2c8bde663788</link>
+      <title>KB5011569: Servicing stack update for Windows 10: March 8, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 09 Mar 2022 00:42:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5011570-servicing-stack-update-for-windows-10-version-1607-and-server-2016-march-8-2022-ac6cb59b-d9c1-4b5a-95bc-cf88c9d3e216</link>
+      <title>KB5011570: Servicing stack update for Windows 10, version 1607 and Server 2016: March
+        8, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 09 Mar 2022 00:42:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5012419-compatibility-update-for-installing-and-recovering-windows-10-version-20h2-21h1-and-21h2-march-8-2022-9d78ba78-80f4-4948-9bb5-3c3667f5b0c7</link>
+      <title>KB5012419: Compatibility update for installing and recovering Windows 10, version 20H2,
+        21H1, and 21H2: March 8, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 08 Mar 2022 18:10:23 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-ethernet-connection-problems-in-windows-2311254e-cab8-42d6-90f3-cb0b9f63645f</link>
+      <title>Fix Ethernet connection problems in Windows - Microsoft Support</title>
+      <description>Learn about different things you can try to fix Ethernet network connection
+        problems in Windows</description>
+      <pubDate>Tue, 08 Mar 2022 16:03:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-default-programs-in-windows-e5d82cad-17d1-c53b-3505-f10a32e1894d</link>
+      <title>Change default programs in Windows - Microsoft Support</title>
+      <description>Use Settings in Windows 10 to change default apps and programs.</description>
+      <pubDate>Mon, 07 Mar 2022 20:58:25 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/using-the-windows-activation-troubleshooter-d717cdff-cf19-9770-7198-40119c2a696c</link>
+      <title>Using the Windows Activation troubleshooter - Microsoft Support</title>
+      <description>Learn how to use the Activation troubleshooter to resolve common activation
+        issues in Windows.</description>
+      <pubDate>Mon, 28 Feb 2022 22:19:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/email-and-phone-scams-claiming-to-be-the-windows-10-upgrade-9674daa6-0f0f-5117-e6c7-3bacf5df2ce9</link>
+      <title>Email and phone scams claiming to be the Windows 10 upgrade - Microsoft Support</title>
+      <description>If you have received an email with an attachment that claims to be the Windows 10
+        upgrade, or have received a call offering to help walk you through the Windows 10 upgrade,
+        please do not open the attachment or follow their instructions.</description>
+      <pubDate>Sat, 26 Feb 2022 00:52:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/shut-down-sleep-or-hibernate-your-pc-2941d165-7d0a-a5e8-c5ad-8c972e8e6eff</link>
+      <title>Shut down, sleep, or hibernate your PC - Microsoft Support</title>
+      <description>Learn how to shut down, sleep, or hibernate your PC</description>
+      <pubDate>Fri, 25 Feb 2022 01:58:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5012334-delete-the-windows-old-folder-using-storage-sense-in-the-settings-app-e12f9d84-ad7f-4780-9406-465670157f8e</link>
+      <title>KB5012334—Delete the Windows.old folder using Storage sense in the Settings app -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 25 Feb 2022 01:15:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/reactivating-windows-after-a-hardware-change-2c0e962a-f04c-145b-6ead-fb3fc72b6665</link>
+      <title>Reactivating Windows after a hardware change - Microsoft Support</title>
+      <description>Learn how to prepare your Windows device for a hardware change and find help
+        reactivating Windows after a hardware change is complete.</description>
+      <pubDate>Tue, 15 Feb 2022 18:15:30 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5010524-setup-dynamic-update-for-windows-10-version-20h2-21h1-and-21h2-february-15-2022-945266cf-f969-4030-8cfa-1e35408af781</link>
+      <title>KB5010524: Setup Dynamic Update for Windows 10, version 20H2, 21H1, and 21H2: February
+        15, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 15 Feb 2022 18:03:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-26-2021-kb5006738-os-builds-19041-1320-19042-1320-and-19043-1320-preview-ccbce6bf-ae00-4e66-9789-ce8e7ea35541</link>
+      <title>October 26, 2021—KB5006738 (OS Builds 19041.1320, 19042.1320, and 19043.1320) Preview -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 10 Feb 2022 22:46:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-30-2021-kb5005611-os-builds-19041-1266-19042-1266-and-19043-1266-preview-a37f5409-f320-4175-9a66-c2682fc11c07</link>
+      <title>September 30, 2021—KB5005611 (OS Builds 19041.1266, 19042.1266, and 19043.1266) Preview
+        - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 10 Feb 2022 22:38:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-1-2021-kb5005101-os-builds-19041-1202-19042-1202-and-19043-1202-preview-82a50f27-a56f-4212-96ce-1554e8058dc1</link>
+      <title>September 1, 2021—KB5005101 (OS Builds 19041.1202, 19042.1202, and 19043.1202) Preview
+        - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 10 Feb 2022 22:33:10 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-29-2021-kb5004296-os-builds-19041-1151-19042-1151-and-19043-1151-preview-6aba536a-6ed2-41cb-bc3d-3980e8693cc4</link>
+      <title>July 29, 2021—KB5004296 (OS Builds 19041.1151, 19042.1151, and 19043.1151) Preview -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 10 Feb 2022 22:28:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/june-11-2021-kb5004476-os-builds-19041-1055-19042-1055-and-19043-1055-out-of-band-e12f58c7-4ceb-4d24-adfb-b13820f4e86b</link>
+      <title>June 11, 2021—KB5004476 (OS Builds 19041.1055, 19042.1055, and 19043.1055) Out-of-band
+        - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 10 Feb 2022 22:23:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-25-2021-kb5003214-os-builds-19041-1023-19042-1023-and-19043-1023-preview-8a58ac95-cf5e-4032-9272-23de9ee1d186</link>
+      <title>May 25, 2021—KB5003214 (OS Builds 19041.1023, 19042.1023, and 19043.1023) Preview
+        - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 10 Feb 2022 22:19:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-28-2021-kb5001391-os-builds-19041-964-and-19042-964-preview-fc8959e2-f2a0-4223-b56b-0ad8d9b4f96c</link>
+      <title>April 28, 2021—KB5001391 (OS Builds 19041.964 and 19042.964) Preview
+        - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 10 Feb 2022 22:16:02 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-help-with-windows-activation-errors-09d8fb64-6768-4815-0c30-159fa7d89d85</link>
+      <title>Get help with Windows activation errors - Microsoft Support</title>
+      <description>Learn how to troubleshoot Windows activation errors. Browse common activation
+        errors and learn what you can do to fix them.</description>
+      <pubDate>Thu, 10 Feb 2022 00:11:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/microsoft-japanese-ime-da40471d-6b91-4042-ae8b-713a96476916</link>
+      <title>Microsoft Japanese IME - Microsoft Support</title>
+      <description>This page helps you with how to use Microsoft Japanese IME including IME features
+        and keyboard shortcuts.</description>
+      <pubDate>Tue, 08 Feb 2022 21:32:15 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/microsoft-traditional-chinese-ime-ef596ca5-aff7-4272-b34b-0ac7c2631a38</link>
+      <title>Microsoft Traditional Chinese IME - Microsoft Support</title>
+      <description>This page helps you with how to use Microsoft Traditional Chinese IME including
+        IME features and keyboard shortcuts.</description>
+      <pubDate>Tue, 08 Feb 2022 21:27:05 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-background-apps-and-your-privacy-83f2de44-d2d9-2b29-4649-2afe0913360a</link>
+      <title>Windows background apps and your privacy - Microsoft Support</title>
+      <description>Learn more about what background apps are in Windows and how to turn them off
+        when you're not using them.</description>
+      <pubDate>Tue, 01 Feb 2022 00:12:56 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/product-keys-for-windows-4317463e-d62d-4ea2-160b-000d2a99065a</link>
+      <title>Product keys for Windows - Microsoft Support</title>
+      <description>Find your product key to activate Windows</description>
+      <pubDate>Mon, 31 Jan 2022 22:36:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/safely-remove-hardware-in-windows-1ee6677d-4e6c-4359-efca-fd44b9cec369</link>
+      <title>Safely remove hardware in Windows - Microsoft Support</title>
+      <description>Follow these steps to safely remove hardware from your Windows device.</description>
+      <pubDate>Mon, 31 Jan 2022 22:35:25 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/pin-an-app-to-the-taskbar-65faa478-5e98-3b74-c6b6-1be3f5b67ed0</link>
+      <title>Pin an app to the taskbar - Microsoft Support</title>
+      <description>From the Start menu or apps list, right-click an app, then select Pin to taskbar.</description>
+      <pubDate>Mon, 31 Jan 2022 22:35:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/where-are-my-game-clips-and-screenshots-saved-in-windows-71480e4e-e691-3406-8be3-31b2d7e3f0c9</link>
+      <title>Where are my game clips and screenshots saved in Windows? - Microsoft Support</title>
+      <description>Where you can find your screenshots and game captures, and how to move that
+        folder to a different location.</description>
+      <pubDate>Mon, 31 Jan 2022 22:35:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/help-in-disk-management-ad88ba19-f0d3-0809-7889-830f63e94405</link>
+      <title>Help in Disk Management - Microsoft Support</title>
+      <description>Disk Management in Windows helps you perform advanced storage tasks like
+        initializing a new drive and extending or shrinking volumes.</description>
+      <pubDate>Mon, 31 Jan 2022 22:34:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/video-quality-of-game-clips-in-windows-af8440c6-dd69-65fc-9e6d-c9872902862e</link>
+      <title>Video quality of game clips in Windows - Microsoft Support</title>
+      <description>How to adjust the frame rate of video clips captured in games in Windows.</description>
+      <pubDate>Mon, 31 Jan 2022 22:34:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5011233-protections-in-cve-2022-21920-may-block-ntlm-authentication-if-kerberos-authentication-is-not-successful-dd415f99-a30c-4664-ba37-83d33fb071f4</link>
+      <title>KB5011233: Protections in CVE-2022-21920 may block NTLM authentication if Kerberos
+        authentication is not successful - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 28 Jan 2022 10:48:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/repair-apps-and-programs-in-windows-e90eefe4-d0a2-7c1b-dd59-949a9030f317</link>
+      <title>Repair apps and programs in Windows - Microsoft Support</title>
+      <description>Repair programs in Control Panel.</description>
+      <pubDate>Thu, 27 Jan 2022 21:25:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-more-done-with-multitasking-in-windows-b4fa0333-98f8-ef43-e25c-06d4fb1d6960</link>
+      <title>Get more done with multitasking in Windows - Microsoft Support</title>
+      <description>Learn how to multitask in Windows by optimizing your screen space with Snap
+        Assist and organizing your windows with Snap Groups.</description>
+      <pubDate>Thu, 27 Jan 2022 02:12:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/troubleshoot-common-usb-problems-5e9a9b49-ad43-702e-083e-6107e95deb88</link>
+      <title>Troubleshoot common USB problems - Microsoft Support</title>
+      <description>Get resources for troubleshooting common USB problems in Windows.</description>
+      <pubDate>Wed, 26 Jan 2022 21:59:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5009645-compatibility-update-for-installing-and-recovering-windows-10-version-20h2-21h1-and-21h2-january-25-2022-493e5bce-25d1-431d-8c5c-a0eb0b5e2529</link>
+      <title>KB5009645: Compatibility update for installing and recovering Windows 10, version 20H2,
+        21H1, and 21H2: January 25, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 25 Jan 2022 22:03:10 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5009647-setup-dynamic-update-for-windows-10-version-20h2-21h1-and-21h2-january-25-2022-b5fb274e-31cc-4c5d-9411-abf3ed01dad5</link>
+      <title>KB5009647: Setup Dynamic Update for Windows 10, version 20H2, 21H1, and 21H2: January
+        25, 2022 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 25 Jan 2022 22:02:40 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-screen-flickering-in-windows-f96b545d-a34c-40da-9115-378f78fbbbbf</link>
+      <title>Fix screen flickering in Windows - Microsoft Support</title>
+      <description>Get tips for how to fix screen flickering in Windows.</description>
+      <pubDate>Fri, 21 Jan 2022 17:38:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/account-billing/how-to-change-your-country-or-region-for-microsoft-store-and-more-e180415a-b4ad-7a9c-ef29-139bc71b1d09</link>
+      <title>How to change your country or region for Microsoft Store and more - Microsoft Support</title>
+      <description>How to change your country or region in Microsoft Store, Windows, and Xbox One.</description>
+      <pubDate>Fri, 21 Jan 2022 17:37:57 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/scan-a-document-or-picture-fa6a57d5-1f31-24e5-2a78-2fb0bb2c2d15</link>
+      <title>Scan a document or picture - Microsoft Support</title>
+      <description>Use your scanner and download an app from Microsoft Store to scan a document or
+        picture to your PC.</description>
+      <pubDate>Fri, 21 Jan 2022 17:37:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/watch-hd-videos-in-the-movies-tv-app-91aee316-d921-cb79-7e32-015815a61727</link>
+      <title>Watch HD videos in the Movies &amp; TV app - Microsoft Support</title>
+      <description>Watch HD videos in the Movies &amp; TV app</description>
+      <pubDate>Thu, 20 Jan 2022 22:25:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/multiple-desktops-in-windows-36f52e38-5b4a-557b-2ff9-e1a60c976434</link>
+      <title>Multiple desktops in Windows - Microsoft Support</title>
+      <description>Use multiple desktops in Windows to organize projects, or quickly switch between
+        desktops before a meeting.</description>
+      <pubDate>Wed, 19 Jan 2022 22:12:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/turn-on-device-encryption-0c453637-bc88-5f74-5105-741561aae838</link>
+      <title>Turn on device encryption - Microsoft Support</title>
+      <description>Learn how to turn on device encryption, or standard BitLocker encryption in
+        Windows.</description>
+      <pubDate>Fri, 14 Jan 2022 20:39:31 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-the-size-of-text-in-windows-1d5830c3-eee3-8eaa-836b-abcc37d99b9a</link>
+      <title>Change the size of text in Windows - Microsoft Support</title>
+      <description>Change the size of text in Windows using Settings or Magnifier.</description>
+      <pubDate>Fri, 14 Jan 2022 20:39:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/manage-display-language-settings-in-windows-219f28b0-9881-cd4c-75ca-dba919c52321</link>
+      <title>Manage display language settings in Windows - Microsoft Support</title>
+      <description>Get steps for how to select display language preferences in Windows.</description>
+      <pubDate>Fri, 14 Jan 2022 19:44:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/disk-cleanup-in-windows-8a96ff42-5751-39ad-23d6-434b4d5b9a68</link>
+      <title>Disk cleanup in Windows - Microsoft Support</title>
+      <description>Learn how to run a disk cleanup in Windows including deleting temporary and
+        system files to free up disk space.</description>
+      <pubDate>Fri, 14 Jan 2022 19:44:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/october-19-2021-kb5006744-os-build-17763-2268-preview-e043a8a3-901b-4190-bb6b-f5a4137411c0</link>
+      <title>October 19, 2021—KB5006744 (OS Build 17763.2268) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 12 Jan 2022 22:22:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/microsoft-edge/location-and-privacy-in-microsoft-edge-31b5d154-0b1b-90ef-e389-7c7d4ffe7b04</link>
+      <title>Location and privacy in Microsoft Edge - Microsoft Support</title>
+      <description>An overview of location permissions and your privacy in the Microsoft Edge web
+        browser.</description>
+      <pubDate>Tue, 11 Jan 2022 23:38:16 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5010265-adds-aes-encryption-protections-to-the-ms-lsad-protocol-for-cve-2022-21913-e466887c-2802-4bd8-b97f-ace25952b0b9</link>
+      <title>KB5010265 adds AES encryption protections to the MS-LSAD protocol for CVE-2022-21913 -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 11 Jan 2022 19:34:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5009497-security-update-for-windows-10-version-1607-for-rsat-january-11-2022-7eee1de6-4d5f-461a-98c4-7397843389fe</link>
+      <title>KB5009497: Security update for Windows 10, version 1607 for RSAT: January 11, 2022 -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 11 Jan 2022 18:05:33 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-connections-to-bluetooth-audio-devices-09ba2fb1-9472-9259-bd05-9306dd839f21</link>
+      <title>Fix connections to Bluetooth audio devices - Microsoft Support</title>
+      <description>Learn how to troubleshoot and fix Bluetooth audio connection issues in Windows 10
+        and 11.</description>
+      <pubDate>Mon, 10 Jan 2022 16:56:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-privacy-settings-in-windows-55466b7b-14de-c230-3ece-6b75557c5227</link>
+      <title>Change privacy settings in Windows - Microsoft Support</title>
+      <description>How to access and change the privacy settings in Windows 10 and 11.</description>
+      <pubDate>Thu, 06 Jan 2022 23:34:41 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/show-desktop-icons-in-windows-c13270f0-3812-c71d-f27e-29aa32588b20</link>
+      <title>Show desktop icons in Windows - Microsoft Support</title>
+      <description>How to display desktop icons in Windows.</description>
+      <pubDate>Thu, 06 Jan 2022 23:34:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-color-filters-in-windows-43893e44-b8b3-2e27-1a29-b0c15ef0e5ce</link>
+      <title>Use color filters in Windows - Microsoft Support</title>
+      <description>Use color filters to help see things on the screen more clearly.</description>
+      <pubDate>Thu, 06 Jan 2022 21:54:35 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/january-5-2022-kb5010195-os-build-14393-4827-out-of-band-c84b3071-ac6e-408d-b2a4-961e8a3e9c53</link>
+      <title>January 5, 2022—KB5010195 (OS Build 14393.4827) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 05 Jan 2022 22:07:45 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/see-all-your-apps-in-windows-fde6f576-0fc0-0813-6b0d-d3ec1d244c50</link>
+      <title>See all your apps in Windows - Microsoft Support</title>
+      <description>Learn how to view all of your installed apps and customize the Start menu or
+        taskbar in Windows.</description>
+      <pubDate>Tue, 04 Jan 2022 00:55:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb4564002-you-might-have-issues-on-windows-10-version-20h2-and-windows-10-version-2004-when-using-some-microsoft-imes-63696506-47d2-9997-0b72-41a68e328692</link>
+      <title>KB4564002: You might have issues on Windows 10, version 20H2 and Windows 10, version
+        2004 when using some Microsoft IMEs - Microsoft Support</title>
+      <description>Learn about issues, workarounds and resolutions for issues with Chinese and
+        Japanese IMEs.</description>
+      <pubDate>Sat, 18 Dec 2021 00:31:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/find-your-notifications-cccdb22c-bda9-5ad5-897d-897ac67f7e39</link>
+      <title>Find your notifications - Microsoft Support</title>
+      <description>Find app notifications from the taskbar in Windows 11, and in Windows 10, use
+        quick actions to change settings quickly as well.</description>
+      <pubDate>Sat, 18 Dec 2021 00:21:53 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-notification-settings-in-windows-8942c744-6198-fe56-4639-34320cf9444e</link>
+      <title>Change notification settings in Windows - Microsoft Support</title>
+      <description>Learn how to change app notifications, banners, and sound settings in Windows. </description>
+      <pubDate>Sat, 18 Dec 2021 00:21:18 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/low-disk-space-error-due-to-a-full-temp-folder-8eb375af-c5d4-22ac-3f3a-ac0a98382749</link>
+      <title>Low Disk Space error due to a full Temp folder - Microsoft Support</title>
+      <description>Steps to take if your Temp folder continually fills up with APPX files after
+        emptying it out.</description>
+      <pubDate>Fri, 17 Dec 2021 21:32:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/pin-apps-and-folders-to-the-desktop-or-taskbar-f3c749fb-e298-4cf1-adda-7fd635df6bb0</link>
+      <title>Pin apps and folders to the desktop or taskbar - Microsoft Support</title>
+      <description>In Windows 11, apps don't automatically get added to your desktop. Learn how to
+        pin apps to your desktop or taskbar in Windows 11 or Windows 10.</description>
+      <pubDate>Fri, 17 Dec 2021 21:19:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-set-up-and-test-microphones-in-windows-ba9a4aab-35d1-12ee-5835-cccac7ee87a4</link>
+      <title>How to set up and test microphones in Windows - Microsoft Support</title>
+      <description>Get tips for how to set up and test microphones in Windows.</description>
+      <pubDate>Fri, 17 Dec 2021 19:15:47 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/personalize-windows-colors-95fb6521-577a-f903-cc40-ac5a010f3466</link>
+      <title>Personalize Windows colors - Microsoft Support</title>
+      <description>Personalize Windows by choosing a Windows color, accent color, and more.</description>
+      <pubDate>Thu, 16 Dec 2021 19:51:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-new-themes-and-desktop-backgrounds-09e3e0a6-02e3-5ecd-22a1-5d048e3cb0d3</link>
+      <title>Get new themes and desktop backgrounds - Microsoft Support</title>
+      <description>Get new themes and desktop backgrounds in the Windows Settings app or in
+        Microsoft Store.</description>
+      <pubDate>Wed, 15 Dec 2021 23:47:10 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/find-all-your-apps-and-programs-cadb9c4b-459d-dfcb-2964-14aac1d7d964</link>
+      <title>Find all your apps and programs - Microsoft Support</title>
+      <description>Learn more about how to find all your apps and programs in the all new Windows
+        Start menu.</description>
+      <pubDate>Wed, 15 Dec 2021 22:45:43 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/pin-and-unpin-apps-to-the-start-menu-10c95188-5f75-bb6c-3fab-cfd678ac8476</link>
+      <title>Pin and unpin apps to the Start menu - Microsoft Support</title>
+      <description>Open the Start menu, then right-click the app you want to pin. Select Pin to
+        Start or Unpin from Start.</description>
+      <pubDate>Wed, 15 Dec 2021 22:43:58 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-help-with-clipboard-30375039-ce71-9fe4-5b30-21b7aab6b13f</link>
+      <title>Get help with clipboard - Microsoft Support</title>
+      <description>Learn how to troubleshoot and use the clipboard in Windows to paste multiple
+        items, pin items, and sync your clipboard to the cloud.</description>
+      <pubDate>Wed, 15 Dec 2021 19:54:18 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/clipboard-in-windows-c436501e-985d-1c8d-97ea-fe46ddf338c6</link>
+      <title>Clipboard in Windows - Microsoft Support</title>
+      <description>Learn how to use the cloud-based clipboard in Windows, share clipboard items
+        across your devices, and pin items to your clipboard menu.</description>
+      <pubDate>Wed, 15 Dec 2021 18:59:57 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-notification-and-quick-settings-in-windows-ddcbbcd4-0a02-f6e4-fe14-6766d850f294</link>
+      <title>Change notification and quick settings in Windows - Microsoft Support</title>
+      <description>Learn how to change your notification settings and quick actions using the
+        notification center in Windows.</description>
+      <pubDate>Wed, 15 Dec 2021 18:57:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/november-14-2021-kb5008601-os-build-14393-4771-out-of-band-c8cd33ce-3d40-4853-bee4-a7cc943582b9</link>
+      <title>November 14, 2021—KB5008601 (OS Build 14393.4771) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 14 Dec 2021 21:09:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-open-notification-center-and-quick-settings-f8dc196e-82db-5d67-f55e-ba5586fbb038</link>
+      <title>How to open Notification Center and Quick Settings - Microsoft Support</title>
+      <description>How to open Notification Center and Quick Settings</description>
+      <pubDate>Fri, 10 Dec 2021 00:46:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/turn-microsoft-defender-firewall-on-or-off-ec0844f7-aebd-0583-67fe-601ecf5d774f</link>
+      <title>Turn Microsoft Defender Firewall on or off - Microsoft Support</title>
+      <description>Get the steps for turning Windows Defender Firewall on or off.</description>
+      <pubDate>Thu, 09 Dec 2021 23:54:19 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/add-an-exclusion-to-windows-security-811816c0-4dfd-af4a-47e4-c301afe13b26</link>
+      <title>Add an exclusion to Windows Security - Microsoft Support</title>
+      <description>Find out how to stop Windows Security from alerting you about or blocking a
+        trusted file, file type, or process, by adding it to the exclusions list.</description>
+      <pubDate>Thu, 09 Dec 2021 23:49:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/customize-the-taskbar-notification-area-e159e8d2-9ac5-b2bd-61c5-bb63c1d437c3</link>
+      <title>Customize the taskbar notification area - Microsoft Support</title>
+      <description>Learn how to use the taskbar notification features in Windows.</description>
+      <pubDate>Thu, 09 Dec 2021 22:47:54 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/open-the-dictation-toolbar-2013a632-3a3f-230e-475d-4ad035ec0102</link>
+      <title>Open the dictation toolbar - Microsoft Support</title>
+      <description>Use the dictation toolbar to talk instead of type.</description>
+      <pubDate>Wed, 08 Dec 2021 22:03:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/activate-windows-11305dbc-ef5d-1c08-3ba7-4c7a2cb8f404</link>
+      <title>Activate Windows - Microsoft Support</title>
+      <description>To activate Windows 10, you need a digital license or a product key. Open the
+        Settings app, and then select Update &amp; Security &gt; Activation.</description>
+      <pubDate>Wed, 08 Dec 2021 21:50:21 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/set-up-dual-monitors-on-windows-3d5c15dc-cc63-d850-aeb6-b41778147554</link>
+      <title>Set up dual monitors on Windows - Microsoft Support</title>
+      <description>Get the steps for setting up dual monitors on your Windows PC.</description>
+      <pubDate>Wed, 08 Dec 2021 21:19:48 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/adjust-background-recording-settings-on-windows-c3e7fa75-817c-2d3f-c89e-08fc90ab6c72</link>
+      <title>Adjust background recording settings on Windows - Microsoft Support</title>
+      <description>When you turn on background recording, Xbox Game Bar keeps track of the last few
+        moments of gameplay so you can capture the magic before it’s gone forever.</description>
+      <pubDate>Wed, 08 Dec 2021 19:14:37 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-29-2021-kb5005393-os-build-14393-4532-out-of-band-97eb0e8c-3748-4570-af41-317aaa2d06ab</link>
+      <title>July 29, 2021—KB5005393 (OS Build 14393.4532) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 03 Dec 2021 22:10:12 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-keyboard-shortcuts-3d444b08-3a00-abd6-67da-ecfc07e86b98</link>
+      <title>Windows keyboard shortcuts - Microsoft Support</title>
+      <description>Get to know common Windows keyboard shortcuts including copy, cut, paste,
+        maximize a window, and more.</description>
+      <pubDate>Fri, 03 Dec 2021 19:40:27 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025</link>
+      <title>Turn high contrast mode on or off in Windows - Microsoft Support</title>
+      <description>Use the Settings app in Windows to turn high contrast mode or contrast themes on
+        or off.</description>
+      <pubDate>Fri, 03 Dec 2021 19:26:13 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5008575-asset-update-for-windows-10-version-2004-20h2-21h1-and-21h2-mixed-reality-november-16-2021-a45072c9-0b03-42c7-bba8-ae12d0d75e53</link>
+      <title>KB5008575: Asset update for Windows 10, version 2004, 20H2, 21H1, and 21H2 Mixed
+        Reality: November 16, 2021 - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 03 Dec 2021 01:10:41 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-21-2021-kb5005625-os-build-17763-2210-preview-5ae2f63d-a9ce-49dd-a5e6-e05b90dc1cd8</link>
+      <title>September 21, 2021—KB5005625 (OS Build 17763.2210) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 02 Dec 2021 23:10:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-27-2021-kb5005394-os-build-17763-2091-out-of-band-58863c8f-e514-47cc-b68e-14dbb883777f</link>
+      <title>July 27, 2021—KB5005394 (OS Build 17763.2091) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 02 Dec 2021 22:30:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-20-2021-kb5004308-os-build-17763-2090-preview-4dfbd8fd-ab65-4223-abdc-ee161bfa00cf</link>
+      <title>July 20, 2021—KB5004308 (OS Build 17763.2090) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 02 Dec 2021 22:27:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-13-2021-kb5004244-os-build-17763-2061-d2b763cb-fad4-4b0a-a67f-4e184e277b99</link>
+      <title>July 13, 2021—KB5004244 (OS Build 17763.2061) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 02 Dec 2021 22:22:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/july-6-2021-kb5004947-os-build-17763-2029-out-of-band-71994811-ff08-4abe-8986-8bd3a4201c5d</link>
+      <title>July 6, 2021—KB5004947 (OS Build 17763.2029) Out-of-band - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 02 Dec 2021 21:21:40 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/may-11-2021-kb5003171-os-build-17763-1935-3f03e74b-4759-4ca3-b9f1-4bc0d5ab5d27</link>
+      <title>May 11, 2021—KB5003171 (OS Build 17763.1935) - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 02 Dec 2021 21:12:08 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/april-22-2021-kb5001384-os-build-17763-1911-preview-e471f445-59be-42cb-8c57-5db644cbc698</link>
+      <title>April 22, 2021—KB5001384 (OS Build 17763.1911) Preview
+        - Microsoft Support</title>
+      <description />
+      <pubDate>Thu, 02 Dec 2021 21:09:00 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/make-your-mouse-keyboard-and-other-input-devices-easier-to-use-10733da7-fa82-88be-0672-f123d4b3dcfe</link>
+      <title>Make your mouse, keyboard, and other input devices easier to use - Microsoft Support</title>
+      <description>Learn how to use Windows accessibility features to make your mouse, keyboard, and
+        other input devices easier to use.</description>
+      <pubDate>Thu, 02 Dec 2021 13:47:29 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/make-windows-easier-to-hear-9c18cfdc-63be-2d47-0f4f-5b00facfd2e1</link>
+      <title>Make Windows easier to hear - Microsoft Support</title>
+      <description>Learn about Windows accessibility features that can help make your PC easier to
+        hear.</description>
+      <pubDate>Thu, 02 Dec 2021 10:45:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/open-the-on-screen-touchpad-2d402c64-949b-05ca-ebeb-978a6548d151</link>
+      <title>Open the on-screen touchpad - Microsoft Support</title>
+      <description>Learn how to open the on-screen touchpad in Windows 10.</description>
+      <pubDate>Thu, 25 Nov 2021 00:39:28 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/fix-touchpad-problems-in-windows-30b498e5-0caa-9740-2b21-336ea75ee756</link>
+      <title>Fix touchpad problems in Windows - Microsoft Support</title>
+      <description>Things to try to fix touchpad problems in Windows 10 and 11.</description>
+      <pubDate>Wed, 24 Nov 2021 20:41:00 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/connect-your-windows-pc-to-an-external-display-that-supports-miracast-765f5cfc-6ef3-fba7-98da-c8267b001a5a</link>
+      <title>Connect your Windows PC to an external display that supports Miracast - Microsoft
+        Support</title>
+      <description>Get steps for connecting a Miracast wireless display.</description>
+      <pubDate>Tue, 23 Nov 2021 21:07:59 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/windows-10-update-history-857b8ccb-71e4-49e5-b3f6-7073197d98fb</link>
+      <title>Windows 10 update history - Microsoft Support</title>
+      <description>Learn more about updates for Windows 10, version 21H2, including improvement and
+        fixes, any known issues, and how to get the update.</description>
+      <pubDate>Mon, 22 Nov 2021 22:04:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5007324-compatibility-update-for-installing-and-recovering-windows-10-version-2004-20h2-21h1-and-21h2-november-22-2021-9bb7d898-8d47-4341-82cd-ec53c300feee</link>
+      <title>KB5007324: Compatibility update for installing and recovering Windows 10, version 2004,
+        20H2, 21H1, and 21H2: November 22, 2021 - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 22 Nov 2021 22:02:55 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5007401-critical-dynamic-update-for-windows-10-version-2004-20h2-21h1-and-21h2-november-22-2021-0fd37674-0515-4666-85d5-acd71a6f985e</link>
+      <title>KB5007401: Critical Dynamic Update for Windows 10, version 2004, 20H2, 21H1, and 21H2:
+        November 22, 2021 - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 22 Nov 2021 22:02:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5007402-setup-dynamic-update-for-windows-10-version-2004-20h2-21h1-and-21h2-november-22-2021-0d108410-0e5d-49d8-b86d-ae3fecd969b5</link>
+      <title>KB5007402: Setup Dynamic Update for Windows 10, version 2004, 20H2, 21H1, and 21H2:
+        November 22, 2021 - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 22 Nov 2021 22:02:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5007267-cumulative-update-for-autopilot-in-windows-10-version-2004-20h2-21h1-and-21h2-november-19-2021-b0018a16-63c6-475a-b6a8-0dce41e9cec3</link>
+      <title>KB5007267: Cumulative update for Autopilot in Windows 10, version 2004, 20H2, 21H1, and
+        21H2: November 19, 2021 - Microsoft Support</title>
+      <description />
+      <pubDate>Mon, 22 Nov 2021 22:01:06 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-get-help-in-windows-711b6492-0435-0038-8706-7c6b0feb200a</link>
+      <title>How to get help in Windows - Microsoft Support</title>
+      <description>Search for help on the taskbar, use the Tips app, select the Get help link in the
+        Settings app, or go to support.microsoft.com/windows.</description>
+      <pubDate>Mon, 22 Nov 2021 21:35:27 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/september-21-2021-kb5005624-os-build-18363-1830-preview-b2a3af81-696b-4d59-8d7b-a05389407bb8</link>
+      <title>September 21, 2021—KB5005624 (OS Build 18363.1830) Preview - Microsoft Support</title>
+      <description />
+      <pubDate>Fri, 19 Nov 2021 22:51:36 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-the-movies-tv-app-with-narrator-a1bfca58-adab-969e-2693-f772e91187ae</link>
+      <title>Use the Movies &amp; TV app with Narrator - Microsoft Support</title>
+      <description>Learn about how to use the Movies &amp; TV app with Narrator, a built in screen
+        reader that reads text on your screen aloud and describes events.</description>
+      <pubDate>Thu, 18 Nov 2021 09:14:40 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5003791-update-to-windows-10-version-21h2-by-using-an-enablement-package-8bc077be-18d7-4aac-81ce-6f6dad2cd384</link>
+      <title>KB5003791: Update to Windows 10, version 21H2 by using an enablement package -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 17 Nov 2021 20:56:38 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/wi-fi-problems-and-your-home-layout-e1ed42e7-a3c5-d1be-2abb-e8fad00ad32a</link>
+      <title>Wi-Fi problems and your home layout - Microsoft Support</title>
+      <description>Learn how your home’s physical layout can affect Wi-Fi performance, and get
+        helpful tips on how to improve it.</description>
+      <pubDate>Wed, 17 Nov 2021 04:02:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/why-can-t-i-change-the-metered-connection-setting-e2bb7d6e-2bd3-1b50-ea9c-ef813f3f58cf</link>
+      <title>Why can’t I change the metered connection setting? - Microsoft Support</title>
+      <description>Learn how to change a data limit or troubleshoot a metered connection in Windows
+        10.</description>
+      <pubDate>Wed, 17 Nov 2021 04:01:22 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/view-display-settings-in-windows-37f0e05e-98a9-474c-317a-e85422daa8bb</link>
+      <title>View display settings in Windows - Microsoft Support</title>
+      <description>Learn how to use the Settings app to view and change display settings in Windows.</description>
+      <pubDate>Wed, 17 Nov 2021 04:00:41 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-an-esim-to-get-a-cellular-data-connection-on-your-windows-pc-0e255714-f8be-b9ef-9e84-f75b05ed98a3</link>
+      <title>Use an eSIM to get a cellular data connection on your Windows PC - Microsoft Support</title>
+      <description>Learn how to use an eSIM to connect your Windows PC to the internet over a
+        cellular data connection.</description>
+      <pubDate>Wed, 17 Nov 2021 03:59:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/tips-to-save-battery-power-in-windows-10-43b3e764-1f7d-4114-fc0a-80ea6359665e</link>
+      <title>Tips to save battery power in Windows 10 - Microsoft Support</title>
+      <description>Learn how to save battery power in Windows 10. Explore tips to make your battery
+        last longer on your Windows laptop or tablet.</description>
+      <pubDate>Wed, 17 Nov 2021 03:58:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/protect-your-pc-27ededb5-bf4d-83e9-c9a4-bb1f5ed640cc</link>
+      <title>Protect your PC - Microsoft Support</title>
+      <description>Learn how to protect your PC from viruses and other malicious software with
+        Windows Security.</description>
+      <pubDate>Wed, 17 Nov 2021 03:56:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/make-windows-easier-to-see-c97c2b0d-cadb-93f0-5fd1-59ccfe19345d</link>
+      <title>Make Windows easier to see - Microsoft Support</title>
+      <description>Learn how to make your Windows display easier to see using accessibility features
+        for ease of access.</description>
+      <pubDate>Wed, 17 Nov 2021 03:55:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/how-to-find-bluetooth-settings-in-windows-5027e93e-a6e8-4b4f-a412-c6c6cd6f57cc</link>
+      <title>How to find Bluetooth settings in Windows - Microsoft Support</title>
+      <description>Learn how to find and adjust Bluetooth settings and Bluetooth options in Windows.</description>
+      <pubDate>Wed, 17 Nov 2021 03:53:24 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-the-power-mode-for-your-windows-pc-c2aff038-22c9-f46d-5ca0-78696fdf2de8</link>
+      <title>Change the power mode for your Windows PC - Microsoft Support</title>
+      <description>Learn how to change the power mode on your Windows PC to preserve your battery,
+        limit notifications, and background activity.</description>
+      <pubDate>Wed, 17 Nov 2021 03:49:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/change-pen-settings-a53cd80e-4f89-ae30-d6da-389d630d89a3</link>
+      <title>Change pen settings - Microsoft Support</title>
+      <description>Learn how to pair a pen to your PC, change pen settings, and make the most out of
+        Windows Ink.</description>
+      <pubDate>Wed, 17 Nov 2021 03:48:52 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/add-or-change-a-vpn-connection-in-windows-3f65c113-33b4-6d80-059f-630aadb9284b</link>
+      <title>Add or change a VPN connection in Windows - Microsoft Support</title>
+      <description>Learn how to add or change a virtual private network (VPN) connection in Windows.</description>
+      <pubDate>Wed, 17 Nov 2021 03:47:26 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-camera-microphone-and-privacy-a83257bc-e990-d54a-d212-b5e41beba857</link>
+      <title>Windows camera, microphone, and privacy - Microsoft Support</title>
+      <description>Find out how to change privacy settings for your camera and microphone in
+        Windows.</description>
+      <pubDate>Thu, 11 Nov 2021 22:11:09 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/manage-app-permissions-for-your-camera-in-windows-87ebc757-1f87-7bbf-84b5-0686afb6ca6b</link>
+      <title>Manage app permissions for your camera in Windows - Microsoft Support</title>
+      <description>Learn how to give your Windows 10 PC permission to access your camera.</description>
+      <pubDate>Thu, 11 Nov 2021 22:01:42 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/use-a-screen-reader-to-record-your-screen-with-xbox-game-bar-5328cd25-9046-4472-8a14-c485f138802c</link>
+      <title>Use a screen reader to record your screen with Xbox Game Bar - Microsoft Support</title>
+      <description>Use the Xbox Game Bar and your screen reader to record and share your screen
+        events.</description>
+      <pubDate>Thu, 11 Nov 2021 13:50:49 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/get-help-with-windows-upgrade-and-installation-errors-ea144c24-513d-a60e-40df-31ff78b3158a</link>
+      <title>Get help with Windows upgrade and installation errors - Microsoft Support</title>
+      <description>See some of the most common upgrade and installation errors for Windows 10 and
+        Windows 11, and what you can do to try to fix them.</description>
+      <pubDate>Wed, 10 Nov 2021 16:37:17 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5000736-featured-update-to-windows-10-version-21h1-by-using-an-enablement-package-75a01e67-3b5f-4677-8efe-42852e41c7cf</link>
+      <title>KB5000736: Featured update to Windows 10, version 21H1 by using an enablement package -
+        Microsoft Support</title>
+      <description />
+      <pubDate>Wed, 10 Nov 2021 02:45:02 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/app-permissions-aea98a7c-b61a-1930-6ed0-47f0ed2ee15c</link>
+      <title>App permissions - Microsoft Support</title>
+      <description>Learn how to locate and manage your app permissions on Windows devices. Some apps
+        or games need specific permissions to work properly.</description>
+      <pubDate>Tue, 09 Nov 2021 20:50:51 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5007114-out-of-box-experience-update-for-windows-10-version-1909-november-9-2021-c8fd0adc-c391-447e-a62c-85f779e2dc4f</link>
+      <title>KB5007114: Out of Box Experience update for Windows 10, version 1909: November 9, 2021
+        - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 09 Nov 2021 18:05:04 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/open-the-camera-in-windows-8da044ed-c4a8-2fb4-da51-232362e4126d</link>
+      <title>Open the Camera in Windows - Microsoft Support</title>
+      <description>How to open the Camera app in Windows</description>
+      <pubDate>Tue, 02 Nov 2021 23:16:03 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5005322-some-devices-cannot-install-new-updates-after-installing-kb5003214-may-25-2021-and-kb5003690-june-21-2021-66edf7cf-5d3c-401f-bd32-49865343144f</link>
+      <title>KB5005322—Some devices cannot install new updates after installing KB5003214 (May 25,
+        2021) and KB5003690 (June 21, 2021) - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 02 Nov 2021 16:23:44 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5004926-download-windows-10-version-1909-monthly-security-updates-for-windows-10-enterprise-multi-session-version-1909-3f670ebe-d3f9-4b9e-af64-16c177612bc7</link>
+      <title>KB5004926—Download Windows 10, version 1909 monthly security updates for Windows 10
+        Enterprise Multi-Session, version 1909 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 02 Nov 2021 16:22:14 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/view-your-data-on-the-privacy-dashboard-03d3e27f-1981-5ff4-ba1c-d6b1031ae433</link>
+      <title>View your data on the privacy dashboard - Microsoft Support</title>
+      <description>Learn how to use the privacy dashboard in your Microsoft account and manage your
+        privacy settings for products you use.</description>
+      <pubDate>Thu, 28 Oct 2021 21:05:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-desktop-apps-and-privacy-8b3b13bc-d8ff-5460-8423-7d5d5c1f6665</link>
+      <title>Windows desktop apps and privacy - Microsoft Support</title>
+      <description>Learn how to protect your privacy when using desktop apps in Windows and find out
+        how they differ from Microsoft Store apps.</description>
+      <pubDate>Thu, 28 Oct 2021 21:05:07 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/browsing-history-on-the-privacy-dashboard-550e772a-04c9-3e9a-3ec0-762519df5e11</link>
+      <title>Browsing history on the privacy dashboard - Microsoft Support</title>
+      <description>Learn how to access, share, or clear your Microsoft search history through the
+        privacy dashboard.</description>
+      <pubDate>Thu, 28 Oct 2021 20:49:27 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-media-player-d10303a5-896c-2ce2-53d4-5bd5b9fd888b</link>
+      <title>Windows Media Player - Microsoft Support</title>
+      <description>Learn how to download and customize Windows Media Player. Get troubleshooting
+        help and how-to information for Windows Media Player 12.</description>
+      <pubDate>Wed, 27 Oct 2021 01:31:46 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/onedrive-video-project-syncing-in-photos-app-4176e59f-7120-084b-ed8e-3817a1deb34d</link>
+      <title>OneDrive video project syncing in Photos app - Microsoft Support</title>
+      <description>OneDrive video project syncing in the Photos app is no longer available. Learn
+        how to save your content in Windows 10 Photos app locally.</description>
+      <pubDate>Wed, 27 Oct 2021 01:29:25 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/photos-app-video-editor-error-can-t-view-this-file-type-173ae0be-2b7d-d413-589e-84ccca0de02e</link>
+      <title>Photos app Video Editor error: Can’t view this file type - Microsoft Support</title>
+      <description>Learn how to convert your photos if the Video Editor in the Photos app can't view
+        the file type.</description>
+      <pubDate>Wed, 27 Oct 2021 01:25:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/windows-essentials-2707b879-5004-4349-c4a4-e5900945f2a9</link>
+      <title>Windows Essentials - Microsoft Support</title>
+      <description>Windows Essentials reached end of support on January 10, 2017 and is no longer
+        available for download.</description>
+      <pubDate>Wed, 27 Oct 2021 01:25:50 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/downloads-for-windows-32490f9b-01ee-c13e-b2af-b5057c2d34e8</link>
+      <title>Downloads for Windows - Microsoft Support</title>
+      <description>Learn what you can download to personalize and protect your PC with Windows.</description>
+      <pubDate>Wed, 27 Oct 2021 01:24:39 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/windows/what-is-windows-hd-color-1afce12f-1f5a-88be-fcd8-bf16303a52f8</link>
+      <title>What is Windows HD Color? - Microsoft Support</title>
+      <description>Learn how Windows HD Color provides a more vivid picture with high dynamic range
+        (HDR) content on your Windows 10 PC.</description>
+      <pubDate>Tue, 26 Oct 2021 18:19:32 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5007115-out-of-box-experience-update-for-windows-10-version-2004-20h2-and-21h1-october-26-2021-80501622-01c4-4673-a074-c132791b386d</link>
+      <title>KB5007115: Out of Box Experience update for Windows 10, version 2004, 20H2, and 21H1:
+        October 26, 2021 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 26 Oct 2021 17:06:34 Z</pubDate>
+    </item>
+    <item>
+      <link>
+        https://support.microsoft.com/en-us/topic/kb5006748-compatibility-update-for-installing-and-recovering-windows-10-version-2004-20h2-and-21h1-october-26-2021-d4a89197-f026-440d-b97b-6d5354fcba53</link>
+      <title>KB5006748: Compatibility update for installing and recovering Windows 10, version 2004,
+        20H2, and 21H1: October 26, 2021 - Microsoft Support</title>
+      <description />
+      <pubDate>Tue, 26 Oct 2021 17:03:48 Z</pubDate>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
Link #224 

Fixes a optimistic check that an RSS channel will always have a link. This value is only used as an optional site URL.

So long as the feed has entries, the feed will be available to add.