### PR TITLE
Exclude rel=enclosure links from article URL detection

### DIFF
--- a/rssparser/src/main/kotlin/com/prof18/rssparser/internal/atom/AtomFeedHandler.kt
+++ b/rssparser/src/main/kotlin/com/prof18/rssparser/internal/atom/AtomFeedHandler.kt
@@ -98,6 +98,7 @@ internal class AtomFeedHandler(val atom: Element) : FeedHandler {
             Link.Edit.value,
             Link.Self.value,
             Link.Replies.value,
+            Link.Enclosure.value,
         )
     }
 }

--- a/rssparser/src/main/kotlin/com/prof18/rssparser/internal/atom/AtomKeyword.kt
+++ b/rssparser/src/main/kotlin/com/prof18/rssparser/internal/atom/AtomKeyword.kt
@@ -10,6 +10,7 @@ internal sealed class AtomKeyword(val value: String) {
         data object Edit : AtomKeyword("edit")
         data object Self : AtomKeyword("self")
         data object Replies : AtomKeyword("replies")
+        data object Enclosure : AtomKeyword("enclosure")
     }
 
     data object Subtitle : AtomKeyword("subtitle")


### PR DESCRIPTION
A small fix for the Atom feed parser.

I've noticed that articles that come from some sites, for example [RSS-Bridge](https://github.com/RSS-Bridge/rss-bridge), often contain links defined as `<link rel="enclosure">`. Such links are used [for large media resources](https://movabletype.org/documentation/developer/api/atom-feeds/element-link.html) (looks like an Atom's counterpart of [RSS enclosure](https://en.wikipedia.org/wiki/RSS_enclosure)) and erroneously get detected as article links. 

This PR is fixing the issue. Not sure if it doesn't break anything else but it shouldn't, given the nature of the "enclosure" keyword, and so far I haven't noticed any problems with my other feeds.

Maybe even better solution would be to prioritize, in order, "alternate", "via", "related" and only then "enclosure", but that would require a slightly bigger refactoring.

So, I hope this one works and doesn't cause troubles for the users :crossed_fingers: 