### PR TITLE
Account for "Z" offset in timestamps

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/common/DateTimeFormatters.kt
+++ b/capy/src/main/java/com/jocmp/capy/common/DateTimeFormatters.kt
@@ -56,4 +56,8 @@ internal object DateTimeFormatters {
             .appendOffset("+HHMM", "GMT")
             .toFormatter()
     }
+
+    val ZULU_DATE_TIME_FORMATTER: DateTimeFormatter by lazy {
+        DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z")
+    }
 }

--- a/capy/src/main/java/com/jocmp/capy/common/TimeHelpers.kt
+++ b/capy/src/main/java/com/jocmp/capy/common/TimeHelpers.kt
@@ -1,6 +1,7 @@
 package com.jocmp.capy.common
 
 import com.jocmp.capy.common.DateTimeFormatters.LONG_MONTH_DATE_TIME_FORMATTER
+import com.jocmp.capy.common.DateTimeFormatters.ZULU_DATE_TIME_FORMATTER
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
@@ -11,6 +12,7 @@ val formatters = listOf(
     DateTimeFormatter.ISO_ZONED_DATE_TIME,
     DateTimeFormatter.RFC_1123_DATE_TIME,
     LONG_MONTH_DATE_TIME_FORMATTER,
+    ZULU_DATE_TIME_FORMATTER,
 )
 
 val String.toDateTime: ZonedDateTime?

--- a/capy/src/test/java/com/jocmp/capy/common/TimeHelpersTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/common/TimeHelpersTest.kt
@@ -4,6 +4,7 @@ package com.jocmp.capy.common
 import org.junit.Test
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import kotlin.math.exp
 import kotlin.test.assertEquals
 
@@ -62,6 +63,23 @@ class TimeHelpersTest {
         assertEquals(expected = expected, actual = result)
     }
 
+    @Test
+    fun `RFC1123 with Z offset`() {
+        val result = "Fri, 30 Aug 2024 05:23:12 Z".toDateTime
+
+        val expected = ZonedDateTime.of(
+            2024,
+            8,
+            30,
+            5,
+            23,
+            12,
+            0,
+            ZoneOffset.UTC
+        )
+
+        assertEquals(expected = expected, actual = result)
+    }
 
     @Test
     fun `parseISODate discards null values`() {


### PR DESCRIPTION
Adds a formatter for dates such as "Tue, 03 Sep 2024 07:06:36 Z"

Link #353