### PR TITLE
Fix local time parser for non-US devices

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/common/TimeFormats.kt
+++ b/capy/src/main/java/com/jocmp/capy/common/TimeFormats.kt
@@ -22,9 +22,11 @@ internal object TimeFormats {
             DateTimeFormatter.ISO_ZONED_DATE_TIME,
             DateTimeFormatter.RFC_1123_DATE_TIME,
             DateTimeFormatter.ofPattern(RSS_1123_UK).withLocale(Locale.UK),
-        ) + patterns(DATETIME_PATTERNS)
+        ) + usPatterns(DATETIME_PATTERNS)
 
-    fun dateFormatters() = patterns(DATE_PATTERNS)
+    fun dateFormatters() = usPatterns(DATE_PATTERNS)
 
-    private fun patterns(list: List<String>) = list.map { DateTimeFormatter.ofPattern(it) }
+    private fun usPatterns(list: List<String>) = list.map {
+        DateTimeFormatter.ofPattern(it).withLocale(Locale.US)
+    }
 }

--- a/capy/src/test/java/com/jocmp/capy/common/TimeHelpersTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/common/TimeHelpersTest.kt
@@ -5,9 +5,18 @@ import org.junit.Test
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Locale
+import kotlin.test.AfterTest
 import kotlin.test.assertEquals
 
 class TimeHelpersTest {
+    private val defaultLocale = Locale.getDefault()
+
+    @AfterTest
+    fun teardown() {
+        Locale.setDefault(defaultLocale)
+    }
+
     @Test
     fun `parseISODate parses an offset ISO timestamp to UTC`() {
         val result = "2023-12-25T09:00:00-05:00".toDateTime
@@ -117,6 +126,46 @@ class TimeHelpersTest {
         assertEquals(expected = expected, actual = result)
     }
 
+
+    @Test
+    fun `RFC1123 with timezone abbreviation non-US locale`() {
+        Locale.setDefault(Locale("en", "AU"))
+
+        val result =  "Sun, 22 Dec 2024 08:18:56 EDT".toDateTime
+
+        val expected = ZonedDateTime.of(
+            2024,
+            12,
+            22,
+            13,
+            18,
+            56,
+            0,
+            ZoneOffset.UTC
+        )
+
+        assertEquals(expected = expected, actual = result)
+    }
+
+    @Test
+    fun `RFC1123 with timezone abbreviation non-English locale`() {
+        Locale.setDefault(Locale("es", "US"))
+
+        val result =  "Sun, 22 Dec 2024 08:18:56 EDT".toDateTime
+
+        val expected = ZonedDateTime.of(
+            2024,
+            12,
+            22,
+            13,
+            18,
+            56,
+            0,
+            ZoneOffset.UTC
+        )
+
+        assertEquals(expected = expected, actual = result)
+    }
 
     @Test
     fun `Date only`() {


### PR DESCRIPTION
Fixes a bug where the `DateTimeFormatter` locale changed based on the device. This change ensures that those locales are set to US so that the formatter doesn't reject the order.

Ref: https://github.com/jocmp/capyreader/issues/353#issuecomment-2560221310