### PR TITLE
Fix Cyrillic charset bug for local feeds

### DIFF
--- a/feedfinder/src/main/java/com/jocmp/feedfinder/DefaultRequest.kt
+++ b/feedfinder/src/main/java/com/jocmp/feedfinder/DefaultRequest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.CompletionHandler
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
 import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import java.io.IOException
 import java.net.URL
@@ -20,9 +21,14 @@ internal class DefaultRequest(private val client: OkHttpClient = OkHttpClient())
             .get()
             .build()
 
-        val body = client.newCall(request).await().body?.string().orEmpty()
+        val response = client.newCall(request).await()
+        val body = response.body?.string().orEmpty()
 
-        return Response(url = parsedURL, body = body)
+        return Response(
+            url = parsedURL,
+            body = body,
+            charset = response.header("content-type")?.toMediaType()?.charset()
+        )
     }
 }
 

--- a/feedfinder/src/main/java/com/jocmp/feedfinder/Response.kt
+++ b/feedfinder/src/main/java/com/jocmp/feedfinder/Response.kt
@@ -3,11 +3,16 @@ package com.jocmp.feedfinder
 import com.jocmp.feedfinder.parser.Feed
 import com.jocmp.feedfinder.parser.Parser
 import java.net.URL
+import java.nio.charset.Charset
 
