### PR TITLE
Only scroll ArticleLayout when necessary to see article

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleLayout.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleLayout.kt
@@ -135,7 +135,12 @@ fun ArticleLayout(
     fun scrollToArticle(index: Int) {
         coroutineScope.launch {
             if (index > -1) {
-                listState.animateScrollToItem(index)
+                val visibleItemsInfo = listState.layoutInfo.visibleItemsInfo
+                val isItemVisible = visibleItemsInfo.any { it.index == index }
+
+                if (!isItemVisible) {
+                    listState.animateScrollToItem(index)
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #820

When in multicolumn mode only scroll the list when the item isn't already visible in order to avoid unexpected scrolls of the list.