### PR TITLE
Support specifying a client certificate for mTLS auth

### DIFF
--- a/app/src/main/java/com/capyreader/app/CommonModule.kt
+++ b/app/src/main/java/com/capyreader/app/CommonModule.kt
@@ -1,10 +1,12 @@
 package com.capyreader.app
 
+import com.capyreader.app.common.AndroidClientCertManager
 import com.capyreader.app.common.AndroidDatabaseProvider
 import com.capyreader.app.common.AppFaviconFetcher
-import com.capyreader.app.preferences.AppPreferences
 import com.capyreader.app.common.SharedPreferenceStoreProvider
+import com.capyreader.app.preferences.AppPreferences
 import com.jocmp.capy.AccountManager
+import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.DatabaseProvider
 import com.jocmp.capy.PreferenceStoreProvider
 import org.koin.android.ext.koin.androidContext
@@ -13,14 +15,15 @@ import org.koin.dsl.module
 internal val common = module {
     single<PreferenceStoreProvider> { SharedPreferenceStoreProvider(get()) }
     single<DatabaseProvider> { AndroidDatabaseProvider(context = get()) }
+    single<ClientCertManager> { AndroidClientCertManager(context = get()) }
     single {
         AccountManager(
-            context = get(),
             rootFolder = androidContext().filesDir.toURI(),
             databaseProvider = get(),
             cacheDirectory = androidContext().cacheDir.toURI(),
             preferenceStoreProvider = get(),
-            faviconFetcher = AppFaviconFetcher(get())
+            faviconFetcher = AppFaviconFetcher(get()),
+            clientCertManager = get(),
         )
     }
     single { AppPreferences(get()) }

--- a/app/src/main/java/com/capyreader/app/CommonModule.kt
+++ b/app/src/main/java/com/capyreader/app/CommonModule.kt
@@ -15,6 +15,7 @@ internal val common = module {
     single<DatabaseProvider> { AndroidDatabaseProvider(context = get()) }
     single {
         AccountManager(
+            context = get(),
             rootFolder = androidContext().filesDir.toURI(),
             databaseProvider = get(),
             cacheDirectory = androidContext().cacheDir.toURI(),

--- a/app/src/main/java/com/capyreader/app/common/AndroidClientCertManager.kt
+++ b/app/src/main/java/com/capyreader/app/common/AndroidClientCertManager.kt
@@ -1,0 +1,59 @@
+package com.capyreader.app.common
+
+import android.app.Activity
+import android.content.Context
+import android.security.KeyChain
+import com.jocmp.capy.ClientCertManager
+import okhttp3.internal.platform.Platform
+import java.net.Socket
+import java.security.Principal
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509KeyManager
+
+class AndroidClientCertManager(private val context: Context) : ClientCertManager {
+
+    override fun chooseClientCert(activity: Activity, onAliasChosen: (String) -> Unit) {
+        KeyChain.choosePrivateKeyAlias(activity, { alias ->
+            onAliasChosen(alias ?: "")
+        }, null, null, null, null)
+    }
+
+    override fun buildSslSocketFactory(clientCertAlias: String): ClientCertManager.ClientSSlSocketFactory {
+        val clientKeyManager = object : X509KeyManager {
+            override fun getClientAliases(keyType: String?, issuers: Array<Principal>?) =
+                throw UnsupportedOperationException("getClientAliases")
+
+            override fun chooseClientAlias(
+                keyType: Array<String>?,
+                issuers: Array<Principal>?,
+                socket: Socket?
+            ) = clientCertAlias
+
+            override fun getServerAliases(keyType: String?, issuers: Array<Principal>?) =
+                throw UnsupportedOperationException("getServerAliases")
+
+            override fun chooseServerAlias(
+                keyType: String?,
+                issuers: Array<Principal>?,
+                socket: Socket?
+            ) = throw UnsupportedOperationException("chooseServerAlias")
+
+            override fun getCertificateChain(alias: String?): Array<X509Certificate>? {
+                return if (alias == clientCertAlias) KeyChain.getCertificateChain(context, clientCertAlias) else null
+            }
+
+            override fun getPrivateKey(alias: String?): PrivateKey? {
+                return if (alias == clientCertAlias) KeyChain.getPrivateKey(context, clientCertAlias) else null
+            }
+        }
+
+        val sslContext = SSLContext.getInstance("TLS")
+        val trustManager = Platform.get().platformTrustManager()
+        sslContext.init(arrayOf(clientKeyManager), arrayOf(trustManager), null)
+        val sslSocketFactory = sslContext.socketFactory
+
+        return ClientCertManager.ClientSSlSocketFactory(sslSocketFactory, trustManager)
+    }
+}

--- a/app/src/main/java/com/capyreader/app/ui/accounts/AuthFields.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/AuthFields.kt
@@ -13,9 +13,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.RemoveCircleOutline
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme.colorScheme
@@ -31,6 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.AutofillType.EmailAddress
 import androidx.compose.ui.autofill.AutofillType.Password
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -58,6 +61,7 @@ fun AuthFields(
     prompt: (@Composable () -> Unit)? = null,
     source: Source,
     onChooseClientCert: () -> Unit = {},
+    onClearClientCert: () -> Unit = {},
     clientCertAlias: String,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -149,6 +153,7 @@ fun AuthFields(
         if (source.hasCustomURL) {
             CertificateField(
                 onChooseClientCert = onChooseClientCert,
+                onClearClientCert = onClearClientCert,
                 certAlias = clientCertAlias,
             )
         }
@@ -171,9 +176,11 @@ fun AuthFields(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CertificateField(
     onChooseClientCert: () -> Unit,
+    onClearClientCert: () -> Unit,
     certAlias: String,
 ) {
     TextField(
@@ -184,8 +191,18 @@ fun CertificateField(
             Text(stringResource(R.string.auth_fields_client_certificate))
         },
         modifier = Modifier
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .focusProperties { canFocus = false },
         readOnly = true,
+        trailingIcon = {
+            if (certAlias.isNotBlank()) {
+                IconButton(
+                    onClick = onClearClientCert
+                ) {
+                    Icon(imageVector = Icons.Filled.RemoveCircleOutline, stringResource(R.string.auth_fields_remove_client_cert))
+                }
+            }
+        },
         interactionSource = remember { MutableInteractionSource() }
             .also { interactionSource ->
                 LaunchedEffect(interactionSource) {
@@ -233,7 +250,7 @@ private fun AuthFieldsPreview() {
             onSubmit = {},
             username = "test@example.com",
             password = "its a secret to everyone",
-            clientCertAlias = "test",
+            clientCertAlias = "test certificate",
             loading = true,
             source = Source.FRESHRSS,
         )

--- a/app/src/main/java/com/capyreader/app/ui/accounts/AuthFields.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/AuthFields.kt
@@ -1,6 +1,8 @@
 package com.capyreader.app.ui.accounts
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,7 +22,9 @@ import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -53,6 +57,8 @@ fun AuthFields(
     errorMessage: String? = null,
     prompt: (@Composable () -> Unit)? = null,
     source: Source,
+    onChooseClientCert: () -> Unit = {},
+    clientCertAlias: String,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -140,6 +146,12 @@ fun AuthFields(
                 }
             }
         )
+        if (source.hasCustomURL) {
+            CertificateField(
+                onChooseClientCert = onChooseClientCert,
+                certAlias = clientCertAlias,
+            )
+        }
         errorMessage?.let { message ->
             ErrorAlert(message = message)
         }
@@ -157,6 +169,34 @@ fun AuthFields(
 
         prompt?.invoke()
     }
+}
+
+@Composable
+fun CertificateField(
+    onChooseClientCert: () -> Unit,
+    certAlias: String,
+) {
+    TextField(
+        value = certAlias,
+        onValueChange = {},
+        singleLine = true,
+        label = {
+            Text(stringResource(R.string.auth_fields_client_certificate))
+        },
+        modifier = Modifier
+            .fillMaxWidth(),
+        readOnly = true,
+        interactionSource = remember { MutableInteractionSource() }
+            .also { interactionSource ->
+                LaunchedEffect(interactionSource) {
+                    interactionSource.interactions.collect {
+                        if (it is PressInteraction.Release) {
+                            onChooseClientCert()
+                        }
+                    }
+                }
+            }
+    )
 }
 
 @Composable
@@ -189,13 +229,13 @@ private val Source.usernameKey
 private fun AuthFieldsPreview() {
     CapyTheme {
         AuthFields(
-            onUsernameChange = {},
             onPasswordChange = {},
             onSubmit = {},
             username = "test@example.com",
             password = "its a secret to everyone",
+            clientCertAlias = "test",
             loading = true,
-            source = Source.FRESHRSS
+            source = Source.FRESHRSS,
         )
     }
 }

--- a/app/src/main/java/com/capyreader/app/ui/accounts/LoginModule.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/LoginModule.kt
@@ -14,12 +14,14 @@ val loginModule = module {
         LoginViewModel(
             handle = get(),
             accountManager = get(),
-            appPreferences = get()
+            appPreferences = get(),
+            clientCertManager = get(),
         )
     }
     viewModel {
         UpdateLoginViewModel(
-            account = get()
+            account = get(),
+            clientCertManager = get(),
         )
     }
 }

--- a/app/src/main/java/com/capyreader/app/ui/accounts/LoginScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/LoginScreen.kt
@@ -1,7 +1,7 @@
 package com.capyreader.app.ui.accounts
 
+import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -10,19 +10,21 @@ fun LoginScreen(
     onNavigateBack: () -> Unit,
     onSuccess: () -> Unit,
 ) {
-    val context = LocalContext.current
+    val activity = LocalActivity.current
     LoginView(
         source = viewModel.source,
         onUsernameChange = viewModel::setUsername,
         onPasswordChange = viewModel::setPassword,
         onUrlChange = viewModel::setURL,
-        onClientCertAliasChange = viewModel::setClientCertAlias,
         onSubmit = {
-            viewModel.submit(context) {
+            viewModel.submit {
                 onSuccess()
             }
         },
         onNavigateBack = onNavigateBack,
+        onChooseClientCert = {
+            activity?.let(viewModel::chooseClientCert)
+        },
         url = viewModel.url,
         clientCertAlias = viewModel.clientCertAlias,
         username = viewModel.username,

--- a/app/src/main/java/com/capyreader/app/ui/accounts/LoginScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/LoginScreen.kt
@@ -25,6 +25,7 @@ fun LoginScreen(
         onChooseClientCert = {
             activity?.let(viewModel::chooseClientCert)
         },
+        onClearClientCert = viewModel::clearClientCert,
         url = viewModel.url,
         username = viewModel.username,
         password = viewModel.password,

--- a/app/src/main/java/com/capyreader/app/ui/accounts/LoginScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/LoginScreen.kt
@@ -1,6 +1,7 @@
 package com.capyreader.app.ui.accounts
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -9,18 +10,21 @@ fun LoginScreen(
     onNavigateBack: () -> Unit,
     onSuccess: () -> Unit,
 ) {
+    val context = LocalContext.current
     LoginView(
         source = viewModel.source,
         onUsernameChange = viewModel::setUsername,
         onPasswordChange = viewModel::setPassword,
         onUrlChange = viewModel::setURL,
+        onClientCertAliasChange = viewModel::setClientCertAlias,
         onSubmit = {
-            viewModel.submit {
+            viewModel.submit(context) {
                 onSuccess()
             }
         },
         onNavigateBack = onNavigateBack,
         url = viewModel.url,
+        clientCertAlias = viewModel.clientCertAlias,
         username = viewModel.username,
         password = viewModel.password,
         loading = viewModel.loading,

--- a/app/src/main/java/com/capyreader/app/ui/accounts/LoginScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/LoginScreen.kt
@@ -26,9 +26,9 @@ fun LoginScreen(
             activity?.let(viewModel::chooseClientCert)
         },
         url = viewModel.url,
-        clientCertAlias = viewModel.clientCertAlias,
         username = viewModel.username,
         password = viewModel.password,
+        clientCertAlias = viewModel.clientCertAlias,
         loading = viewModel.loading,
         errorMessage = viewModel.errorMessage
     )

--- a/app/src/main/java/com/capyreader/app/ui/accounts/LoginView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/LoginView.kt
@@ -48,6 +48,7 @@ fun LoginView(
     onSubmit: () -> Unit = {},
     onNavigateBack: () -> Unit = {},
     onChooseClientCert: () -> Unit = {},
+    onClearClientCert: () -> Unit = {},
     url: String,
     username: String,
     password: String,
@@ -120,6 +121,7 @@ fun LoginView(
                             },
                             source = source,
                             onChooseClientCert = onChooseClientCert,
+                            onClearClientCert = onClearClientCert,
                             clientCertAlias = clientCertAlias,
                         )
                     }

--- a/app/src/main/java/com/capyreader/app/ui/accounts/LoginView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/LoginView.kt
@@ -1,7 +1,5 @@
 package com.capyreader.app.ui.accounts
 
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,8 +20,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -53,9 +49,9 @@ fun LoginView(
     onNavigateBack: () -> Unit = {},
     onChooseClientCert: () -> Unit = {},
     url: String,
-    clientCertAlias: String,
     username: String,
     password: String,
+    clientCertAlias: String,
     loading: Boolean = false,
     errorMessage: String? = null,
 ) {
@@ -110,23 +106,21 @@ fun LoginView(
                                     }
                                 }
                             )
-                            CertificateField(
-                                onChooseClientCert = onChooseClientCert,
-                                certAlias = clientCertAlias,
-                            )
                         }
                         AuthFields(
-                            username = username,
-                            password = password,
                             onUsernameChange = onUsernameChange,
                             onPasswordChange = onPasswordChange,
                             onSubmit = onSubmit,
+                            username = username,
+                            password = password,
                             loading = loading,
                             errorMessage = errorMessage,
-                            source = source,
                             prompt = {
                                 ServiceSignup(source)
-                            }
+                            },
+                            source = source,
+                            onChooseClientCert = onChooseClientCert,
+                            clientCertAlias = clientCertAlias,
                         )
                     }
                 }
@@ -155,34 +149,6 @@ fun UrlField(
         ),
         modifier = Modifier
             .fillMaxWidth()
-    )
-}
-
-@Composable
-fun CertificateField(
-    onChooseClientCert: () -> Unit,
-    certAlias: String,
-) {
-    TextField(
-        value = certAlias,
-        onValueChange = {},
-        singleLine = true,
-        label = {
-            Text(stringResource(R.string.auth_fields_client_certificate))
-        },
-        modifier = Modifier
-            .fillMaxWidth(),
-        readOnly = true,
-        interactionSource = remember { MutableInteractionSource() }
-            .also { interactionSource ->
-                LaunchedEffect(interactionSource) {
-                    interactionSource.interactions.collect {
-                        if (it is PressInteraction.Release) {
-                            onChooseClientCert()
-                        }
-                    }
-                }
-            }
     )
 }
 

--- a/app/src/main/java/com/capyreader/app/ui/accounts/LoginView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/LoginView.kt
@@ -1,7 +1,5 @@
 package com.capyreader.app.ui.accounts
 
-import android.app.Activity
-import android.security.KeyChain
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Arrangement
@@ -51,9 +49,9 @@ fun LoginView(
     onUsernameChange: (username: String) -> Unit = {},
     onPasswordChange: (password: String) -> Unit = {},
     onUrlChange: (url: String) -> Unit = {},
-    onClientCertAliasChange: (clientCertAlias: String) -> Unit = {},
     onSubmit: () -> Unit = {},
     onNavigateBack: () -> Unit = {},
+    onChooseClientCert: () -> Unit = {},
     url: String,
     clientCertAlias: String,
     username: String,
@@ -113,7 +111,7 @@ fun LoginView(
                                 }
                             )
                             CertificateField(
-                                onChange = onClientCertAliasChange,
+                                onChooseClientCert = onChooseClientCert,
                                 certAlias = clientCertAlias,
                             )
                         }
@@ -162,13 +160,12 @@ fun UrlField(
 
 @Composable
 fun CertificateField(
-    onChange: (certAlias: String) -> Unit,
+    onChooseClientCert: () -> Unit,
     certAlias: String,
 ) {
-    val context = LocalContext.current
     TextField(
         value = certAlias,
-        onValueChange = onChange,
+        onValueChange = {},
         singleLine = true,
         label = {
             Text(stringResource(R.string.auth_fields_client_certificate))
@@ -181,9 +178,7 @@ fun CertificateField(
                 LaunchedEffect(interactionSource) {
                     interactionSource.interactions.collect {
                         if (it is PressInteraction.Release) {
-                            KeyChain.choosePrivateKeyAlias(context as Activity, { alias ->
-                                onChange(alias ?: "")
-                            }, null, null, null, null)
+                            onChooseClientCert()
                         }
                     }
                 }

--- a/app/src/main/java/com/capyreader/app/ui/accounts/LoginViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/LoginViewModel.kt
@@ -1,5 +1,6 @@
 package com.capyreader.app.ui.accounts
 
+import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -28,6 +29,7 @@ class LoginViewModel(
     private var _username by mutableStateOf("")
     private var _password by mutableStateOf("")
     private var _url by mutableStateOf("")
+    private var _clientCertAlias by mutableStateOf("")
     private var _result by mutableStateOf<Async<Unit>>(Async.Uninitialized)
     val source = handle.toRoute<Route.Login>().source
 
@@ -39,6 +41,9 @@ class LoginViewModel(
 
     val url
         get() = _url
+
+    val clientCertAlias
+        get() = _clientCertAlias
 
     val loading: Boolean
         get() = _result is Async.Loading
@@ -58,7 +63,11 @@ class LoginViewModel(
         _url = url
     }
 
-    fun submit(onSuccess: () -> Unit) {
+    fun setClientCertAlias(clientCertAlias: String) {
+        _clientCertAlias = clientCertAlias
+    }
+
+    fun submit(context: Context, onSuccess: () -> Unit) {
         if (username.isBlank() || password.isBlank()) {
             _result = Async.Failure(loginError())
         }
@@ -68,7 +77,7 @@ class LoginViewModel(
         viewModelScope.launchIO {
             _result = Async.Loading
 
-            credentials.verify()
+            credentials.verify(context)
                 .onSuccess { result ->
                     createAccount(result)
 
@@ -98,7 +107,8 @@ class LoginViewModel(
             source = source,
             username = username,
             password = password,
-            url = _url
+            url = url,
+            clientCertAlias = clientCertAlias,
         )
 
     private fun createAccount(credentials: Credentials) {
@@ -106,6 +116,7 @@ class LoginViewModel(
             username = credentials.username,
             password = credentials.secret,
             url = credentials.url,
+            clientCertAlias = credentials.clientCertAlias,
             source = credentials.source
         )
 

--- a/app/src/main/java/com/capyreader/app/ui/accounts/LoginViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/LoginViewModel.kt
@@ -81,7 +81,7 @@ class LoginViewModel(
         viewModelScope.launchIO {
             _result = Async.Loading
 
-            credentials.verify(clientCertManager)
+            credentials.verify()
                 .onSuccess { result ->
                     createAccount(result)
 
@@ -113,6 +113,7 @@ class LoginViewModel(
             password = password,
             url = url,
             clientCertAlias = clientCertAlias,
+            clientCertManager = clientCertManager,
         )
 
     private fun createAccount(credentials: Credentials) {

--- a/app/src/main/java/com/capyreader/app/ui/accounts/LoginViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/LoginViewModel.kt
@@ -1,6 +1,6 @@
 package com.capyreader.app.ui.accounts
 
-import android.content.Context
+import android.app.Activity
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -12,6 +12,7 @@ import com.capyreader.app.loadAccountModules
 import com.capyreader.app.preferences.AppPreferences
 import com.capyreader.app.ui.Route
 import com.jocmp.capy.AccountManager
+import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.accounts.Credentials
 import com.jocmp.capy.accounts.withFreshRSSPath
 import com.jocmp.capy.common.Async
@@ -25,6 +26,7 @@ class LoginViewModel(
     handle: SavedStateHandle,
     private val accountManager: AccountManager,
     private val appPreferences: AppPreferences,
+    private val clientCertManager: ClientCertManager,
 ) : ViewModel() {
     private var _username by mutableStateOf("")
     private var _password by mutableStateOf("")
@@ -63,11 +65,13 @@ class LoginViewModel(
         _url = url
     }
 
-    fun setClientCertAlias(clientCertAlias: String) {
-        _clientCertAlias = clientCertAlias
+    fun chooseClientCert(activity: Activity) {
+        clientCertManager.chooseClientCert(activity) { alias ->
+            _clientCertAlias = alias
+        }
     }
 
-    fun submit(context: Context, onSuccess: () -> Unit) {
+    fun submit(onSuccess: () -> Unit) {
         if (username.isBlank() || password.isBlank()) {
             _result = Async.Failure(loginError())
         }
@@ -77,7 +81,7 @@ class LoginViewModel(
         viewModelScope.launchIO {
             _result = Async.Loading
 
-            credentials.verify(context)
+            credentials.verify(clientCertManager)
                 .onSuccess { result ->
                     createAccount(result)
 

--- a/app/src/main/java/com/capyreader/app/ui/accounts/LoginViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/LoginViewModel.kt
@@ -71,6 +71,10 @@ class LoginViewModel(
         }
     }
 
+    fun clearClientCert() {
+        _clientCertAlias = ""
+    }
+
     fun submit(onSuccess: () -> Unit) {
         if (username.isBlank() || password.isBlank()) {
             _result = Async.Failure(loginError())

--- a/app/src/main/java/com/capyreader/app/ui/accounts/UpdateLoginViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/UpdateLoginViewModel.kt
@@ -1,5 +1,6 @@
 package com.capyreader.app.ui.accounts
 
+import android.app.Activity
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -20,13 +21,16 @@ class UpdateLoginViewModel(
     val username = account.preferences.username.get()
     val source = account.source
     private val url = account.preferences.url.get()
-    private val clientCertAlias = account.preferences.clientCertAlias.get()
 
     private var _password by mutableStateOf("")
+    private var _clientCertAlias by mutableStateOf("")
     private var _result by mutableStateOf<Async<Unit>>(Async.Uninitialized)
 
     val password: String
         get() = _password
+
+    val clientCertAlias: String
+        get() = _clientCertAlias
 
     val loading: Boolean
         get() = _result is Async.Loading
@@ -36,6 +40,12 @@ class UpdateLoginViewModel(
 
     fun setPassword(password: String) {
         _password = password
+    }
+
+    fun chooseClientCert(activity: Activity) {
+        clientCertManager.chooseClientCert(activity) { alias ->
+            _clientCertAlias = alias
+        }
     }
 
     fun submit(onSuccess: () -> Unit) {

--- a/app/src/main/java/com/capyreader/app/ui/accounts/UpdateLoginViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/UpdateLoginViewModel.kt
@@ -46,7 +46,7 @@ class UpdateLoginViewModel(
         viewModelScope.launchIO {
             _result = Async.Loading
 
-            credentials.verify(clientCertManager)
+            credentials.verify()
                 .onSuccess { result ->
                     updateAccount(result)
 
@@ -67,6 +67,7 @@ class UpdateLoginViewModel(
             password = password,
             url = url,
             clientCertAlias = clientCertAlias,
+            clientCertManager = clientCertManager,
         )
 
     private fun updateAccount(result: Credentials) {

--- a/app/src/main/java/com/capyreader/app/ui/accounts/UpdateLoginViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/UpdateLoginViewModel.kt
@@ -48,6 +48,10 @@ class UpdateLoginViewModel(
         }
     }
 
+    fun clearClientCert() {
+        _clientCertAlias = ""
+    }
+
     fun submit(onSuccess: () -> Unit) {
         if (password.isBlank()) {
             _result = Async.Failure(loginError())

--- a/app/src/main/java/com/capyreader/app/ui/accounts/UpdateLoginViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/UpdateLoginViewModel.kt
@@ -1,5 +1,6 @@
 package com.capyreader.app.ui.accounts
 
+import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -18,6 +19,7 @@ class UpdateLoginViewModel(
     val username = account.preferences.username.get()
     val source = account.source
     private val url = account.preferences.url.get()
+    private val clientCertAlias = account.preferences.clientCertAlias.get()
 
     private var _password by mutableStateOf("")
     private var _result by mutableStateOf<Async<Unit>>(Async.Uninitialized)
@@ -35,7 +37,7 @@ class UpdateLoginViewModel(
         _password = password
     }
 
-    fun submit(onSuccess: () -> Unit) {
+    fun submit(context: Context, onSuccess: () -> Unit) {
         if (password.isBlank()) {
             _result = Async.Failure(loginError())
         }
@@ -43,7 +45,7 @@ class UpdateLoginViewModel(
         viewModelScope.launchIO {
             _result = Async.Loading
 
-            credentials.verify()
+            credentials.verify(context)
                 .onSuccess { result ->
                     updateAccount(result)
 
@@ -62,7 +64,8 @@ class UpdateLoginViewModel(
             source = source,
             username = username,
             password = password,
-            url = url
+            url = url,
+            clientCertAlias = clientCertAlias,
         )
 
     private fun updateAccount(result: Credentials) {

--- a/app/src/main/java/com/capyreader/app/ui/accounts/UpdateLoginViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/UpdateLoginViewModel.kt
@@ -1,12 +1,12 @@
 package com.capyreader.app.ui.accounts
 
-import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jocmp.capy.Account
+import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.accounts.Credentials
 import com.jocmp.capy.common.Async
 import com.jocmp.capy.common.launchIO
@@ -15,6 +15,7 @@ import kotlinx.coroutines.withContext
 
 class UpdateLoginViewModel(
     private val account: Account,
+    private val clientCertManager: ClientCertManager,
 ) : ViewModel() {
     val username = account.preferences.username.get()
     val source = account.source
@@ -37,7 +38,7 @@ class UpdateLoginViewModel(
         _password = password
     }
 
-    fun submit(context: Context, onSuccess: () -> Unit) {
+    fun submit(onSuccess: () -> Unit) {
         if (password.isBlank()) {
             _result = Async.Failure(loginError())
         }
@@ -45,7 +46,7 @@ class UpdateLoginViewModel(
         viewModelScope.launchIO {
             _result = Async.Loading
 
-            credentials.verify(context)
+            credentials.verify(clientCertManager)
                 .onSuccess { result ->
                     updateAccount(result)
 

--- a/app/src/main/java/com/capyreader/app/ui/articles/UpdateAuthDialog.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/UpdateAuthDialog.kt
@@ -1,7 +1,6 @@
 package com.capyreader.app.ui.articles
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -16,7 +15,6 @@ fun UpdateAuthDialog(
     onSuccess: (message: String) -> Unit,
     viewModel: UpdateLoginViewModel = koinViewModel()
 ) {
-    val context = LocalContext.current
     val successMessage = stringResource(R.string.update_auth_success_message)
 
     Dialog(
@@ -29,7 +27,7 @@ fun UpdateAuthDialog(
                 onPasswordChange = viewModel::setPassword,
                 onNavigateBack = onDismissRequest,
                 onSubmit = {
-                    viewModel.submit(context) {
+                    viewModel.submit {
                         onSuccess(successMessage)
                     }
                 },

--- a/app/src/main/java/com/capyreader/app/ui/articles/UpdateAuthDialog.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/UpdateAuthDialog.kt
@@ -1,6 +1,7 @@
 package com.capyreader.app.ui.articles
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -15,6 +16,7 @@ fun UpdateAuthDialog(
     onSuccess: (message: String) -> Unit,
     viewModel: UpdateLoginViewModel = koinViewModel()
 ) {
+    val context = LocalContext.current
     val successMessage = stringResource(R.string.update_auth_success_message)
 
     Dialog(
@@ -27,7 +29,7 @@ fun UpdateAuthDialog(
                 onPasswordChange = viewModel::setPassword,
                 onNavigateBack = onDismissRequest,
                 onSubmit = {
-                    viewModel.submit {
+                    viewModel.submit(context) {
                         onSuccess(successMessage)
                     }
                 },

--- a/app/src/main/java/com/capyreader/app/ui/articles/UpdateAuthDialog.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/UpdateAuthDialog.kt
@@ -1,5 +1,6 @@
 package com.capyreader.app.ui.articles
 
+import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.window.Dialog
@@ -15,6 +16,7 @@ fun UpdateAuthDialog(
     onSuccess: (message: String) -> Unit,
     viewModel: UpdateLoginViewModel = koinViewModel()
 ) {
+    val activity = LocalActivity.current
     val successMessage = stringResource(R.string.update_auth_success_message)
 
     Dialog(
@@ -26,6 +28,9 @@ fun UpdateAuthDialog(
                 source = viewModel.source,
                 onPasswordChange = viewModel::setPassword,
                 onNavigateBack = onDismissRequest,
+                onChooseClientCert = {
+                    activity?.let(viewModel::chooseClientCert)
+                },
                 onSubmit = {
                     viewModel.submit {
                         onSuccess(successMessage)
@@ -33,6 +38,7 @@ fun UpdateAuthDialog(
                 },
                 username = viewModel.username,
                 password = viewModel.password,
+                clientCertAlias = viewModel.clientCertAlias,
                 loading = viewModel.loading,
                 errorMessage = viewModel.errorMessage
             )

--- a/app/src/main/java/com/capyreader/app/ui/articles/UpdateAuthDialog.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/UpdateAuthDialog.kt
@@ -31,6 +31,7 @@ fun UpdateAuthDialog(
                 onChooseClientCert = {
                     activity?.let(viewModel::chooseClientCert)
                 },
+                onClearClientCert = viewModel::clearClientCert,
                 onSubmit = {
                     viewModel.submit {
                         onSuccess(successMessage)

--- a/app/src/main/java/com/capyreader/app/ui/articles/UpdateAuthView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/UpdateAuthView.kt
@@ -29,8 +29,10 @@ fun UpdateAuthView(
     onPasswordChange: (password: String) -> Unit = {},
     onSubmit: () -> Unit = {},
     onNavigateBack: () -> Unit = {},
+    onChooseClientCert: () -> Unit = {},
     username: String,
     password: String,
+    clientCertAlias: String,
     loading: Boolean = false,
     errorMessage: String? = null
 ) {
@@ -62,11 +64,13 @@ fun UpdateAuthView(
                 onPasswordChange = onPasswordChange,
                 onSubmit = onSubmit,
                 username = username,
-                password = password,
                 readOnlyUsername = true,
+                password = password,
                 loading = loading,
                 errorMessage = errorMessage,
-                source = source
+                source = source,
+                onChooseClientCert = onChooseClientCert,
+                clientCertAlias = clientCertAlias,
             )
         }
     }
@@ -79,7 +83,8 @@ private fun UpdateAuthViewPreview() {
         UpdateAuthView(
             source = Source.FRESHRSS,
             username = "test@example.com",
-            password = "secrets"
+            password = "secrets",
+            clientCertAlias = "test",
         )
     }
 }

--- a/app/src/main/java/com/capyreader/app/ui/articles/UpdateAuthView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/UpdateAuthView.kt
@@ -30,6 +30,7 @@ fun UpdateAuthView(
     onSubmit: () -> Unit = {},
     onNavigateBack: () -> Unit = {},
     onChooseClientCert: () -> Unit = {},
+    onClearClientCert: () -> Unit = {},
     username: String,
     password: String,
     clientCertAlias: String,
@@ -70,6 +71,7 @@ fun UpdateAuthView(
                 errorMessage = errorMessage,
                 source = source,
                 onChooseClientCert = onChooseClientCert,
+                onClearClientCert = onClearClientCert,
                 clientCertAlias = clientCertAlias,
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="auth_fields_hide_password">Hide password</string>
     <string name="auth_fields_show_password">Show password</string>
     <string name="auth_fields_log_in_button">Log In</string>
+    <string name="auth_fields_remove_client_cert">Remove client certificate</string>
     <string name="settings_top_bar_title">Settings</string>
     <string name="update_auth_success_message">Successfully logged in</string>
     <string name="crash_reporting_checkbox_title">Enable crash reporting</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="auth_fields_username">Username</string>
     <string name="auth_fields_api_url">Server</string>
     <string name="auth_fields_api_url_placeholder" translatable="false">https://example.com/</string>
+    <string name="auth_fields_client_certificate">Client certificate (optional)</string>
     <string name="auth_fields_hide_password">Hide password</string>
     <string name="auth_fields_show_password">Show password</string>
     <string name="auth_fields_log_in_button">Log In</string>

--- a/capy/src/main/java/com/jocmp/capy/Account.kt
+++ b/capy/src/main/java/com/jocmp/capy/Account.kt
@@ -1,5 +1,6 @@
 package com.jocmp.capy
 
+import android.content.Context
 import com.jocmp.capy.accounts.AddFeedResult
 import com.jocmp.capy.accounts.AutoDelete
 import com.jocmp.capy.accounts.FaviconFetcher
@@ -39,6 +40,7 @@ import java.net.URI
 import java.time.ZonedDateTime
 
 data class Account(
+    val context: Context,
     val id: String,
     val path: URI,
     val cacheDirectory: URI,
@@ -66,6 +68,7 @@ data class Account(
         Source.FRESHRSS,
         Source.MINIFLUX,
         Source.READER -> buildReaderDelegate(
+            context = context,
             source = source,
             database = database,
             path = cacheDirectory,

--- a/capy/src/main/java/com/jocmp/capy/Account.kt
+++ b/capy/src/main/java/com/jocmp/capy/Account.kt
@@ -1,6 +1,5 @@
 package com.jocmp.capy
 
-import android.content.Context
 import com.jocmp.capy.accounts.AddFeedResult
 import com.jocmp.capy.accounts.AutoDelete
 import com.jocmp.capy.accounts.FaviconFetcher
@@ -40,7 +39,6 @@ import java.net.URI
 import java.time.ZonedDateTime
 
 data class Account(
-    val context: Context,
     val id: String,
     val path: URI,
     val cacheDirectory: URI,
@@ -48,6 +46,7 @@ data class Account(
     val preferences: AccountPreferences,
     val source: Source = Source.LOCAL,
     val faviconFetcher: FaviconFetcher,
+    private val clientCertManager: ClientCertManager,
     private val localHttpClient: OkHttpClient = LocalOkHttpClient.forAccount(path = cacheDirectory),
     val delegate: AccountDelegate = when (source) {
         Source.LOCAL -> LocalAccountDelegate(
@@ -68,11 +67,11 @@ data class Account(
         Source.FRESHRSS,
         Source.MINIFLUX,
         Source.READER -> buildReaderDelegate(
-            context = context,
             source = source,
             database = database,
             path = cacheDirectory,
-            preferences = preferences
+            preferences = preferences,
+            clientCertManager = clientCertManager,
         )
     }
 ) {

--- a/capy/src/main/java/com/jocmp/capy/AccountManager.kt
+++ b/capy/src/main/java/com/jocmp/capy/AccountManager.kt
@@ -1,6 +1,5 @@
 package com.jocmp.capy
 
-import android.content.Context
 import com.jocmp.capy.accounts.FaviconFetcher
 import com.jocmp.capy.accounts.Source
 import com.jocmp.capy.db.Database
@@ -10,12 +9,12 @@ import java.net.URI
 import java.util.UUID
 
 class AccountManager(
-    private val context: Context,
     val rootFolder: URI,
     private val cacheDirectory: URI,
     private val databaseProvider: DatabaseProvider,
     private val preferenceStoreProvider: PreferenceStoreProvider,
     private val faviconFetcher: FaviconFetcher,
+    private val clientCertManager: ClientCertManager,
 ) {
     fun findByID(
         id: String,
@@ -23,7 +22,7 @@ class AccountManager(
     ): Account? {
         val existingAccount = findAccountFile(id) ?: return null
 
-        return buildAccount(context, existingAccount, database, faviconFetcher)
+        return buildAccount(existingAccount, database)
     }
 
     fun createAccount(
@@ -76,10 +75,8 @@ class AccountManager(
     private fun accountFolder() = File(rootFolder.path, DIRECTORY_NAME)
 
     private fun buildAccount(
-        context: Context,
         path: File,
         database: Database,
-        faviconFetcher: FaviconFetcher,
         preferences: AccountPreferences = preferenceStoreProvider.build(path.name)
     ): Account {
         val id = path.name
@@ -87,7 +84,6 @@ class AccountManager(
         val cacheDirectory = File(cacheDirectory.path, id).toURI()
 
         return Account(
-            context = context,
             id = id,
             path = pathURI,
             cacheDirectory = cacheDirectory,
@@ -95,6 +91,7 @@ class AccountManager(
             source = preferences.source.get(),
             preferences = preferences,
             faviconFetcher = faviconFetcher,
+            clientCertManager = clientCertManager,
         )
     }
 

--- a/capy/src/main/java/com/jocmp/capy/AccountManager.kt
+++ b/capy/src/main/java/com/jocmp/capy/AccountManager.kt
@@ -1,5 +1,6 @@
 package com.jocmp.capy
 
+import android.content.Context
 import com.jocmp.capy.accounts.FaviconFetcher
 import com.jocmp.capy.accounts.Source
 import com.jocmp.capy.db.Database
@@ -9,6 +10,7 @@ import java.net.URI
 import java.util.UUID
 
 class AccountManager(
+    private val context: Context,
     val rootFolder: URI,
     private val cacheDirectory: URI,
     private val databaseProvider: DatabaseProvider,
@@ -21,13 +23,14 @@ class AccountManager(
     ): Account? {
         val existingAccount = findAccountFile(id) ?: return null
 
-        return buildAccount(existingAccount, database, faviconFetcher)
+        return buildAccount(context, existingAccount, database, faviconFetcher)
     }
 
     fun createAccount(
         username: String,
         password: String,
         url: String,
+        clientCertAlias: String,
         source: Source
     ): String {
         val accountID = createAccount(source = source)
@@ -36,6 +39,7 @@ class AccountManager(
             preferences.username.set(username)
             preferences.password.set(password)
             preferences.url.set(url)
+            preferences.clientCertAlias.set(clientCertAlias)
         }
 
         return accountID
@@ -72,6 +76,7 @@ class AccountManager(
     private fun accountFolder() = File(rootFolder.path, DIRECTORY_NAME)
 
     private fun buildAccount(
+        context: Context,
         path: File,
         database: Database,
         faviconFetcher: FaviconFetcher,
@@ -82,6 +87,7 @@ class AccountManager(
         val cacheDirectory = File(cacheDirectory.path, id).toURI()
 
         return Account(
+            context = context,
             id = id,
             path = pathURI,
             cacheDirectory = cacheDirectory,

--- a/capy/src/main/java/com/jocmp/capy/AccountPreferences.kt
+++ b/capy/src/main/java/com/jocmp/capy/AccountPreferences.kt
@@ -18,6 +18,9 @@ class AccountPreferences(
     val url: Preference<String>
         get() = store.getString("api_url", "")
 
+    val clientCertAlias: Preference<String>
+        get() = store.getString("client_cert_alias", "")
+
     val password: Preference<String>
         get() = store.getString("password", "")
 

--- a/capy/src/main/java/com/jocmp/capy/ClientCertManager.kt
+++ b/capy/src/main/java/com/jocmp/capy/ClientCertManager.kt
@@ -1,0 +1,17 @@
+package com.jocmp.capy
+
+import android.app.Activity
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.X509TrustManager
+
+interface ClientCertManager {
+
+    fun chooseClientCert(activity: Activity, onAliasChosen: (String) -> Unit)
+
+    data class ClientSSlSocketFactory(
+        val sslSocketFactory: SSLSocketFactory,
+        val trustManager: X509TrustManager,
+    )
+
+    fun buildSslSocketFactory(clientCertAlias: String) : ClientSSlSocketFactory
+}

--- a/capy/src/main/java/com/jocmp/capy/accounts/Credentials.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/Credentials.kt
@@ -1,6 +1,6 @@
 package com.jocmp.capy.accounts
 
-import android.content.Context
+import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.accounts.feedbin.FeedbinCredentials
 import com.jocmp.capy.accounts.reader.ReaderCredentials
 import com.jocmp.capy.common.optionalURL
@@ -12,7 +12,7 @@ interface Credentials {
     val clientCertAlias: String
     val source: Source
 
-    suspend fun verify(context: Context): Result<Credentials>
+    suspend fun verify(clientCertManager: ClientCertManager): Result<Credentials>
 
     companion object {
         fun from(

--- a/capy/src/main/java/com/jocmp/capy/accounts/Credentials.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/Credentials.kt
@@ -12,7 +12,7 @@ interface Credentials {
     val clientCertAlias: String
     val source: Source
 
-    suspend fun verify(clientCertManager: ClientCertManager): Result<Credentials>
+    suspend fun verify(): Result<Credentials>
 
     companion object {
         fun from(
@@ -21,6 +21,7 @@ interface Credentials {
             password: String,
             url: String,
             clientCertAlias: String,
+            clientCertManager: ClientCertManager,
         ): Credentials {
             return when (source) {
                 Source.FEEDBIN -> FeedbinCredentials(username, password)
@@ -31,7 +32,8 @@ interface Credentials {
                     password,
                     url = normalizeURL(url),
                     clientCertAlias = clientCertAlias,
-                    source = source
+                    source = source,
+                    clientCertManager = clientCertManager,
                 )
 
                 Source.LOCAL -> throw UnsupportedOperationException()

--- a/capy/src/main/java/com/jocmp/capy/accounts/Credentials.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/Credentials.kt
@@ -1,5 +1,6 @@
 package com.jocmp.capy.accounts
 
+import android.content.Context
 import com.jocmp.capy.accounts.feedbin.FeedbinCredentials
 import com.jocmp.capy.accounts.reader.ReaderCredentials
 import com.jocmp.capy.common.optionalURL
@@ -8,9 +9,10 @@ interface Credentials {
     val username: String
     val secret: String
     val url: String
+    val clientCertAlias: String
     val source: Source
 
-    suspend fun verify(): Result<Credentials>
+    suspend fun verify(context: Context): Result<Credentials>
 
     companion object {
         fun from(
@@ -18,6 +20,7 @@ interface Credentials {
             username: String,
             password: String,
             url: String,
+            clientCertAlias: String,
         ): Credentials {
             return when (source) {
                 Source.FEEDBIN -> FeedbinCredentials(username, password)
@@ -27,6 +30,7 @@ interface Credentials {
                     username,
                     password,
                     url = normalizeURL(url),
+                    clientCertAlias = clientCertAlias,
                     source = source
                 )
 

--- a/capy/src/main/java/com/jocmp/capy/accounts/feedbin/FeedbinCredentials.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/feedbin/FeedbinCredentials.kt
@@ -1,6 +1,5 @@
 package com.jocmp.capy.accounts.feedbin
 
-import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.accounts.Credentials
 import com.jocmp.capy.accounts.Source
 import com.jocmp.feedbinclient.Feedbin
@@ -14,7 +13,7 @@ internal data class FeedbinCredentials(
 
     override val source: Source = Source.FEEDBIN
 
-    override suspend fun verify(clientCertManager: ClientCertManager): Result<Credentials> {
+    override suspend fun verify(): Result<Credentials> {
         val response = Feedbin.verifyCredentials(
             username = username,
             password = secret

--- a/capy/src/main/java/com/jocmp/capy/accounts/feedbin/FeedbinCredentials.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/feedbin/FeedbinCredentials.kt
@@ -1,6 +1,6 @@
 package com.jocmp.capy.accounts.feedbin
 
-import android.content.Context
+import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.accounts.Credentials
 import com.jocmp.capy.accounts.Source
 import com.jocmp.feedbinclient.Feedbin
@@ -14,7 +14,7 @@ internal data class FeedbinCredentials(
 
     override val source: Source = Source.FEEDBIN
 
-    override suspend fun verify(context: Context): Result<Credentials> {
+    override suspend fun verify(clientCertManager: ClientCertManager): Result<Credentials> {
         val response = Feedbin.verifyCredentials(
             username = username,
             password = secret

--- a/capy/src/main/java/com/jocmp/capy/accounts/feedbin/FeedbinCredentials.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/feedbin/FeedbinCredentials.kt
@@ -1,5 +1,6 @@
 package com.jocmp.capy.accounts.feedbin
 
+import android.content.Context
 import com.jocmp.capy.accounts.Credentials
 import com.jocmp.capy.accounts.Source
 import com.jocmp.feedbinclient.Feedbin
@@ -9,10 +10,11 @@ internal data class FeedbinCredentials(
     override val secret: String,
 ) : Credentials {
     override val url = ""
+    override val clientCertAlias: String = ""
 
     override val source: Source = Source.FEEDBIN
 
-    override suspend fun verify(): Result<Credentials> {
+    override suspend fun verify(context: Context): Result<Credentials> {
         val response = Feedbin.verifyCredentials(
             username = username,
             password = secret

--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/BuildReaderDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/BuildReaderDelegate.kt
@@ -1,5 +1,6 @@
 package com.jocmp.capy.accounts.reader
 
+import android.content.Context
 import com.jocmp.capy.AccountDelegate
 import com.jocmp.capy.AccountPreferences
 import com.jocmp.capy.accounts.Source
@@ -8,12 +9,13 @@ import com.jocmp.readerclient.GoogleReader
 import java.net.URI
 
 internal fun buildReaderDelegate(
+    context: Context,
     source: Source,
     database: Database,
     path: URI,
     preferences: AccountPreferences
 ): AccountDelegate {
-    val httpClient = ReaderOkHttpClient.forAccount(path, preferences)
+    val httpClient = ReaderOkHttpClient.forAccount(context, path, preferences)
 
     return ReaderAccountDelegate(
         source = source,

--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/BuildReaderDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/BuildReaderDelegate.kt
@@ -1,21 +1,21 @@
 package com.jocmp.capy.accounts.reader
 
-import android.content.Context
 import com.jocmp.capy.AccountDelegate
 import com.jocmp.capy.AccountPreferences
+import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.accounts.Source
 import com.jocmp.capy.db.Database
 import com.jocmp.readerclient.GoogleReader
 import java.net.URI
 
 internal fun buildReaderDelegate(
-    context: Context,
     source: Source,
     database: Database,
     path: URI,
-    preferences: AccountPreferences
+    preferences: AccountPreferences,
+    clientCertManager: ClientCertManager,
 ): AccountDelegate {
-    val httpClient = ReaderOkHttpClient.forAccount(context, path, preferences)
+    val httpClient = ReaderOkHttpClient.forAccount(path, preferences, clientCertManager)
 
     return ReaderAccountDelegate(
         source = source,

--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderCredentials.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderCredentials.kt
@@ -1,8 +1,10 @@
 package com.jocmp.capy.accounts.reader
 
+import android.content.Context
 import com.jocmp.capy.accounts.Credentials
 import com.jocmp.capy.accounts.Source
 import com.jocmp.capy.accounts.baseHttpClient
+import com.jocmp.capy.accounts.reader.ReaderOkHttpClient.clientCertAlias
 import com.jocmp.readerclient.GoogleReader
 import com.jocmp.readerclient.GoogleReader.Companion.UNAUTHORIZED_MESSAGE
 
@@ -10,15 +12,19 @@ data class ReaderCredentials(
     override val username: String,
     override val secret: String,
     override val url: String,
+    override val clientCertAlias: String,
     override val source: Source
 ) : Credentials {
-    override suspend fun verify(): Result<Credentials> {
+    override suspend fun verify(context: Context): Result<Credentials> {
         try {
             val response = GoogleReader.verifyCredentials(
                 username = username,
                 password = secret,
                 baseURL = url,
                 client = baseHttpClient()
+                    .newBuilder()
+                    .clientCertAlias(context, clientCertAlias)
+                    .build()
             )
 
             val responseBody = response.body()

--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderCredentials.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderCredentials.kt
@@ -13,9 +13,10 @@ data class ReaderCredentials(
     override val secret: String,
     override val url: String,
     override val clientCertAlias: String,
-    override val source: Source
+    override val source: Source,
+    private val clientCertManager: ClientCertManager,
 ) : Credentials {
-    override suspend fun verify(clientCertManager: ClientCertManager): Result<Credentials> {
+    override suspend fun verify(): Result<Credentials> {
         try {
             val response = GoogleReader.verifyCredentials(
                 username = username,

--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderCredentials.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderCredentials.kt
@@ -1,6 +1,6 @@
 package com.jocmp.capy.accounts.reader
 
-import android.content.Context
+import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.accounts.Credentials
 import com.jocmp.capy.accounts.Source
 import com.jocmp.capy.accounts.baseHttpClient
@@ -15,7 +15,7 @@ data class ReaderCredentials(
     override val clientCertAlias: String,
     override val source: Source
 ) : Credentials {
-    override suspend fun verify(context: Context): Result<Credentials> {
+    override suspend fun verify(clientCertManager: ClientCertManager): Result<Credentials> {
         try {
             val response = GoogleReader.verifyCredentials(
                 username = username,
@@ -23,7 +23,7 @@ data class ReaderCredentials(
                 baseURL = url,
                 client = baseHttpClient()
                     .newBuilder()
-                    .clientCertAlias(context, clientCertAlias)
+                    .clientCertAlias(clientCertManager, clientCertAlias)
                     .build()
             )
 

--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderOkHttpClient.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderOkHttpClient.kt
@@ -1,22 +1,14 @@
 package com.jocmp.capy.accounts.reader
 
-import android.content.Context
-import android.security.KeyChain
 import com.jocmp.capy.AccountPreferences
+import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.accounts.BasicAuthInterceptor
 import com.jocmp.capy.accounts.httpClientBuilder
 import okhttp3.OkHttpClient
-import okhttp3.internal.platform.Platform
-import java.net.Socket
 import java.net.URI
-import java.security.Principal
-import java.security.PrivateKey
-import java.security.cert.X509Certificate
-import javax.net.ssl.SSLContext
-import javax.net.ssl.X509KeyManager
 
 internal object ReaderOkHttpClient {
-    fun forAccount(context: Context, path: URI, preferences: AccountPreferences): OkHttpClient {
+    fun forAccount(path: URI, preferences: AccountPreferences, clientCertManager: ClientCertManager): OkHttpClient {
         return httpClientBuilder(cachePath = path)
             .addInterceptor(
                 BasicAuthInterceptor {
@@ -25,46 +17,14 @@ internal object ReaderOkHttpClient {
                     "GoogleLogin auth=${secret}"
                 }
             )
-            .clientCertAlias(context, preferences.clientCertAlias.get())
+            .clientCertAlias(clientCertManager, preferences.clientCertAlias.get())
             .build()
     }
 
-    fun OkHttpClient.Builder.clientCertAlias(context: Context, clientCertAlias: String): OkHttpClient.Builder {
+    fun OkHttpClient.Builder.clientCertAlias(manager: ClientCertManager, clientCertAlias: String): OkHttpClient.Builder {
         if (clientCertAlias.isNotEmpty()) {
-            val clientKeyManager = object : X509KeyManager {
-                override fun getClientAliases(keyType: String?, issuers: Array<Principal>?) =
-                    throw UnsupportedOperationException("getClientAliases")
-
-                override fun chooseClientAlias(
-                    keyType: Array<String>?,
-                    issuers: Array<Principal>?,
-                    socket: Socket?
-                ) = clientCertAlias
-
-                override fun getServerAliases(keyType: String?, issuers: Array<Principal>?) =
-                    throw UnsupportedOperationException("getServerAliases")
-
-                override fun chooseServerAlias(
-                    keyType: String?,
-                    issuers: Array<Principal>?,
-                    socket: Socket?
-                ) = throw UnsupportedOperationException("chooseServerAlias")
-
-                override fun getCertificateChain(alias: String?): Array<X509Certificate>? {
-                    return if (alias == clientCertAlias) KeyChain.getCertificateChain(context, clientCertAlias) else null
-                }
-
-                override fun getPrivateKey(alias: String?): PrivateKey? {
-                    return if (alias == clientCertAlias) KeyChain.getPrivateKey(context, clientCertAlias) else null
-                }
-            }
-
-            val sslContext = SSLContext.getInstance("TLS")
-            val trustManager = Platform.get().platformTrustManager()
-            sslContext.init(arrayOf(clientKeyManager), arrayOf(trustManager), null)
-            val sslSocketFactory = sslContext.socketFactory
-
-            sslSocketFactory(sslSocketFactory, trustManager)
+            val clientSSlSocketFactory = manager.buildSslSocketFactory(clientCertAlias)
+            sslSocketFactory(clientSSlSocketFactory.sslSocketFactory, clientSSlSocketFactory.trustManager)
         }
         return this
     }

--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderOkHttpClient.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderOkHttpClient.kt
@@ -1,13 +1,22 @@
 package com.jocmp.capy.accounts.reader
 
+import android.content.Context
+import android.security.KeyChain
 import com.jocmp.capy.AccountPreferences
 import com.jocmp.capy.accounts.BasicAuthInterceptor
 import com.jocmp.capy.accounts.httpClientBuilder
 import okhttp3.OkHttpClient
+import okhttp3.internal.platform.Platform
+import java.net.Socket
 import java.net.URI
+import java.security.Principal
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509KeyManager
 
 internal object ReaderOkHttpClient {
-    fun forAccount(path: URI, preferences: AccountPreferences): OkHttpClient {
+    fun forAccount(context: Context, path: URI, preferences: AccountPreferences): OkHttpClient {
         return httpClientBuilder(cachePath = path)
             .addInterceptor(
                 BasicAuthInterceptor {
@@ -16,6 +25,47 @@ internal object ReaderOkHttpClient {
                     "GoogleLogin auth=${secret}"
                 }
             )
+            .clientCertAlias(context, preferences.clientCertAlias.get())
             .build()
+    }
+
+    fun OkHttpClient.Builder.clientCertAlias(context: Context, clientCertAlias: String): OkHttpClient.Builder {
+        if (clientCertAlias.isNotEmpty()) {
+            val clientKeyManager = object : X509KeyManager {
+                override fun getClientAliases(keyType: String?, issuers: Array<Principal>?) =
+                    throw UnsupportedOperationException("getClientAliases")
+
+                override fun chooseClientAlias(
+                    keyType: Array<String>?,
+                    issuers: Array<Principal>?,
+                    socket: Socket?
+                ) = clientCertAlias
+
+                override fun getServerAliases(keyType: String?, issuers: Array<Principal>?) =
+                    throw UnsupportedOperationException("getServerAliases")
+
+                override fun chooseServerAlias(
+                    keyType: String?,
+                    issuers: Array<Principal>?,
+                    socket: Socket?
+                ) = throw UnsupportedOperationException("chooseServerAlias")
+
+                override fun getCertificateChain(alias: String?): Array<X509Certificate>? {
+                    return if (alias == clientCertAlias) KeyChain.getCertificateChain(context, clientCertAlias) else null
+                }
+
+                override fun getPrivateKey(alias: String?): PrivateKey? {
+                    return if (alias == clientCertAlias) KeyChain.getPrivateKey(context, clientCertAlias) else null
+                }
+            }
+
+            val sslContext = SSLContext.getInstance("TLS")
+            val trustManager = Platform.get().platformTrustManager()
+            sslContext.init(arrayOf(clientKeyManager), arrayOf(trustManager), null)
+            val sslSocketFactory = sslContext.socketFactory
+
+            sslSocketFactory(sslSocketFactory, trustManager)
+        }
+        return this
     }
 }

--- a/capy/src/test/java/com/jocmp/capy/AccountManagerTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/AccountManagerTest.kt
@@ -2,6 +2,7 @@ package com.jocmp.capy
 
 import com.jocmp.capy.accounts.FakeFaviconFetcher
 import com.jocmp.capy.accounts.Source
+import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -17,6 +18,7 @@ class AccountManagerTest {
 
     private fun buildManager(): AccountManager {
         return AccountManager(
+            context = mockk(),
             rootFolder = rootFolder.newFolder().toURI(),
             preferenceStoreProvider = InMemoryPreferencesProvider(),
             cacheDirectory = rootFolder.newFolder().toURI(),
@@ -29,14 +31,14 @@ class AccountManagerTest {
     fun addAccount() {
         val manager = buildManager()
 
-        assertNotNull(manager.createAccount("foo", "bar", "", Source.LOCAL))
+        assertNotNull(manager.createAccount("foo", "bar", "", "", Source.LOCAL))
     }
 
     @Test
     fun findById() = runBlocking {
         val manager = buildManager()
 
-        val accountID = manager.createAccount("foo", "bar", "", Source.LOCAL)
+        val accountID = manager.createAccount("foo", "bar", "", "", Source.LOCAL)
 
         val account = manager.findByID(accountID)
 

--- a/capy/src/test/java/com/jocmp/capy/AccountManagerTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/AccountManagerTest.kt
@@ -2,7 +2,6 @@ package com.jocmp.capy
 
 import com.jocmp.capy.accounts.FakeFaviconFetcher
 import com.jocmp.capy.accounts.Source
-import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -18,12 +17,12 @@ class AccountManagerTest {
 
     private fun buildManager(): AccountManager {
         return AccountManager(
-            context = mockk(),
             rootFolder = rootFolder.newFolder().toURI(),
             preferenceStoreProvider = InMemoryPreferencesProvider(),
             cacheDirectory = rootFolder.newFolder().toURI(),
             databaseProvider = InMemoryDatabaseProvider,
-            faviconFetcher = FakeFaviconFetcher
+            faviconFetcher = FakeFaviconFetcher,
+            clientCertManager = FakeClientCertManager,
         )
     }
 

--- a/capy/src/test/java/com/jocmp/capy/FakeClientCertManager.kt
+++ b/capy/src/test/java/com/jocmp/capy/FakeClientCertManager.kt
@@ -1,0 +1,21 @@
+package com.jocmp.capy
+
+import android.app.Activity
+import okhttp3.internal.platform.Platform
+import javax.net.ssl.SSLContext
+
+object FakeClientCertManager : ClientCertManager {
+    override fun chooseClientCert(activity: Activity, onAliasChosen: (String) -> Unit) {
+        TODO("Not yet implemented")
+    }
+
+    override fun buildSslSocketFactory(clientCertAlias: String): ClientCertManager.ClientSSlSocketFactory {
+        val sslContext = SSLContext.getInstance("TLS")
+        val trustManager = Platform.get().platformTrustManager()
+        sslContext.init(emptyArray(), arrayOf(trustManager), null)
+        return ClientCertManager.ClientSSlSocketFactory(
+            sslContext.socketFactory,
+            trustManager,
+        )
+    }
+}

--- a/capy/src/test/java/com/jocmp/capy/accounts/feedbin/FeedbinCredentialsTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/feedbin/FeedbinCredentialsTest.kt
@@ -30,7 +30,7 @@ internal class FeedbinCredentialsTest {
     fun verify_onSuccess_shouldReturnCredentials() = runTest {
         coEvery { feedbin.authentication(authentication = any()) }.returns(Response.success(null))
 
-        val result = credentials.verify().getOrNull()!!
+        val result = credentials.verify(mockk()).getOrNull()!!
 
         assertEquals(actual = result.username, expected = username)
         assertEquals(actual = result.secret, expected = password)
@@ -45,7 +45,7 @@ internal class FeedbinCredentialsTest {
             )
         )
 
-        val result = credentials.verify()
+        val result = credentials.verify(mockk())
 
         assertTrue(result.isFailure)
     }

--- a/capy/src/test/java/com/jocmp/capy/accounts/feedbin/FeedbinCredentialsTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/feedbin/FeedbinCredentialsTest.kt
@@ -30,7 +30,7 @@ internal class FeedbinCredentialsTest {
     fun verify_onSuccess_shouldReturnCredentials() = runTest {
         coEvery { feedbin.authentication(authentication = any()) }.returns(Response.success(null))
 
-        val result = credentials.verify(mockk()).getOrNull()!!
+        val result = credentials.verify().getOrNull()!!
 
         assertEquals(actual = result.username, expected = username)
         assertEquals(actual = result.secret, expected = password)
@@ -45,7 +45,7 @@ internal class FeedbinCredentialsTest {
             )
         )
 
-        val result = credentials.verify(mockk())
+        val result = credentials.verify()
 
         assertTrue(result.isFailure)
     }

--- a/capy/src/test/java/com/jocmp/capy/accounts/reader/ReaderCredentialsTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/reader/ReaderCredentialsTest.kt
@@ -18,7 +18,14 @@ internal class ReaderCredentialsTest {
     private val username = "alice"
     private val password = "its-a-secret-to-everybody"
     private val url = "http://selfhosted.example.com/greader.php"
-    private val credentials = ReaderCredentials(username, password, url, Source.FRESHRSS)
+    private val clientCertAlias = "alice@homelab"
+    private val credentials = ReaderCredentials(
+        username = username,
+        secret = password,
+        url = url,
+        clientCertAlias = clientCertAlias,
+        source = Source.FRESHRSS
+    )
     lateinit var googleReader: GoogleReader
     private val auth = "alice/8e6845e089457af25303abc6f53356eb60bdb5f8"
 
@@ -43,7 +50,7 @@ internal class ReaderCredentialsTest {
             )
         }.returns(Response.success(successResponse))
 
-        val result = credentials.verify().getOrNull()!!
+        val result = credentials.verify(mockk()).getOrNull()!!
 
         assertEquals(actual = result.username, expected = username)
         assertEquals(actual = result.secret, expected = auth)
@@ -58,7 +65,7 @@ internal class ReaderCredentialsTest {
             )
         )
 
-        val result = credentials.verify()
+        val result = credentials.verify(mockk())
 
         assertTrue(result.isFailure)
         assertEquals(result.exceptionOrNull()!!.message, "Unauthorized!")
@@ -73,7 +80,7 @@ internal class ReaderCredentialsTest {
             )
         )
 
-        val result = credentials.verify()
+        val result = credentials.verify(mockk())
 
         assertTrue(result.isFailure)
     }

--- a/capy/src/test/java/com/jocmp/capy/accounts/reader/ReaderCredentialsTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/reader/ReaderCredentialsTest.kt
@@ -25,7 +25,8 @@ internal class ReaderCredentialsTest {
         secret = password,
         url = url,
         clientCertAlias = clientCertAlias,
-        source = Source.FRESHRSS
+        source = Source.FRESHRSS,
+        clientCertManager = FakeClientCertManager,
     )
     lateinit var googleReader: GoogleReader
     private val auth = "alice/8e6845e089457af25303abc6f53356eb60bdb5f8"
@@ -51,7 +52,7 @@ internal class ReaderCredentialsTest {
             )
         }.returns(Response.success(successResponse))
 
-        val result = credentials.verify(FakeClientCertManager).getOrNull()!!
+        val result = credentials.verify().getOrNull()!!
 
         assertEquals(actual = result.username, expected = username)
         assertEquals(actual = result.secret, expected = auth)
@@ -66,7 +67,7 @@ internal class ReaderCredentialsTest {
             )
         )
 
-        val result = credentials.verify(FakeClientCertManager)
+        val result = credentials.verify()
 
         assertTrue(result.isFailure)
         assertEquals(result.exceptionOrNull()!!.message, "Unauthorized!")
@@ -81,7 +82,7 @@ internal class ReaderCredentialsTest {
             )
         )
 
-        val result = credentials.verify(FakeClientCertManager)
+        val result = credentials.verify()
 
         assertTrue(result.isFailure)
     }

--- a/capy/src/test/java/com/jocmp/capy/accounts/reader/ReaderCredentialsTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/reader/ReaderCredentialsTest.kt
@@ -1,5 +1,6 @@
 package com.jocmp.capy.accounts.reader
 
+import com.jocmp.capy.FakeClientCertManager
 import com.jocmp.capy.accounts.Source
 import com.jocmp.readerclient.GoogleReader
 import io.mockk.coEvery
@@ -50,7 +51,7 @@ internal class ReaderCredentialsTest {
             )
         }.returns(Response.success(successResponse))
 
-        val result = credentials.verify(mockk()).getOrNull()!!
+        val result = credentials.verify(FakeClientCertManager).getOrNull()!!
 
         assertEquals(actual = result.username, expected = username)
         assertEquals(actual = result.secret, expected = auth)
@@ -65,7 +66,7 @@ internal class ReaderCredentialsTest {
             )
         )
 
-        val result = credentials.verify(mockk())
+        val result = credentials.verify(FakeClientCertManager)
 
         assertTrue(result.isFailure)
         assertEquals(result.exceptionOrNull()!!.message, "Unauthorized!")
@@ -80,7 +81,7 @@ internal class ReaderCredentialsTest {
             )
         )
 
-        val result = credentials.verify(mockk())
+        val result = credentials.verify(FakeClientCertManager)
 
         assertTrue(result.isFailure)
     }

--- a/capy/src/test/java/com/jocmp/capy/fixtures/AccountFixture.kt
+++ b/capy/src/test/java/com/jocmp/capy/fixtures/AccountFixture.kt
@@ -19,6 +19,7 @@ object AccountFixture {
         accountDelegate: AccountDelegate = mockk()
     ): Account {
         return Account(
+            context = mockk(),
             id = id,
             path = parentFolder.newFile().toURI(),
             database = database,

--- a/capy/src/test/java/com/jocmp/capy/fixtures/AccountFixture.kt
+++ b/capy/src/test/java/com/jocmp/capy/fixtures/AccountFixture.kt
@@ -3,6 +3,7 @@ package com.jocmp.capy.fixtures
 import com.jocmp.capy.Account
 import com.jocmp.capy.AccountDelegate
 import com.jocmp.capy.AccountPreferences
+import com.jocmp.capy.FakeClientCertManager
 import com.jocmp.capy.InMemoryDataStore
 import com.jocmp.capy.InMemoryDatabaseProvider
 import com.jocmp.capy.RandomUUID
@@ -19,14 +20,14 @@ object AccountFixture {
         accountDelegate: AccountDelegate = mockk()
     ): Account {
         return Account(
-            context = mockk(),
             id = id,
             path = parentFolder.newFile().toURI(),
             database = database,
             cacheDirectory = parentFolder.newFile().toURI(),
             preferences = AccountPreferences(InMemoryDataStore()),
             delegate = accountDelegate,
-            faviconFetcher = FakeFaviconFetcher
+            faviconFetcher = FakeFaviconFetcher,
+            clientCertManager = FakeClientCertManager,
         )
     }
 }


### PR DESCRIPTION
Using a reverse-proxy with [mTLS (client authentication)](https://en.wikipedia.org/wiki/Mutual_authentication) is a [decent way](https://dominikbritz.com/posts/secure-remote-access/#create-a-certificate-authority) to expose your self-hosted services on the internet.

This PR adds support for using a certificate that's [installed in your Android device](https://support.google.com/pixelphone/answer/2844832?hl=en).

The changes are largely based on:
- This Photoprism client: https://github.com/Radiokot/photoprism-android-client/pull/14
- This sample: https://github.com/diebietse/mtls-android

An optional client certificate can be selected when adding self-hosted accounts (FreshRSS and Reader).

The code uses the default system Keychain to pick a certificate, and only its alias (label) is saved, to be later used in the OkHttp SSL stack. Note that the OkHttp changes only affect client certificates, so the app should behave the same in regards to server certificates.

I considered letting the user select/change a certificate on `UpdateLoginViewModel` (which is shown when authentication fails during regular app usage, right?), but I don't think it is necessary.

I'm comfortable with the logic changes, but I don't have experience with Compose, so my code there can be sub-optimal.

<img src="https://github.com/user-attachments/assets/b186ae9e-c9e8-492f-8991-1f06589e96c9" width=320/>    <img src="https://github.com/user-attachments/assets/47d3abaf-b146-4a06-abcb-65687e8aa034" width=320/>
<img src="https://github.com/user-attachments/assets/7fc871b6-4ad7-4810-bea5-3387665ea869" width=320/>