### PR TITLE
Bugfix: don't upgrade protocol in feed finder

### DIFF
--- a/feedfinder/src/main/java/com/jocmp/feedfinder/DefaultRequest.kt
+++ b/feedfinder/src/main/java/com/jocmp/feedfinder/DefaultRequest.kt
@@ -13,7 +13,7 @@ import kotlin.coroutines.resumeWithException
 
 internal class DefaultRequest(private val client: OkHttpClient = OkHttpClient()) : Request {
     override suspend fun fetch(url: URL): Response {
-        val parsedURL = URL("https", url.host, url.port, url.file)
+        val parsedURL = URL(url.protocol, url.host, url.port, url.file)
 
         val request = okhttp3.Request.Builder()
             .url(parsedURL)


### PR DESCRIPTION
Fixes an issue where `http` was always changed to `https`.