### PR TITLE
Add an option to enable or disable "Mark all as read" confirmation dialog

### DIFF
--- a/app/src/main/java/com/capyreader/app/common/AppPreferences.kt
+++ b/app/src/main/java/com/capyreader/app/common/AppPreferences.kt
@@ -111,6 +111,6 @@ class AppPreferences(context: Context) {
             get() = preferenceStore.getEnum("article_list_swipe_end", RowSwipeOption.default)
 
         val confirmMarkAllRead: Preference<Boolean>
-            get() = preferenceStore.getBoolean("article_list_mark_all_read_confirmation_enabled", true)
+            get() = preferenceStore.getBoolean("article_list_confirm_mark_all_read", true)
     }
 }

--- a/app/src/main/java/com/capyreader/app/common/AppPreferences.kt
+++ b/app/src/main/java/com/capyreader/app/common/AppPreferences.kt
@@ -109,5 +109,8 @@ class AppPreferences(context: Context) {
 
         val swipeEnd: Preference<RowSwipeOption>
             get() = preferenceStore.getEnum("article_list_swipe_end", RowSwipeOption.default)
+
+        val confirmMarkAllRead: Preference<Boolean>
+            get() = preferenceStore.getBoolean("article_list_mark_all_read_confirmation_enabled", true)
     }
 }

