### PR TITLE
Add padding to reader when bars are pinned

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticlesModule.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticlesModule.kt
@@ -23,6 +23,7 @@ internal val articlesModule = module {
             context = get(),
             textSize = get<AppPreferences>().readerOptions.textSize,
             fontOption = get<AppPreferences>().readerOptions.fontFamily,
+            hideTopMargin = get<AppPreferences>().readerOptions.pinToolbars,
         )
     }
     viewModel {

--- a/capy/src/main/java/com/jocmp/capy/articles/ArticleRenderer.kt
+++ b/capy/src/main/java/com/jocmp/capy/articles/ArticleRenderer.kt
@@ -11,6 +11,7 @@ class ArticleRenderer(
     private val context: Context,
     private val textSize: Preference<TextSize>,
     private val fontOption: Preference<FontOption>,
+    private val hideTopMargin: Preference<Boolean>,
 ) {
     private val template by lazy {
         context.resources.openRawResource(CapyRes.raw.template)
@@ -33,7 +34,7 @@ class ArticleRenderer(
             "text_size" to textSize.get().slug,
             "font_family" to fontFamily.slug,
             "font_preload" to fontPreload(fontFamily),
-            "top_margin" to "64px"
+            "top_margin" to topMargin()
         )
 
         val html = MacroProcessor(
@@ -50,6 +51,14 @@ class ArticleRenderer(
         cleanLinks(document)
 
         return document.html()
+    }
+
+    private fun topMargin(): String {
+        return if (hideTopMargin.get()) {
+            "0px"
+        } else {
+            "64px"
+        }
     }
 
     private fun fontPreload(fontFamily: FontOption): String {


### PR DESCRIPTION
Link #460

<!-- pix table -->
<table>
<tr>
<th>Before</th>
<th>After</th>
</th>
</tr>
<tr>
<td valign="top">
<img src="https://github.com/user-attachments/assets/ad6e7102-08c1-4d36-957d-13a20a177a17">
</td>
<td valign="top">
<img src="https://github.com/user-attachments/assets/3e4c1c64-0c27-44cb-a094-427d04316c0d">
</td>
</tr>
</table>