### PR TITLE
[Local] Skip media type if it's invalid

### DIFF
--- a/feedfinder/src/main/java/com/jocmp/feedfinder/DefaultRequest.kt
+++ b/feedfinder/src/main/java/com/jocmp/feedfinder/DefaultRequest.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.CompletionHandler
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
 import okhttp3.Callback
-import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import java.io.IOException
 import java.net.URL
@@ -27,7 +27,7 @@ internal class DefaultRequest(private val client: OkHttpClient = OkHttpClient())
         return Response(
             url = parsedURL,
             body = body,
-            charset = response.header("content-type")?.toMediaType()?.charset()
+            charset = response.header("content-type")?.toMediaTypeOrNull()?.charset()
         )
     }
 }


### PR DESCRIPTION
Fixes the following error when adding a feed that sends back the wrong content type.

`2025-01-19 16:46:24.146 12335-29945 cr.local_account.find   com.capyreader.app.debug             I  error_message=Parameter is not formatted correctly: "application/rss+xml; charset=utf-8" for: "text/xml; application/rss+xml; charset=utf-8"`

The fix is to call `toMediaTypeOrNull` instead of `toMediaType` which will throw.