--- a/app/src/main/java/com/capyreader/app/ui/articles/list/MarkAllReadButton.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/list/MarkAllReadButton.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.res.stringResource
@@ -14,7 +15,8 @@ import com.capyreader.app.R
 fun MarkAllReadButton(
     onMarkAllRead: () -> Unit
 ) {
-    val state = rememberMarkAllReadState()
+    val confirmationEnabled by rememberMarkAllReadState()
+
     val (isDialogOpen, setDialogOpen) = remember {
         mutableStateOf(false)
     }
@@ -23,10 +25,15 @@ fun MarkAllReadButton(
         setDialogOpen(false)
     }
 
-    IconButton(onClick = { when(state.confirmationEnabled) {
-        true -> setDialogOpen(true)
-        false -> onMarkAllRead()
-    } }) {
+    IconButton(
+        onClick = {
+            if (confirmationEnabled) {
+                setDialogOpen(true)
+            } else {
+                onMarkAllRead()
+            }
+        }
+    ) {
         Icon(
             imageVector = Icons.Filled.CheckCircle,
             contentDescription = stringResource(R.string.action_mark_all_read)

--- a/app/src/main/java/com/capyreader/app/ui/articles/list/MarkAllReadButton.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/list/MarkAllReadButton.kt
@@ -14,6 +14,7 @@ import com.capyreader.app.R
 fun MarkAllReadButton(
     onMarkAllRead: () -> Unit
 ) {
+    val state = rememberMarkAllReadState()
     val (isDialogOpen, setDialogOpen) = remember {
         mutableStateOf(false)
     }
@@ -22,7 +23,10 @@ fun MarkAllReadButton(
         setDialogOpen(false)
     }
 
-    IconButton(onClick = { setDialogOpen(true) }) {
+    IconButton(onClick = { when(state.confirmationEnabled) {
+        true -> setDialogOpen(true)
+        false -> onMarkAllRead()
+    } }) {
         Icon(
             imageVector = Icons.Filled.CheckCircle,
             contentDescription = stringResource(R.string.action_mark_all_read)

--- a/app/src/main/java/com/capyreader/app/ui/articles/list/MarkAllReadState.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/list/MarkAllReadState.kt
@@ -1,0 +1,21 @@
+package com.capyreader.app.ui.articles.list
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import com.capyreader.app.common.AppPreferences
+import com.capyreader.app.common.asState
+import org.koin.compose.koinInject
+
+
+internal data class MarkAllReadState(
+    val confirmationEnabled: Boolean,
+)
+@Composable
+internal fun rememberMarkAllReadState(
+    appPreferences: AppPreferences = koinInject(),
+): MarkAllReadState {
+    val confirmationEnabled by appPreferences.articleListOptions.confirmMarkAllRead.asState()
+
+    return remember { MarkAllReadState(confirmationEnabled) }
+}

--- a/app/src/main/java/com/capyreader/app/ui/articles/list/MarkAllReadState.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/list/MarkAllReadState.kt
@@ -1,21 +1,14 @@
 package com.capyreader.app.ui.articles.list
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.State
 import com.capyreader.app.common.AppPreferences
 import com.capyreader.app.common.asState
 import org.koin.compose.koinInject
 
-
-internal data class MarkAllReadState(
-    val confirmationEnabled: Boolean,
-)
 @Composable
 internal fun rememberMarkAllReadState(
     appPreferences: AppPreferences = koinInject(),
-): MarkAllReadState {
-    val confirmationEnabled by appPreferences.articleListOptions.confirmMarkAllRead.asState()
-
-    return remember { MarkAllReadState(confirmationEnabled) }
+): State<Boolean> {
+    return appPreferences.articleListOptions.confirmMarkAllRead.asState()
 }

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/ArticleListSettings.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/ArticleListSettings.kt
@@ -61,7 +61,7 @@ fun ArticleListSettings(
             TextSwitch(
                 onCheckedChange = options.updateConfirmMarkAllRead,
                 checked = options.confirmMarkAllRead,
-                title = stringResource(R.string.settings_article_list_confirm_mark_all_read),
+                title = stringResource(R.string.settings_confirm_mark_all_read),
             )
         }
 

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/ArticleListSettings.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/ArticleListSettings.kt
@@ -26,11 +26,13 @@ data class ArticleListOptions(
     val showFeedName: Boolean,
     val showSummary: Boolean,
     val fontScale: ArticleListFontScale,
+    val confirmMarkAllRead: Boolean,
     val updateFeedIcons: (show: Boolean) -> Unit,
     val updateFeedName: (show: Boolean) -> Unit,
     val updateImagePreview: (preview: ImagePreview) -> Unit,
     val updateSummary: (show: Boolean) -> Unit,
     val updateFontScale: (scale: ArticleListFontScale) -> Unit,
+    val updateConfirmMarkAllRead: (confirm: Boolean) -> Unit,
 )
 
 @Composable
@@ -55,6 +57,11 @@ fun ArticleListSettings(
                 onCheckedChange = options.updateSummary,
                 checked = options.showSummary,
                 title = stringResource(R.string.settings_article_list_summary)
+            )
+            TextSwitch(
+                onCheckedChange = options.updateConfirmMarkAllRead,
+                checked = options.confirmMarkAllRead,
+                title = stringResource(R.string.settings_article_list_confirm_mark_all_read),
             )
         }
 
@@ -98,11 +105,13 @@ private fun ArticleListSettingsPreview() {
             showFeedIcons = true,
             fontScale = ArticleListFontScale.LARGE,
             showFeedName = false,
+            confirmMarkAllRead = true,
             updateImagePreview = {},
             updateSummary = {},
             updateFeedName = {},
             updateFeedIcons = {},
-            updateFontScale = {}
+            updateFontScale = {},
+            updateConfirmMarkAllRead = {},
         )
     )
 }

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/DisplaySettingsPanel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/DisplaySettingsPanel.kt
@@ -40,11 +40,13 @@ fun DisplaySettingsPanel(
             fontScale = viewModel.fontScale,
             showFeedIcons = viewModel.showFeedIcons,
             showFeedName = viewModel.showFeedName,
+            confirmMarkAllRead = viewModel.confirmMarkAllRead,
             updateImagePreview = viewModel::updateImagePreview,
             updateSummary = viewModel::updateSummary,
             updateFeedName = viewModel::updateFeedName,
             updateFeedIcons = viewModel::updateFeedIcons,
             updateFontScale = viewModel::updateFontScale,
+            updateConfirmMarkAllRead = viewModel::updateConfirmMarkAllRead,
         )
     )
 }
@@ -106,11 +108,13 @@ private fun DisplaySettingsPanelViewPreview() {
                 fontScale = ArticleListFontScale.MEDIUM,
                 showFeedIcons = true,
                 showFeedName = false,
+                confirmMarkAllRead = true,
                 updateImagePreview = {},
                 updateSummary = {},
                 updateFeedName = {},
                 updateFeedIcons = {},
-                updateFontScale = {}
+                updateFontScale = {},
+                updateConfirmMarkAllRead = {},
             )
         )
     }

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/DisplaySettingsViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/DisplaySettingsViewModel.kt
@@ -29,6 +29,9 @@ class DisplaySettingsViewModel(
     private val _showFeedIcons =
         mutableStateOf(appPreferences.articleListOptions.showFeedIcons.get())
 
+    private val _confirmMarkAllRead =
+        mutableStateOf(appPreferences.articleListOptions.confirmMarkAllRead.get())
+
     var fontScale by mutableStateOf(appPreferences.articleListOptions.fontScale.get())
         private set
 
@@ -46,6 +49,9 @@ class DisplaySettingsViewModel(
 
     val showFeedIcons: Boolean
         get() = _showFeedIcons.value
+
+    val confirmMarkAllRead: Boolean
+        get() = _confirmMarkAllRead.value
 
     var enableStickyFullContent by mutableStateOf(appPreferences.enableStickyFullContent.get())
         private set
@@ -102,5 +108,11 @@ class DisplaySettingsViewModel(
         appPreferences.articleListOptions.showFeedName.set(show)
 
         _showFeedName.value = show
+    }
+
+    fun updateConfirmMarkAllRead(confirm: Boolean) {
+        appPreferences.articleListOptions.confirmMarkAllRead.set(confirm)
+
+        _confirmMarkAllRead.value = confirm
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -189,4 +189,5 @@
     <string name="settings_notifications_select_all">Select All</string>
     <string name="article_list_row_swipe_open_externally">Open article in browser</string>
     <string name="article_view_open_externally">Open externally</string>
+    <string name="settings_article_list_confirm_mark_all_read">Confirm marking all as read</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -189,5 +189,5 @@
     <string name="settings_notifications_select_all">Select All</string>
     <string name="article_list_row_swipe_open_externally">Open article in browser</string>
     <string name="article_view_open_externally">Open externally</string>
-    <string name="settings_article_list_confirm_mark_all_read">Confirm marking all as read</string>
+    <string name="settings_confirm_mark_all_read">Confirm marking all as read</string>
 </resources>


### PR DESCRIPTION
Hello :wave: 

Thank you for the great app @jocmp!

I'd like to introduce one small options in the app settings to allow users enable or disable the "Mark all as read" confirmation dialog. By default this option is enabled (same as current behavior), but once the user disables it, the "Mark all as read" button will work silently, without asking user's confirmation.

Hope it makes sense to you and the code is good enough :)

Happy to change it if needed.

Cheers!


