### PR TITLE
Don't reselect feed if selected

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/FolderRow.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/FolderRow.kt
@@ -73,7 +73,7 @@ fun FolderRow(
                         FeedRow(
                             feed = feed,
                             onSelect = { onFeedSelect(feed) },
-                            selected = filter.isFeedSelected(feed, folderTitle = folder.title),
+                            selected = filter.isFeedSelected(feed),
                         )
                     }
                 }

--- a/capy/src/main/java/com/jocmp/capy/ArticleFilter.kt
+++ b/capy/src/main/java/com/jocmp/capy/ArticleFilter.kt
@@ -8,8 +8,8 @@ sealed class ArticleFilter(open val status: ArticleStatus) {
         return this is Folders && this.folderTitle == folder.title
     }
 
-    fun isFeedSelected(feed: Feed, folderTitle: String? = null): Boolean {
-        return this is Feeds && this.feedID == feed.id && this.folderTitle == folderTitle
+    fun isFeedSelected(feed: Feed): Boolean {
+        return this is Feeds && this.feedID == feed.id && this.folderTitle.orEmpty() == feed.folderName
     }
 
     fun hasArticlesSelected(): Boolean {


### PR DESCRIPTION
Solves bug where reselecting a feed triggers the "open" fade animation.