### PR TITLE
Don't save new articles older than 3 months

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/AccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/AccountDelegate.kt
@@ -1,6 +1,7 @@
 package com.jocmp.capy
 
 import com.jocmp.capy.accounts.AddFeedResult
+import java.time.ZonedDateTime
 
 interface AccountDelegate {
     suspend fun addFeed(
@@ -11,7 +12,7 @@ interface AccountDelegate {
 
     suspend fun addStar(articleIDs: List<String>): Result<Unit>
 
-    suspend fun refresh(): Result<Unit>
+    suspend fun refresh(cutoffDate: ZonedDateTime? = null): Result<Unit>
 
     suspend fun removeStar(articleIDs: List<String>): Result<Unit>
 

--- a/capy/src/main/java/com/jocmp/capy/accounts/FeedbinAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/FeedbinAccountDelegate.kt
@@ -26,7 +26,6 @@ import com.jocmp.feedbinclient.UpdateSubscriptionRequest
 import com.jocmp.feedbinclient.pagingInfo
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import java.net.UnknownHostException
 import java.time.ZonedDateTime
@@ -181,7 +180,7 @@ internal class FeedbinAccountDelegate(
         }
     }
 
-    override suspend fun refresh(): Result<Unit> {
+    override suspend fun refresh(cutoffDate: ZonedDateTime?): Result<Unit> {
         val since = articleRecords.maxUpdatedAt()
 
         return try {

--- a/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
@@ -261,6 +261,10 @@ internal class ArticleRecords internal constructor(
             )
         }
     }
+
+    internal fun cutoffDate(): ZonedDateTime {
+        return nowUTC().minusMonths(3)
+    }
 }
 
 private fun mapLastRead(read: Boolean?, value: OffsetDateTime?): Long? {
@@ -269,8 +273,4 @@ private fun mapLastRead(read: Boolean?, value: OffsetDateTime?): Long? {
     }
 
     return null
-}
-
-private fun cutoffDate(): ZonedDateTime {
-    return nowUTC().minusMonths(3)
 }

--- a/capy/src/test/java/com/jocmp/capy/AccountTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/AccountTest.kt
@@ -24,7 +24,7 @@ class AccountTest {
     @Before
     fun setup() {
         account = AccountFixture.create(parentFolder = folder)
-        coEvery { account.delegate.refresh() }.returns(Result.success(Unit))
+        coEvery { account.delegate.refresh(any()) }.returns(Result.success(Unit))
     }
 
     @Test


### PR DESCRIPTION
If "Auto Delete" is enabled, ensure that the 3 month cutoff date is applied to refreshed feeds. This will prevent old articles from getting saved again.

Sample feed

- https://blog.ashampoo.com/de/rss