### PR TITLE
i18n:fr fix below/after

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -137,8 +137,8 @@
     <string name="feed_action_unsubscribe_message">Voulez-vous vraiment vous désinscrire de \"%1$s\" ?</string>
     <string name="folder_action_edit">Renommer</string>
     <string name="settings_remove_account_button_local">Supprimer le compte</string>
-    <string name="article_actions_mark_below_as_read">Marquer au-dessus comme lus</string>
-    <string name="article_actions_mark_after_as_read">Marquer en-dessous comme lus</string>
+    <string name="article_actions_mark_below_as_read">Marquer ci-dessous comme lus</string>
+    <string name="article_actions_mark_after_as_read">Marquer ci-dessus comme lus</string>
     <string name="unauthorized_dialog_description">Un problème est apparu lors de la connexion à votre compte. Veuillez vous connecter à nouveau.</string>
     <string name="auth_fields_hide_password">Masquer le mot de passe</string>
     <string name="auth_fields_show_password">Afficher le mot de passe</string>


### PR DESCRIPTION
The French translation for below and after/above was reversed.

![image](https://github.com/user-attachments/assets/d1c99703-ebb6-42de-9a1f-8269774a1e22)
