### PR TITLE
Fetch starred articles before unread articles

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/accounts/FeedbinAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/FeedbinAccountDelegate.kt
@@ -186,8 +186,8 @@ internal class FeedbinAccountDelegate(
         return try {
             refreshFeeds()
             refreshTaggings()
-            refreshUnreadEntries()
             refreshStarredEntries()
+            refreshUnreadEntries()
             refreshAllArticles(since = since)
             fetchMissingArticles()
 


### PR DESCRIPTION
Link #306 

Fixes a bug where new starred articles were always fetched as unread. Instead, unread articles should be fetched after starred articles to sync the read state for both groups.