### PR TITLE
Catch all IO errors on refresh

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/accounts/FeedbinAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/FeedbinAccountDelegate.kt
@@ -27,6 +27,8 @@ import com.jocmp.feedbinclient.pagingInfo
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import okio.IOException
+import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.time.ZonedDateTime
 
@@ -179,7 +181,7 @@ internal class FeedbinAccountDelegate(
 
                 AddFeedResult.MultipleChoices(choices)
             }
-        } catch (e: UnknownHostException) {
+        } catch (e: IOException) {
             AddFeedResult.Failure(AddFeedError.NetworkError())
         }
     }
@@ -193,10 +195,10 @@ internal class FeedbinAccountDelegate(
             refreshArticles(since = since)
 
             Result.success(Unit)
-        } catch (exception: UnknownHostException) {
+        } catch (exception: IOException) {
             Result.failure(exception)
         } catch (e: UnauthorizedError) {
-            return Result.failure(e)
+            Result.failure(e)
         }
     }
 

--- a/capy/src/test/java/com/jocmp/capy/accounts/FeedbinAccountDelegateTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/FeedbinAccountDelegateTest.kt
@@ -29,6 +29,7 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Before
 import org.junit.Test
 import retrofit2.Response
+import java.net.SocketTimeoutException
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -136,6 +137,18 @@ class FeedbinAccountDelegateTest {
         assertEquals(expected = listOf(null, "Gadgets"), actual = taggedNames)
 
         assertEquals(expected = 1, actual = articles.size)
+    }
+
+    @Test
+    fun refreshAll_IOException() = runTest {
+        val networkError = SocketTimeoutException("Sorry networked charlie")
+        coEvery { feedbin.subscriptions() }.throws(networkError)
+
+        val delegate = FeedbinAccountDelegate(database, feedbin)
+
+        val result = delegate.refresh()
+
+        assertEquals(result, Result.failure(networkError))
     }
 
     @Test


### PR DESCRIPTION
Link #416 

Fixes a bug where flaky networks would raise an uncaught SocketTimeoutException.

The refresher was already handling unknown hosts errors which also extend the Java IOException class.