### PR TITLE
Fix coroutine scope in local account delegate

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/accounts/LocalAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/LocalAccountDelegate.kt
@@ -129,8 +129,8 @@ class LocalAccountDelegate(
     private suspend fun refreshFeeds(cutoffDate: ZonedDateTime?) {
         val feeds = feedRecords.feeds().firstOrNull() ?: return
 
-        feeds.forEach { feed ->
-            coroutineScope {
+        coroutineScope {
+            feeds.forEach { feed ->
                 launch {
                     feedFinder.fetch(feed.feedURL).onSuccess { channel ->
                         saveArticles(channel.items, cutoffDate = cutoffDate, feed = feed)


### PR DESCRIPTION
Link #278 

Fixes a bug where a new coroutine scope was opened for each feed refresh. Based on [a Baeldung article](https://www.baeldung.com/kotlin/parallel-coroutines) this meant the refresh still acted sequentially since each new `coroutineScope` is a blocking call.

The fix is to move the `coroutineScope` out of the each iteration. For the set of feeds I tried, this results in ~2x speedup from 13 seconds down to about 6 seconds.

### Before

![before](https://github.com/user-attachments/assets/1deda4f9-d3d2-4f90-b227-c411c483fd64)

### After

![after](https://github.com/user-attachments/assets/80dfd448-d650-4b16-8cf0-228f13ecb305)