### PR TITLE
Add support for brotli content encoding

### DIFF
--- a/capy/build.gradle.kts
+++ b/capy/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     implementation(libs.retrofit2.retrofit)
     implementation(libs.sqldelight.androidx.paging.extensions)
     implementation(libs.sqldelight.coroutines.extensions)
+    implementation(libs.okhttp.brotli)
     implementation(project(":feedbinclient"))
     implementation(project(":feedfinder"))
     implementation(project(":rssparser"))

--- a/capy/src/main/java/com/jocmp/capy/accounts/LocalOkHttpClient.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/LocalOkHttpClient.kt
@@ -5,12 +5,14 @@ import okhttp3.Cache
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
+import okhttp3.brotli.BrotliInterceptor
 import java.io.File
 import java.net.URI
 
 internal object LocalOkHttpClient {
     fun forAccount(path: URI): OkHttpClient {
         return OkHttpClient.Builder()
+            .addInterceptor(BrotliInterceptor)
             .addNetworkInterceptor(CacheInterceptor())
             .addInterceptor(UserAgentInterceptor())
             .cache(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ androidx-lifecycle-runtime = "2.8.5"
 androidx-adaptive = "1.1.0-alpha02"
 mockk = "1.13.12"
 navigation-compose = "2.8.0"
+okhttp = "4.12.0"
 paging-compose = "3.3.2"
 readability4j = "1.0.8"
 sqldelight = "2.0.2"
@@ -54,7 +55,8 @@ lazycolumnscrollbar = { module = "com.github.nanihadesuka:LazyColumnScrollbar", 
 moshi = { module = "com.squareup.moshi:moshi", version = "1.15.1" }
 moshi-converter = { module = "com.squareup.retrofit2:converter-moshi", version = "2.9.0" }
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version = "1.14.0" }
-okhttp-client = { module = "com.squareup.okhttp3:okhttp", version = "4.12.0" }
+okhttp-brotli = { module = "com.squareup.okhttp3:okhttp-brotli", version.ref = "okhttp" }
+okhttp-client = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 readability4j = { module = "net.dankito.readability4j:readability4j", version.ref = "readability4j" }
 retrofit2-retrofit = { module = "com.squareup.retrofit2:retrofit", version = "2.11.0" }
 sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }


### PR DESCRIPTION
Link #359

Fixes an issue where euronews.com may send "Content-Encoding: br." Previously this was not handled by the OkHttp Client.

- https://github.com/square/okhttp/tree/master/okhttp-brotli