### PR TITLE
Call 'attr' instead of 'absUrl' for images

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/articles/CleanLinks.kt
+++ b/capy/src/main/java/com/jocmp/capy/articles/CleanLinks.kt
@@ -10,7 +10,7 @@ internal fun cleanLinks(element: Element) {
     }
 
     element.select("img[data-src]").forEach { child ->
-        child.attr("src", child.absUrl("data-src"))
+        child.attr("src", child.attr("data-src"))
     }
 
     extractChildImages(element)


### PR DESCRIPTION
Ref

- https://github.com/jocmp/capyreader/issues/897