### PR TITLE
Add 'dismissed_at' column to notifications table

### DIFF
--- a/app/src/main/java/com/capyreader/app/notifications/NotificationHelper.kt
+++ b/app/src/main/java/com/capyreader/app/notifications/NotificationHelper.kt
@@ -43,7 +43,7 @@ class NotificationHelper(
     }
 
     fun dismissNotifications(ids: List<String>) {
-        account.deleteNotifications(ids)
+        account.dismissNotifications(ids)
 
         val notificationManager = NotificationManagerCompat.from(applicationContext)
 

--- a/capy/src/main/java/com/jocmp/capy/Account.kt
+++ b/capy/src/main/java/com/jocmp/capy/Account.kt
@@ -232,8 +232,8 @@ data class Account(
         return articleRecords.countNotifications()
     }
 
-    fun deleteNotifications(ids: List<String>) {
-        articleRecords.deleteNotification(ids)
+    fun dismissNotifications(ids: List<String>) {
+        articleRecords.dismissNotifications(ids)
     }
 
     suspend fun import(inputStream: InputStream, onProgress: (ImportProgress) -> Unit) {

--- a/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
@@ -95,12 +95,12 @@ internal class ArticleRecords internal constructor(
             }
         }
 
-        return allNotifications()
+        return activeNotifications()
     }
 
-    private suspend fun allNotifications(): List<ArticleNotification> {
+    private suspend fun activeNotifications(): List<ArticleNotification> {
         return notificationQueries
-            .allNotifications(mapper = ::articleNotificationMapper)
+            .activeNotifications(mapper = ::articleNotificationMapper)
             .asFlow()
             .mapToList(Dispatchers.IO)
             .firstOrNull()
@@ -113,8 +113,11 @@ internal class ArticleRecords internal constructor(
             .executeAsOneOrNull() ?: 0
     }
 
-    internal fun deleteNotification(ids: List<String>) {
-        notificationQueries.deleteNotifications(ids = ids)
+    internal fun dismissNotifications(ids: List<String>) {
+        notificationQueries.dismissNotifications(
+            ids = ids,
+            deleted_at = nowUTC().toEpochSecond()
+        )
     }
 
     fun deleteAllArticles() {

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/10_AddDismissedAtToArticleNotifications.sqm
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/10_AddDismissedAtToArticleNotifications.sqm
@@ -1,0 +1,2 @@
+ALTER TABLE article_notifications
+ADD COLUMN dismissed_at INTEGER;

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/article_notifications.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/article_notifications.sq
@@ -1,4 +1,4 @@
-allNotifications:
+activeNotifications:
 SELECT
     article_id,
     articles.title,
@@ -7,7 +7,8 @@ SELECT
     feeds.favicon_url AS feed_favicon_url
 FROM article_notifications
 JOIN articles ON article_notifications.article_id = articles.id
-JOIN feeds ON articles.feed_id = feeds.id;
+JOIN feeds ON articles.feed_id = feeds.id
+AND article_notifications.dismissed_at IS NULL;
 
 createNotification:
 INSERT INTO article_notifications(
@@ -22,8 +23,9 @@ count:
 SELECT COUNT(*)
 FROM article_notifications;
 
-deleteNotifications:
-DELETE FROM article_notifications WHERE article_id IN :ids;
+dismissNotifications:
+UPDATE article_notifications SET
+dismissed_at = :deleted_at WHERE article_id IN :ids;
 
 articlesToNotify:
 SELECT
@@ -31,6 +33,8 @@ SELECT
 FROM articles
 JOIN article_statuses ON articles.id = article_statuses.article_id
 JOIN feeds ON articles.feed_id = feeds.id
+LEFT JOIN article_notifications ON article_notifications.article_id = articles.id
 WHERE article_statuses.updated_at >= :since
 AND article_statuses.read = 0
-AND feeds.enable_notifications = 1;
+AND feeds.enable_notifications = 1
+AND article_notifications.dismissed_at IS NULL;

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articles.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articles.sq
@@ -358,6 +358,11 @@ deleteAllArticles {
   WHERE article_id NOT IN (
     SELECT article_id FROM article_statuses
   );
+
+  DELETE FROM article_notifications
+  WHERE article_id NOT IN (
+   SELECT article_id FROM article_statuses
+  );
 }
 
 deleteArticles {
@@ -370,6 +375,11 @@ deleteArticles {
   DELETE FROM articles
   WHERE id NOT IN (
     SELECT article_id FROM article_statuses
+  );
+
+  DELETE FROM article_notifications
+  WHERE article_id NOT IN (
+   SELECT article_id FROM article_statuses
   );
 
   DELETE FROM saved_search_articles

--- a/capy/src/test/java/com/jocmp/capy/fixtures/FeedFixture.kt
+++ b/capy/src/test/java/com/jocmp/capy/fixtures/FeedFixture.kt
@@ -14,8 +14,9 @@ internal class FeedFixture(
         feedID: String = randomID(),
         feedURL: String = "https://example.com",
         title: String = "My Feed",
+        enableNotifications: Boolean = false,
     ): Feed = runBlocking {
-        records.upsert(
+        val feed = records.upsert(
             feedID = feedID,
             subscriptionID = randomID(),
             title = title,
@@ -23,6 +24,12 @@ internal class FeedFixture(
             siteURL = feedURL,
             faviconURL = null,
         )!!
+
+        if (enableNotifications) {
+            records.enableNotifications(feed.id, enabled = true)
+        }
+
+        records.find(feed.id)!!
     }
 
     private fun randomID() = SecureRandom.getInstanceStrong().nextInt().toString()


### PR DESCRIPTION
Ensures that notifications are kept in the database with a "dismissed_at" column to represent when the notification was dismissed.

Ref

- #781 