### PR TITLE
Fix 'mark read' bug on reverse read order

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,34 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />

--- a/app/src/main/java/com/capyreader/app/ui/articles/list/ArticleActionMenu.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/list/ArticleActionMenu.kt
@@ -1,20 +1,10 @@
 package com.capyreader.app.ui.articles.list
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -24,7 +14,6 @@ import com.jocmp.capy.MarkRead
 import com.jocmp.capy.MarkRead.After
 import com.jocmp.capy.MarkRead.Before
 import com.capyreader.app.R
-import kotlin.math.exp
 
 @Composable
 fun ArticleActionMenu(

--- a/capy/src/main/java/com/jocmp/capy/Account.kt
+++ b/capy/src/main/java/com/jocmp/capy/Account.kt
@@ -8,6 +8,7 @@ import com.jocmp.capy.accounts.LocalAccountDelegate
 import com.jocmp.capy.accounts.LocalOkHttpClient
 import com.jocmp.capy.accounts.Source
 import com.jocmp.capy.accounts.asOPML
+import com.jocmp.capy.articles.UnreadSortOrder
 import com.jocmp.capy.common.TimeHelpers.nowUTC
 import com.jocmp.capy.common.sortedByTitle
 import com.jocmp.capy.db.Database
@@ -147,10 +148,23 @@ data class Account(
         return delegate.removeStar(listOf(articleID))
     }
 
-    fun unreadArticleIDs(filter: ArticleFilter, range: MarkRead): List<String> {
+    fun unreadArticleIDs(
+        filter: ArticleFilter,
+        range: MarkRead,
+        unreadSort: UnreadSortOrder,
+    ): List<String> {
+        val flipRange = filter.status == ArticleStatus.UNREAD &&
+                unreadSort == UnreadSortOrder.OLDEST_FIRST
+
+        val orderedRange = if (flipRange) {
+            range.reversed()
+        } else {
+            range
+        }
+
         return articleRecords.unreadArticleIDs(
             filter = filter,
-            range = range
+            range = orderedRange,
         )
     }
 

--- a/capy/src/main/java/com/jocmp/capy/MarkRead.kt
+++ b/capy/src/main/java/com/jocmp/capy/MarkRead.kt
@@ -12,6 +12,14 @@ sealed class MarkRead {
 
     data class After(val articleID: String): MarkRead()
 
+    fun reversed(): MarkRead {
+        return when(this) {
+            is All -> All
+            is Before -> After(articleID)
+            is After -> Before(articleID)
+        }
+    }
+
     val toPair: Pair
         get() = when(this) {
             is After -> Pair(afterArticleID = articleID)

--- a/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
@@ -186,9 +186,6 @@ internal class ArticleRecords internal constructor(
         ): Query<Article> {
             val (read, starred) = status.toStatusPair
 
-            val newestFirst = status != ArticleStatus.UNREAD ||
-                    unreadSort == UnreadSortOrder.NEWEST_FIRST
-
             return database.articlesQueries.allByFeeds(
                 feedIDs = feedIDs,
                 query = query,
@@ -197,7 +194,7 @@ internal class ArticleRecords internal constructor(
                 limit = limit,
                 offset = offset,
                 lastReadAt = mapLastRead(read, since),
-                newestFirst = newestFirst,
+                newestFirst = isDescendingOrder(status, unreadSort),
                 mapper = ::listMapper
             )
         }
@@ -208,13 +205,14 @@ internal class ArticleRecords internal constructor(
             range: MarkRead,
         ): Query<String> {
             val (_, starred) = status.toStatusPair
+
             val (afterArticleID, beforeArticleID) = range.toPair
 
             return database.articlesQueries.findArticleIDsByFeeds(
                 feedIDs = feedIDs,
                 starred = starred,
                 afterArticleID = afterArticleID,
-                beforeArticleID = beforeArticleID
+                beforeArticleID = beforeArticleID,
             )
         }
 
@@ -292,6 +290,11 @@ internal class ArticleRecords internal constructor(
         return nowUTC().minusMonths(3)
     }
 }
+
+
+private fun isDescendingOrder(status: ArticleStatus, unreadSort: UnreadSortOrder) =
+    status != ArticleStatus.UNREAD ||
+            unreadSort == UnreadSortOrder.NEWEST_FIRST
 
 private fun mapLastRead(read: Boolean?, value: OffsetDateTime?): Long? {
     if (read != null) {

--- a/capy/src/test/java/com/jocmp/capy/AccountTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/AccountTest.kt
@@ -1,6 +1,7 @@
 package com.jocmp.capy
 
 import com.jocmp.capy.accounts.AutoDelete
+import com.jocmp.capy.articles.UnreadSortOrder
 import com.jocmp.capy.common.TimeHelpers.nowUTC
 import com.jocmp.capy.fixtures.AccountFixture
 import com.jocmp.capy.fixtures.ArticleFixture
@@ -47,5 +48,118 @@ class AccountTest {
 
         assertEquals(account.refresh(), Result.success(Unit))
         assertNotNull(account.database.reload(oldArticle))
+    }
+
+    @Test
+    fun unreadArticleIDs() = runTest {
+        val articleFixture = ArticleFixture(account.database)
+
+        articleFixture.create() // read article
+
+        val unreadArticleIDs = 3
+            .repeated { articleFixture.create(read = false) }
+            .map { it.id }
+
+        val ids = account.unreadArticleIDs(
+            filter = ArticleFilter.Articles(ArticleStatus.ALL),
+            range = MarkRead.All,
+            unreadSort = UnreadSortOrder.NEWEST_FIRST,
+        )
+
+        assertEquals(unreadArticleIDs, ids)
+    }
+
+    /**
+     * Take the following list from newest to oldest
+     * [3, 2, 1]
+     * Request articles before "2"
+     * [2, 1]
+     */
+    @Test
+    fun unreadArticleIDs_beforeID() = runTest {
+        val articleFixture = ArticleFixture(account.database)
+        val time = nowUTC().minusMonths(1)
+
+        val unreadArticleIDs = 3
+            .repeated { offset ->
+                articleFixture.create(
+                    read = false,
+                    publishedAt = time.minusDays(offset.toLong()).toEpochSecond()
+                )
+            }
+            .map { it.id }
+
+        val ids = account.unreadArticleIDs(
+            filter = ArticleFilter.Articles(ArticleStatus.UNREAD),
+            range = MarkRead.Before(unreadArticleIDs[1]),
+            unreadSort = UnreadSortOrder.NEWEST_FIRST,
+        )
+
+        val result = unreadArticleIDs.takeLast(2)
+
+        assertEquals(result, ids)
+    }
+
+    /**
+     * Take the following list from newest to oldest
+     * [3, 2, 1]
+     * Request articles after "2"
+     * [3, 2]
+     */
+    @Test
+    fun unreadArticleIDs_afterID() = runTest {
+        val articleFixture = ArticleFixture(account.database)
+        val time = nowUTC().minusMonths(1)
+
+        val unreadArticleIDs = 3
+            .repeated { offset ->
+                articleFixture.create(
+                    read = false,
+                    publishedAt = time.minusDays(offset.toLong()).toEpochSecond()
+                )
+            }
+            .map { it.id }
+
+        val ids = account.unreadArticleIDs(
+            filter = ArticleFilter.Articles(ArticleStatus.UNREAD),
+            range = MarkRead.After(unreadArticleIDs[1]),
+            unreadSort = UnreadSortOrder.NEWEST_FIRST,
+        )
+
+        val result = unreadArticleIDs.take(2)
+
+        assertEquals(result, ids)
+    }
+
+    /**
+     * Take the following list from oldest to newest
+     * [1, 2, 3]
+     * Request articles after "2"
+     * [2, 3]
+     */
+    @Test
+    fun unreadArticleIDs_byIDReversed() = runTest {
+        val articleFixture = ArticleFixture(account.database)
+        val time = nowUTC().minusMonths(1)
+
+        val unreadArticleIDs = 3
+            .repeated { offset ->
+                articleFixture.create(
+                    id = "${offset + 1}_${RandomUUID.generate()}",
+                    read = false,
+                    publishedAt = time.plusDays(offset.toLong()).toEpochSecond()
+                )
+            }
+            .map { it.id }
+
+        val ids = account.unreadArticleIDs(
+            filter = ArticleFilter.Articles(ArticleStatus.UNREAD),
+            range = MarkRead.Before(unreadArticleIDs[1]),
+            unreadSort = UnreadSortOrder.OLDEST_FIRST,
+        )
+
+        val result = unreadArticleIDs.takeLast(2)
+
+        assertEquals(result, ids)
     }
 }


### PR DESCRIPTION
Fixes an issue where tapping "Mark above as read" would mark the articles read in the opposite direction.