### PR TITLE
Skip already created notifications on notify

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
@@ -95,12 +95,15 @@ internal class ArticleRecords internal constructor(
             }
         }
 
-        return activeNotifications()
+        return notifications(articleIDs)
     }
 
-    private suspend fun activeNotifications(): List<ArticleNotification> {
+    private suspend fun notifications(articleIDs: List<String>): List<ArticleNotification> {
         return notificationQueries
-            .activeNotifications(mapper = ::articleNotificationMapper)
+            .notificationsByID(
+                article_ids = articleIDs,
+                mapper = ::articleNotificationMapper
+            )
             .asFlow()
             .mapToList(Dispatchers.IO)
             .firstOrNull()

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/article_notifications.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/article_notifications.sq
@@ -1,4 +1,4 @@
-activeNotifications:
+notificationsByID:
 SELECT
     article_id,
     articles.title,
@@ -9,7 +9,7 @@ SELECT
 FROM article_notifications
 JOIN articles ON article_notifications.article_id = articles.id
 JOIN feeds ON articles.feed_id = feeds.id
-AND article_notifications.dismissed_at IS NULL;
+WHERE articles.id IN :article_ids;
 
 createNotification:
 INSERT INTO article_notifications(
@@ -39,4 +39,4 @@ LEFT JOIN article_notifications ON article_notifications.article_id = articles.i
 WHERE article_statuses.updated_at >= :since
 AND article_statuses.read = 0
 AND feeds.enable_notifications = 1
-AND article_notifications.dismissed_at IS NULL;
+AND article_notifications.article_id IS NULL;

--- a/capy/src/test/java/com/jocmp/capy/persistence/ArticleRecordsTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/persistence/ArticleRecordsTest.kt
@@ -11,7 +11,6 @@ import com.jocmp.capy.fixtures.ArticleFixture
 import com.jocmp.capy.fixtures.FeedFixture
 import com.jocmp.capy.reload
 import com.jocmp.capy.repeated
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -437,7 +436,7 @@ class ArticleRecordsTest {
     }
 
     @Test
-    fun createNotifications_ignoresDeletedNotifications() = runBlocking {
+    fun createNotifications_ignoresDeletedNotifications() = runTest {
         val feed = FeedFixture(database).create(enableNotifications = true)
         val article = articleFixture.create(feed = feed, read = false)
         val since = article.publishedAt.minusMinutes(15)
@@ -446,6 +445,20 @@ class ArticleRecordsTest {
         assertEquals(actual = notifications.size, expected = 1)
 
         articleRecords.dismissNotifications(listOf(article.id))
+        val refreshedNotifications = articleRecords.createNotifications(since = since)
+
+        assertEquals(actual = refreshedNotifications.size, expected = 0)
+    }
+
+    @Test
+    fun createNotifications_ignoresCreatedNotifications() = runTest {
+        val feed = FeedFixture(database).create(enableNotifications = true)
+        val article = articleFixture.create(feed = feed, read = false)
+        val since = article.publishedAt.minusMinutes(15)
+
+        val notifications = articleRecords.createNotifications(since = since)
+        assertEquals(actual = notifications.size, expected = 1)
+
         val refreshedNotifications = articleRecords.createNotifications(since = since)
 
         assertEquals(actual = refreshedNotifications.size, expected = 0)


### PR DESCRIPTION
Instead of checking for a null "dismissed at," this change will check to see if the notification is in the database.

If the notification was created, it will skip re-notifying it.