### PR TITLE
Undo 2 second wait for 'mark read on scroll'

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
@@ -129,8 +129,7 @@ fun MarkReadOnScroll(
 
     LaunchedEffect(listState) {
         snapshotFlow { listState.firstVisibleItemIndex }
-            .distinctUntilChanged()
-            .debounce(2_000)
+            .debounce(500)
             .collect { firstVisibleIndex ->
                 val index = firstVisibleIndex - 1
 


### PR DESCRIPTION
Ref

- https://github.com/jocmp/capyreader/issues/909