### PR TITLE
Construct window origin for WebView

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/components/WebView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/components/WebView.kt
@@ -32,6 +32,7 @@ import com.capyreader.app.ui.articles.detail.articleTemplateColors
 import com.capyreader.app.ui.articles.detail.byline
 import com.jocmp.capy.Article
 import com.jocmp.capy.articles.ArticleRenderer
+import com.jocmp.capy.common.windowOrigin
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -158,11 +159,11 @@ class WebViewState(
 
                 withContext(Dispatchers.Main) {
                     webView.loadDataWithBaseURL(
-                        article.url?.toString(),
+                        windowOrigin(article.url),
                         html,
                         null,
                         "UTF-8",
-                        null
+                        null,
                     )
                 }
             }

--- a/capy/src/main/java/com/jocmp/capy/common/WindowOrigin.kt
+++ b/capy/src/main/java/com/jocmp/capy/common/WindowOrigin.kt
@@ -1,0 +1,21 @@
+package com.jocmp.capy.common
+
+import java.net.MalformedURLException
+import java.net.URL
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/API/Window/origin
+ *
+ * Returns the URL's scheme/host/port
+ */
+fun windowOrigin(url: URL?): String? {
+    if (url == null || !(url.protocol == "http" || url.protocol == "https")) {
+        return null
+    }
+
+    return try {
+        URL(url.protocol, url.host, url.port, "", null).toString()
+    } catch (e: MalformedURLException) {
+        null
+    }
+}

--- a/capy/src/test/java/com/jocmp/capy/common/WindowOriginTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/common/WindowOriginTest.kt
@@ -1,0 +1,43 @@
+package com.jocmp.capy.common
+
+import java.net.URL
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class WindowOriginTest {
+    @Test
+    fun `with an null URL`() {
+        val result = windowOrigin(null)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `with a valid URL`() {
+        val result = windowOrigin(URL("https://developer.mozilla.org/en-US/docs/Web/API/Window/origin"))
+
+        assertEquals(expected = "https://developer.mozilla.org", actual = result)
+    }
+
+    @Test
+    fun `with an HTTP URL`() {
+        val result = windowOrigin(URL("http://developer.mozilla.org/en-US/docs/Web/API/Window/origin"))
+
+        assertEquals(expected = "http://developer.mozilla.org", actual = result)
+    }
+
+    @Test
+    fun `with an explicit port`() {
+        val result = windowOrigin(URL("https://example.com:3000"))
+
+        assertEquals(expected = "https://example.com:3000", actual = result)
+    }
+
+    @Test
+    fun `with a non-HTTP scheme`() {
+        val result = windowOrigin(URL("file:///Users/test/my.html"))
+
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
Ref #659 

Prevents an issue where article URLs don't reroute since the current page matches the title link.

This also attempts to preserve the window.origin handling that's necessary to avoid cross-origin errors when loading strict site assets.