-internal class Response(val url: URL, val body: String) {
+internal class Response(
+    val url: URL,
+    val body: String,
+    val charset: Charset?
+) {
     suspend fun parse(validate: Boolean = true): Parser.Result {
         if (parsed == null) {
-            parsed = Parser.parse(body, url = url, validate = validate)
+            parsed = Parser.parse(body, url = url, charset = charset, validate = validate)
         }
 
         return parsed!!

--- a/feedfinder/src/main/java/com/jocmp/feedfinder/parser/Parser.kt
+++ b/feedfinder/src/main/java/com/jocmp/feedfinder/parser/Parser.kt
@@ -4,13 +4,14 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import java.io.IOException
 import java.net.URL
+import java.nio.charset.Charset
 
 internal object Parser {
     class NotFeedError : Throwable()
 
     @Throws(NotFeedError::class)
-    suspend fun parse(body: String, url: URL, validate: Boolean): Result {
-        val xmlFeed = XMLFeed.from(url, body)
+    suspend fun parse(body: String, url: URL, charset: Charset?, validate: Boolean): Result {
+        val xmlFeed = XMLFeed.from(url, body = body, charset = charset)
 
         if (xmlFeed.isValid()) {
             return Result.ParsedFeed(xmlFeed)
@@ -38,7 +39,7 @@ internal object Parser {
     }
 
     sealed class Result {
-        class ParsedFeed(val feed: Feed): Result()
-        class HTMLDocument(val document: Document): Result()
+        class ParsedFeed(val feed: Feed) : Result()
+        class HTMLDocument(val document: Document) : Result()
     }
 }

--- a/feedfinder/src/main/java/com/jocmp/feedfinder/parser/XMLFeed.kt
+++ b/feedfinder/src/main/java/com/jocmp/feedfinder/parser/XMLFeed.kt
@@ -5,6 +5,7 @@ import com.jocmp.rssparser.RssParser
 import com.jocmp.rssparser.model.RssChannel
 import com.jocmp.rssparser.model.RssItem
 import java.net.URL
+import java.nio.charset.Charset
 
 internal class XMLFeed(
     override val feedURL: URL,
@@ -27,15 +28,10 @@ internal class XMLFeed(
     override val items: List<RssItem>
         get() = channel?.items.orEmpty()
 
-    private fun hasEntries(): Boolean {
-        return channel != null &&
-                channel.items.isNotEmpty()
-    }
-
     companion object {
-        suspend fun from(url: URL, body: String): XMLFeed {
+        suspend fun from(url: URL, body: String, charset: Charset?): XMLFeed {
             val channel = try {
-                RssParser().parse(body)
+                RssParser().parse(body, charset = charset)
             } catch (e: Exception) {
                 null
             }

--- a/feedfinder/src/test/java/com/jocmp/feedfinder/TestRequest.kt
+++ b/feedfinder/src/test/java/com/jocmp/feedfinder/TestRequest.kt
@@ -13,6 +13,6 @@ internal class TestRequest(val sites: Map<String, String>) : Request {
             File(bodyPath).readText()
         }
 
-        return Response(url = url, body = body)
+        return Response(url = url, body = body, charset = null)
     }
 }

--- a/feedfinder/src/test/java/com/jocmp/feedfinder/parser/XMLFeedTest.kt
+++ b/feedfinder/src/test/java/com/jocmp/feedfinder/parser/XMLFeedTest.kt
@@ -1,6 +1,5 @@
 package com.jocmp.feedfinder.parser
 
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import java.io.File
 import java.net.URL
@@ -13,7 +12,7 @@ class XMLFeedTest {
     fun isValid() = runTest {
         val responseBody = File("src/test/resources/arstechnica_feed.xml").readText()
 
-        val feed = XMLFeed.from(url = URL("https://arstechnica.com"), body = responseBody)
+        val feed = XMLFeed.from(url = URL("https://arstechnica.com"), body = responseBody, charset = null)
 
         assertTrue(feed.isValid())
     }
@@ -24,7 +23,8 @@ class XMLFeedTest {
 
         val feed = XMLFeed.from(
             url = URL("https://support.microsoft.com/en-us/feed/rss/6ae59d69-36fc-8e4d-23dd-631d98bf74a9"),
-            body = responseBody
+            body = responseBody,
+            charset = null,
         )
 
         assertTrue(feed.isValid())
@@ -37,7 +37,8 @@ class XMLFeedTest {
 
         val feed = XMLFeed.from(
             url = URL("https://www.brasildefato.com.br/rss2.xml"),
-            body = responseBody
+            body = responseBody,
+            charset = null,
         )
 
         assertTrue(feed.isValid())

--- a/feedfinder/src/test/java/com/jocmp/feedfinder/sources/BodyLinksTest.kt
+++ b/feedfinder/src/test/java/com/jocmp/feedfinder/sources/BodyLinksTest.kt
@@ -19,7 +19,9 @@ class BodyLinksTest {
     @Test
     fun `finds candidate links in the document body`() = runBlocking {
         val response = Response(
-            url = URL("https://example.com"), body = document
+            url = URL("https://example.com"),
+            body = document,
+            charset = null,
         )
 
         val sites = mapOf(
@@ -36,7 +38,9 @@ class BodyLinksTest {
     @Test
     fun `should skip HTML links`() = runBlocking {
         val response = Response(
-            url = URL("https://example.com"), body = document
+            url = URL("https://example.com"),
+            body = document,
+            charset = null,
         )
 
         val sites = mapOf(

--- a/feedfinder/src/test/java/com/jocmp/feedfinder/sources/GuessTest.kt
+++ b/feedfinder/src/test/java/com/jocmp/feedfinder/sources/GuessTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertEquals
 class GuessTest {
     @Test
     fun `should guess feed`() = runBlocking {
-        val response = Response(url = URL("https://example.com"), body = "")
+        val response = Response(url = URL("https://example.com"), body = "", charset = null)
 
         val sites = mapOf(
             "https://example.com/feed" to testResource("arstechnica_feed.xml")
@@ -28,7 +28,7 @@ class GuessTest {
 
     @Test
     fun `should guess rss`() = runBlocking {
-        val response = Response(url = URL("https://example.com"), body = "")
+        val response = Response(url = URL("https://example.com"), body = "", charset = null)
 
         val sites = mapOf(
             "https://example.com/rss" to testResource("arstechnica_feed.xml")

--- a/feedfinder/src/test/java/com/jocmp/feedfinder/sources/MetaLinksTest.kt
+++ b/feedfinder/src/test/java/com/jocmp/feedfinder/sources/MetaLinksTest.kt
@@ -1,13 +1,11 @@
 package com.jocmp.feedfinder.sources
 
-import com.jocmp.feedfinder.Request
 import com.jocmp.feedfinder.Response
 import com.jocmp.feedfinder.TestRequest
 import com.jocmp.feedfinder.testFile
 import com.jocmp.feedfinder.testResource
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
-import java.io.File
 import java.net.URL
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -18,7 +16,8 @@ class MetaLinksTest {
         val feedURL = "http://feeds.arstechnica.com/arstechnica/index"
         val response = Response(
             url = URL("https://arstechnica.com"),
-            body = testFile("arstechnica.html").readText()
+            body = testFile("arstechnica.html").readText(),
+            charset = null
         )
 
         val sites = mapOf(
@@ -38,7 +37,8 @@ class MetaLinksTest {
 
         val response = Response(
             url = URL("https://theverge.com"),
-            body = testFile("theverge.html").readText()
+            body = testFile("theverge.html").readText(),
+            charset = null,
         )
 
         val sites = mapOf(

--- a/feedfinder/src/test/java/com/jocmp/feedfinder/sources/XMLTest.kt
+++ b/feedfinder/src/test/java/com/jocmp/feedfinder/sources/XMLTest.kt
@@ -12,7 +12,7 @@ class XMLTest {
     fun `it parses from an XML source`() = runBlocking {
         val body = File("src/test/resources/arstechnica_feed.xml").readText()
 
-        val feeds = XML(Response(url = URL("https://arstechnica.com"), body = body)).find()
+        val feeds = XML(Response(url = URL("https://arstechnica.com"), body = body, charset = null)).find()
 
         assertEquals(expected = 1, actual = feeds.size)
     }

--- a/rssparser/src/main/kotlin/com/jocmp/rssparser/RssParser.kt
+++ b/rssparser/src/main/kotlin/com/jocmp/rssparser/RssParser.kt
@@ -7,6 +7,7 @@ import com.jocmp.rssparser.model.RssChannel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.withContext
+import java.nio.charset.Charset
 import kotlin.coroutines.CoroutineContext
 
 class RssParser internal constructor(
@@ -31,14 +32,15 @@ class RssParser internal constructor(
     /**
      * Parses an RSS feed provided by [rawRssFeed] and returns an [RssChannel]
      */
-    suspend fun parse(rawRssFeed: String): RssChannel = withContext(coroutineContext) {
-        val parserInput = generateParserInputFromString(rawRssFeed)
-        return@withContext parser.parse(parserInput)
-    }
+    suspend fun parse(rawRssFeed: String, charset: Charset? = null): RssChannel =
+        withContext(coroutineContext) {
+            val parserInput = generateParserInputFromString(rawRssFeed, charset)
+            return@withContext parser.parse(parserInput)
+        }
 
-    private fun generateParserInputFromString(rawRssFeed: String): ParserInput {
+    private fun generateParserInputFromString(rawRssFeed: String, charset: Charset?): ParserInput {
         val cleanedXml = rawRssFeed.trim()
-        val inputStream = cleanedXml.byteInputStream(Charsets.UTF_8)
-        return ParserInput.from(inputStream)
+        val inputStream = cleanedXml.byteInputStream(charset ?: Charsets.UTF_8)
+        return ParserInput.from(inputStream, charset)
     }
 }

--- a/rssparser/src/main/kotlin/com/jocmp/rssparser/internal/DefaultFetcher.kt
+++ b/rssparser/src/main/kotlin/com/jocmp/rssparser/internal/DefaultFetcher.kt
@@ -4,6 +4,7 @@ import com.jocmp.rssparser.exception.HttpException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
 import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.Response
 import java.io.IOException
@@ -33,8 +34,9 @@ internal class DefaultFetcher(
                 override fun onResponse(call: Call, response: Response) {
                     if (response.isSuccessful) {
                         val body = requireNotNull(response.body)
+                        val charset = response.header("content-type")?.toMediaType()?.charset()
                         continuation.resume(
-                            ParserInput(body.bytes())
+                            ParserInput(body.bytes(), charset = charset)
                         )
                     } else {
                         val exception = HttpException(

--- a/rssparser/src/main/kotlin/com/jocmp/rssparser/internal/ParserInput.kt
+++ b/rssparser/src/main/kotlin/com/jocmp/rssparser/internal/ParserInput.kt
@@ -1,11 +1,13 @@
 package com.jocmp.rssparser.internal
 
 import java.io.InputStream
+import java.nio.charset.Charset
 
-internal class ParserInput(private val bytes: ByteArray) {
+internal class ParserInput(private val bytes: ByteArray, val charset: Charset?) {
     fun inputStream() = bytes.inputStream()
 
     companion object {
-        fun from(inputStream: InputStream) = ParserInput(inputStream.readBytes())
+        fun from(inputStream: InputStream, charset: Charset?) =
+            ParserInput(inputStream.readBytes(), charset = charset)
     }
 }

--- a/rssparser/src/test/kotlin/com/jocmp/rssparser/TestUtils.kt
+++ b/rssparser/src/test/kotlin/com/jocmp/rssparser/TestUtils.kt
@@ -8,5 +8,5 @@ internal fun readFileFromResources(
 ): ParserInput {
     val file = File("src/test/resources/$resourceName")
 
-    return ParserInput(file.readBytes())
+    return ParserInput(file.readBytes(), charset = null)
 }


### PR DESCRIPTION
Ref #640 

Ensures that the response content type is used when parsing local feeds to avoid parsing charsets like windows-1252 as UTF-8.