### PR TITLE
Improve cleanup when dismissing notifications

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/Account.kt
+++ b/capy/src/main/java/com/jocmp/capy/Account.kt
@@ -227,6 +227,10 @@ data class Account(
         return articleRecords.createNotifications(since = since)
     }
 
+    fun dismissStaleNotifications() {
+        articleRecords.dismissStaleNotifications()
+    }
+
     fun countActiveNotifications(): Long {
         return articleRecords.countActiveNotifications()
     }

--- a/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
@@ -164,6 +164,10 @@ internal class ArticleRecords internal constructor(
             .executeAsOneOrNull() ?: 0
     }
 
+    internal fun dismissStaleNotifications() {
+        notificationQueries.dismissStaleNotifications(deleted_at = nowUTC().toEpochSecond())
+    }
+
     internal fun dismissNotifications(ids: List<String>) {
         notificationQueries.dismissNotifications(
             ids = ids,

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/article_notifications.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/article_notifications.sq
@@ -29,6 +29,10 @@ dismissNotifications:
 UPDATE article_notifications SET
 dismissed_at = :deleted_at WHERE article_id IN :ids;
 
+dismissStaleNotifications:
+UPDATE article_notifications SET
+dismissed_at = :deleted_at WHERE dismissed_at IS NULL;
+
 articlesToNotify:
 SELECT
     articles.id AS article_id

--- a/capy/src/test/java/com/jocmp/capy/persistence/ArticleRecordsTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/persistence/ArticleRecordsTest.kt
@@ -463,6 +463,22 @@ class ArticleRecordsTest {
 
         assertEquals(actual = refreshedNotifications.size, expected = 0)
     }
+
+    @Test
+    fun dismissStaleNotifications_deletesAllUndeletedNotifications() = runTest {
+        val feed = FeedFixture(database).create(enableNotifications = true)
+        val articles = 3.repeated { articleFixture.create(feed = feed, read = false) }
+        val since = articles.first().publishedAt.minusMinutes(15)
+
+        articleRecords.createNotifications(since = since)
+        val activeCount = articleRecords.countActiveNotifications()
+        assertEquals(actual = activeCount, expected = 3)
+
+        articleRecords.dismissStaleNotifications()
+
+        val updatedCount = articleRecords.countActiveNotifications()
+        assertEquals(actual = updatedCount, expected = 0)
+    }
 }
 
 fun sortedMessage(expected: List<Article>, actual: List<Article>): String {


### PR DESCRIPTION
Attempts to solve an issue where an empty group notification will stay in the notification shade. The fix is to clear article notifications on refresh, and also check for active notifications on dismiss.