### PR TITLE
Simplify User-Agent header

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/UserAgentInterceptor.kt
+++ b/capy/src/main/java/com/jocmp/capy/UserAgentInterceptor.kt
@@ -3,7 +3,6 @@ package com.jocmp.capy
 import okhttp3.Interceptor
 import okhttp3.Interceptor.Chain
 import okhttp3.Response
-import okhttp3.internal.userAgent as OkHttpUserAgent
 
 class UserAgentInterceptor : Interceptor {
     override fun intercept(chain: Chain): Response {
@@ -15,6 +14,6 @@ class UserAgentInterceptor : Interceptor {
     }
 
     companion object {
-        const val USER_AGENT = "CapyReader (RSS Reader https://capyreader.com/) $OkHttpUserAgent"
+        const val USER_AGENT = "CapyReader (RSS Reader; https://capyreader.com/)"
     }
 }


### PR DESCRIPTION
Attempt to avoid bad bot detection by removing the okhttp suffix.