### PR TITLE
[FreshRSS] Only fetch 10k articles at most from categories

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
@@ -47,6 +47,16 @@ internal class ArticleRecords internal constructor(
     }
 
     /**
+     * Create placeholder statuses to be updated
+     * by the [findMissingArticles] query
+     */
+    fun createStatuses(articleIDs: List<String>, updatedAt: ZonedDateTime = nowUTC()) {
+        database.transactionWithErrorHandling {
+            articleIDs.forEach { createStatus(articleID = it, updatedAt = updatedAt, read = false) }
+        }
+    }
+
+    /**
      * Upserts a record status. On conflict it overwrites "read" metadata.
      */
     fun updateStatus(articleID: String, updatedAt: ZonedDateTime, read: Boolean, starred: Boolean) {

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articles.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articles.sq
@@ -154,8 +154,7 @@ findMissingArticles:
 SELECT article_id
 FROM article_statuses
 LEFT OUTER JOIN articles ON article_statuses.article_id = articles.id
-WHERE articles.id IS NULL
-AND article_statuses.read = 0 OR article_statuses.starred = 1;
+WHERE articles.id IS NULL;
 
 create:
 INSERT INTO articles(

--- a/capy/src/test/java/com/jocmp/capy/accounts/feedbin/FeedbinAccountDelegateTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/feedbin/FeedbinAccountDelegateTest.kt
@@ -191,7 +191,7 @@ class FeedbinAccountDelegateTest {
             ),
         )
 
-        val starredEntries = listOf(readEntry, unreadEntry)
+        val starredEntries = listOf(unreadEntry, readEntry)
 
         coEvery { feedbin.subscriptions() }.returns(Response.success(subscriptions))
         coEvery { feedbin.unreadEntries() }.returns(Response.success(listOf(unreadEntry.id)))

--- a/capy/src/test/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegateTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegateTest.kt
@@ -623,7 +623,7 @@ class ReaderAccountDelegateTest {
             googleReader.streamItemsIDs(
                 streamID = stream.id,
                 since = any(),
-                count = 100,
+                count = 10_000,
             )
         }.returns(Response.success(StreamItemIDsResult(itemRefs = itemRefs, continuation = null)))
 

--- a/readerclient/src/main/java/com/jocmp/readerclient/ItemIdentifiers.kt
+++ b/readerclient/src/main/java/com/jocmp/readerclient/ItemIdentifiers.kt
@@ -1,0 +1,5 @@
+package com.jocmp.readerclient
+
+object ItemIdentifiers {
+    fun parseToHexID(numericID: String) = String.format("%016x", numericID.toLong())
+}

--- a/readerclient/src/main/java/com/jocmp/readerclient/ItemRef.kt
+++ b/readerclient/src/main/java/com/jocmp/readerclient/ItemRef.kt
@@ -1,12 +1,11 @@
 package com.jocmp.readerclient
 
+import com.jocmp.readerclient.ItemIdentifiers.parseToHexID
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class ItemRef(
     val id: String,
 ) {
-    val hexID = buildHexID(id)
+    val hexID = parseToHexID(id)
 }
-
-fun buildHexID(id: String) = String.format("%016x", id.toLong())


### PR DESCRIPTION
- On refresh for a feed or folder in FreshRSS, cap the fetch count to 10,000
- Once collected, only fetch the articles that are missing from the database.

Ref

- https://github.com/jocmp/capyreader/discussions/532#discussioncomment-11806359