### PR TITLE
Close drawer on back nav

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleLayout.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleLayout.kt
@@ -514,10 +514,15 @@ fun ArticleLayout(
     }
 
     ArticleListBackHandler(
-        enabled = isFeedActive(media, article, search)
-    ) {
-        toggleDrawer()
-    }
+        enabled = isFeedActive(media, article, search),
+        isDrawerOpen = drawerState.isOpen,
+        toggleDrawer = {
+            toggleDrawer()
+        },
+        closeDrawer = {
+            closeDrawer()
+        }
+    )
 
     LayoutNavigationHandler(
         enabled = article == null

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleListBackHandler.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleListBackHandler.kt
@@ -11,12 +11,18 @@ import org.koin.compose.koinInject
 @Composable
 fun ArticleListBackHandler(
     appPreferences: AppPreferences = koinInject(),
+    closeDrawer: () -> Unit,
+    toggleDrawer: () -> Unit,
     enabled: Boolean,
-    onBack: () -> Unit,
+    isDrawerOpen: Boolean,
 ) {
     val backAction by appPreferences.articleListOptions.backAction.asState()
 
     BackHandler(enabled && backAction != BackAction.SYSTEM_BACK) {
-        onBack()
+        toggleDrawer()
+    }
+
+    BackHandler(enabled && isDrawerOpen && backAction == BackAction.SYSTEM_BACK) {
+        closeDrawer()
     }
 }


### PR DESCRIPTION
If the drawer is open, close it on back navigation instead of exiting the app.

Ref

- #831 