### PR TITLE
Deduplicate feeds in notification settings

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
@@ -96,7 +96,7 @@ class ArticleScreenViewModel(
 
     val savedSearches = account.savedSearches
 
-    val allFeeds = account.allFeeds
+    val allFeeds = account.taggedFeeds
 
     val allFolders = account.folders
 

--- a/capy/src/main/java/com/jocmp/capy/Account.kt
+++ b/capy/src/main/java/com/jocmp/capy/Account.kt
@@ -68,6 +68,10 @@ data class Account(
 
     private val articleContent = ArticleContent(httpClient = localHttpClient)
 
+    val taggedFeeds = feedRecords.taggedFeeds().map {
+        it.sortedByTitle()
+    }
+
     val allFeeds = feedRecords.feeds().map {
         it.sortedByTitle()
     }
@@ -76,12 +80,12 @@ data class Account(
         it.sortedByName()
     }
 
-    val feeds: Flow<List<Feed>> = allFeeds.map { all ->
+    val feeds: Flow<List<Feed>> = taggedFeeds.map { all ->
         all.filter { it.folderName.isBlank() }
             .sortedByTitle()
     }
 
-    val folders: Flow<List<Folder>> = allFeeds.map { ungrouped ->
+    val folders: Flow<List<Folder>> = taggedFeeds.map { ungrouped ->
         ungrouped
             .filter { it.folderName.isNotBlank() }
             .groupBy { it.folderName }

--- a/capy/src/main/java/com/jocmp/capy/accounts/local/LocalAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/local/LocalAccountDelegate.kt
@@ -155,7 +155,7 @@ internal class LocalAccountDelegate(
     }
 
     private suspend fun refreshArticleFilter(cutoffDate: ZonedDateTime?) {
-        val feeds = feedRecords.feeds().firstOrNull() ?: return
+        val feeds = feedRecords.taggedFeeds().firstOrNull() ?: return
 
         refreshFeeds(feeds, cutoffDate = cutoffDate)
     }

--- a/capy/src/main/java/com/jocmp/capy/accounts/local/LocalAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/local/LocalAccountDelegate.kt
@@ -155,7 +155,7 @@ internal class LocalAccountDelegate(
     }
 
     private suspend fun refreshArticleFilter(cutoffDate: ZonedDateTime?) {
-        val feeds = feedRecords.taggedFeeds().firstOrNull() ?: return
+        val feeds = feedRecords.feeds().firstOrNull() ?: return
 
         refreshFeeds(feeds, cutoffDate = cutoffDate)
     }

--- a/capy/src/main/java/com/jocmp/capy/persistence/FeedRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/FeedRecords.kt
@@ -86,9 +86,16 @@ internal class FeedRecords(private val database: Database) {
         return Folder(title = title, feeds = feeds)
     }
 
-    internal fun feeds(): Flow<List<Feed>> {
+    internal fun taggedFeeds(): Flow<List<Feed>> {
         return database.feedsQueries
             .tagged(mapper = ::feedMapper)
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+    }
+
+    internal fun feeds(): Flow<List<Feed>> {
+        return database.feedsQueries
+            .all(mapper = ::feedMapper)
             .asFlow()
             .mapToList(Dispatchers.IO)
     }


### PR DESCRIPTION
Previously this used the tagged feeds query which JOINs to the feed table, causing duplicates.

Ref

- #826 