### PR TITLE
Revert ON CONFLICT change

### DIFF
--- a/capy/build.gradle.kts
+++ b/capy/build.gradle.kts
@@ -25,7 +25,9 @@ android {
                 packageName.set("com.jocmp.capy.db")
                 verifyMigrations.set(true)
                 deriveSchemaFromMigrations.set(true)
-                dialect("app.cash.sqldelight:sqlite-3-38-dialect:$sqldelightVersion")
+                // Explicitly set API 30's version
+                // https://developer.android.com/reference/android/database/sqlite/package-summary
+                dialect("app.cash.sqldelight:sqlite-3-25-dialect:$sqldelightVersion")
             }
         }
     }

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articles.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articles.sq
@@ -121,7 +121,7 @@ VALUES (
   0,
   NULL
 )
-ON CONFLICT DO UPDATE
+ON CONFLICT(article_id) DO UPDATE
 SET
 last_read_at = excluded.last_read_at,
 read = excluded.read;
@@ -143,7 +143,7 @@ VALUES (
   :updatedAt,
   1
 )
-ON CONFLICT DO UPDATE
+ON CONFLICT(article_id) DO UPDATE
 SET
 starred = excluded.starred;
 


### PR DESCRIPTION
Addresses a SQLite syntax error with Android 12 and below where the `ON CONFLICT` failed. The conflict clause without a conflict target is only available in SQLite 3.35.0 or above which correlates with Android 14.

The fix is to reintroduce the `ON CONFLICT(article_id)` that was removed in v2025.02.1107-dev, specifically commit f92294e.

Additionally, this change explicitly targets dialect SQLite 3.25.0 to avoid silent compatibility bugs going forward.

## Reference

- #909 
- https://developer.android.com/reference/android/database/sqlite/package-summary
- https://www.sqlite.org/lang_upsert.html
- https://github.com/jocmp/capyreader/commit/f92294e0e4363a0bac6a72537d79ba93efc9d263#diff-ebff157bdb9ef6664a1e618e22377b55f81084087f248e73bd5c26f1f2b3566e