### PR TITLE
Fix bug for "Sept" abbreviated dates

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/common/DateTimeFormatters.kt
+++ b/capy/src/main/java/com/jocmp/capy/common/DateTimeFormatters.kt
@@ -1,0 +1,59 @@
+package com.jocmp.capy.common
+
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.format.SignStyle
+import java.time.temporal.ChronoField
+
+internal object DateTimeFormatters {
+    val LONG_MONTH_DATE_TIME_FORMATTER: DateTimeFormatter by lazy {
+        val dow = mapOf(
+            1L to "Mon",
+            2L to "Tue",
+            3L to "Wed",
+            4L to "Thu",
+            5L to "Fri",
+            6L to "Sat",
+            7L to "Sun",
+        )
+
+        val moy = mapOf(
+            1L to "Jan",
+            2L to "Feb",
+            3L to "Mar",
+            4L to "Apr",
+            5L to "May",
+            6L to "Jun",
+            7L to "Jul",
+            8L to "Aug",
+            9L to "Sept",
+            10L to "Oct",
+            11L to "Nov",
+            12L to "Dec",
+        )
+
+        DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .parseLenient()
+            .optionalStart()
+            .appendText(ChronoField.DAY_OF_WEEK, dow)
+            .appendLiteral(", ")
+            .optionalEnd()
+            .appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NOT_NEGATIVE)
+            .appendLiteral(' ')
+            .appendText(ChronoField.MONTH_OF_YEAR, moy)
+            .appendLiteral(' ')
+            .appendValue(ChronoField.YEAR, 4)
+            .appendLiteral(' ')
+            .appendValue(ChronoField.HOUR_OF_DAY, 2)
+            .appendLiteral(':')
+            .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+            .optionalStart()
+            .appendLiteral(':')
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+            .optionalEnd()
+            .appendLiteral(' ')
+            .appendOffset("+HHMM", "GMT")
+            .toFormatter()
+    }
+}

--- a/capy/src/main/java/com/jocmp/capy/common/TimeHelpers.kt
+++ b/capy/src/main/java/com/jocmp/capy/common/TimeHelpers.kt
@@ -1,29 +1,30 @@
 package com.jocmp.capy.common
 
+import com.jocmp.capy.common.DateTimeFormatters.LONG_MONTH_DATE_TIME_FORMATTER
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 
+val formatters = listOf(
+    DateTimeFormatter.ISO_ZONED_DATE_TIME,
+    DateTimeFormatter.RFC_1123_DATE_TIME,
+    LONG_MONTH_DATE_TIME_FORMATTER,
+)
+
 val String.toDateTime: ZonedDateTime?
     get() {
-        val dateTime = isoFormat(this) ?: rfc1123Format(this)
+        val dateTime = formatters.firstNotNullOfOrNull { formatter ->
+            parseOrNull(this, formatter)
+        }
 
         return dateTime?.withZoneSameInstant(ZoneOffset.UTC)
     }
 
-private fun isoFormat(dateTime: String): ZonedDateTime? {
+private fun parseOrNull(text: CharSequence, formatter: DateTimeFormatter): ZonedDateTime? {
     return try {
-        ZonedDateTime.parse(dateTime)
-    } catch (_: DateTimeParseException) {
-        null
-    }
-}
-
-private fun rfc1123Format(dateTime: String): ZonedDateTime? {
-    return try {
-        ZonedDateTime.parse(dateTime, DateTimeFormatter.RFC_1123_DATE_TIME)
+        ZonedDateTime.parse(text, formatter)
     } catch (_: DateTimeParseException) {
         null
     }

--- a/capy/src/test/java/com/jocmp/capy/common/TimeHelpersTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/common/TimeHelpersTest.kt
@@ -27,7 +27,7 @@ class TimeHelpersTest {
     }
 
     @Test
-    fun `parseISODate parses RFC822 timestamps`() {
+    fun `parseISODate parses RFC1123 timestamps`() {
         val result = "Mon, 25 Dec 2023 17:18:03 +0000".toDateTime
 
         val expected = ZonedDateTime.of(
@@ -43,6 +43,25 @@ class TimeHelpersTest {
 
         assertEquals(expected = expected, actual = result)
     }
+
+    @Test
+    fun `RFC1123 with 4 letter dates`(){
+        val result = "Thu, 05 Sept 2024 15:26:54 +0200".toDateTime
+
+        val expected = ZonedDateTime.of(
+            2024,
+            9,
+            5,
+            13,
+            26,
+            54,
+            0,
+            ZoneOffset.UTC
+        )
+
+        assertEquals(expected = expected, actual = result)
+    }
+
 
     @Test
     fun `parseISODate discards null values`() {


### PR DESCRIPTION
Adds a formatter to handle [tagesspiegel.de](https://www.tagesspiegel.de/contentexport/feed) which formats September dates with "Sept" instead of the RFC1123 standard 3 letter abbreviation of "Sep."