### PR TITLE
Enable 'mark all read' offline

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
@@ -20,6 +20,7 @@ import com.jocmp.capy.MarkRead
 import com.jocmp.capy.articles.parseHtml
 import com.jocmp.capy.buildArticlePager
 import com.jocmp.capy.common.UnauthorizedError
+import com.jocmp.capy.common.launchIO
 import com.jocmp.capy.countAll
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -136,10 +137,12 @@ class ArticleScreenViewModel(
     }
 
     fun markAllRead(range: MarkRead) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launchIO {
             val articleIDs = account.unreadArticleIDs(filter = filter.value, range = range)
 
-            Sync.markReadAsync(articleIDs, context)
+            account.markAllRead(articleIDs).onFailure {
+                Sync.markReadAsync(articleIDs, context)
+            }
         }
     }
 

--- a/capy/src/main/java/com/jocmp/capy/accounts/LocalAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/LocalAccountDelegate.kt
@@ -126,16 +126,20 @@ class LocalAccountDelegate(
     }
 
     private suspend fun refreshFeeds(cutoffDate: ZonedDateTime?) {
-        val feeds = feedRecords.feeds().firstOrNull() ?: return
+        try {
+            val feeds = feedRecords.feeds().firstOrNull() ?: return
 
-        coroutineScope {
-            feeds.forEach { feed ->
-                launch {
-                    feedFinder.fetch(feed.feedURL).onSuccess { channel ->
-                        saveArticles(channel.items, cutoffDate = cutoffDate, feed = feed)
+            coroutineScope {
+                feeds.forEach { feed ->
+                    launch {
+                        feedFinder.fetch(feed.feedURL).onSuccess { channel ->
+                            saveArticles(channel.items, cutoffDate = cutoffDate, feed = feed)
+                        }
                     }
                 }
             }
+        } catch (e: Throwable) {
+            // continue
         }
     }
 


### PR DESCRIPTION
Fixes a bug where "mark all as read" always waits for the network to proceed. The fix is to mark read at the database level and retry for external feeds on network reconnect.

Link #411 