### PR TITLE
Display URL if title and summary are empty

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/persistence/ArticleMapper.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/ArticleMapper.kt
@@ -78,7 +78,13 @@ internal fun listMapper(
         url = url,
         feedTitle = feedTitle,
         imageURL = imageURL,
-        summary = summary ?: "",
+        summary = if (!summary.isNullOrBlank()) {
+           summary
+        } else if (title.isNullOrBlank()) {
+            url.orEmpty()
+        } else {
+            ""
+        },
         updatedAt = updatedAt,
         read = read ?: false,
         starred = starred ?: false,


### PR DESCRIPTION
In the worst case scenario, display the article's URL to give context about an article if both the article's title and summary are missing.

Ref

- #827 

<img src="https://github.com/user-attachments/assets/386ff415-e497-47ba-afd8-aec6f7753d40" width="300px">
