### PR TITLE
[gplay] Add call to ProviderInstaller

### DIFF
--- a/app/src/free/java/com/capyreader/app/common/SecurityUpdater.kt
+++ b/app/src/free/java/com/capyreader/app/common/SecurityUpdater.kt
@@ -1,0 +1,10 @@
+package com.capyreader.app.common
+
+import android.content.Context
+
+
+class SecurityUpdater {
+    fun updateAsync(context: Context) {
+        // Stub
+    }
+}

--- a/app/src/gplay/java/com/capyreader/app/common/SecurityUpdater.kt
+++ b/app/src/gplay/java/com/capyreader/app/common/SecurityUpdater.kt
@@ -1,0 +1,26 @@
+package com.capyreader.app.common
+
+import android.content.Context
+import android.content.Intent
+import com.google.android.gms.security.ProviderInstaller
+import com.jocmp.capy.logging.CapyLog
+
+class SecurityUpdater {
+    fun updateAsync(context: Context) {
+        ProviderInstaller.installIfNeededAsync(context, Listener())
+    }
+
+    private class Listener : ProviderInstaller.ProviderInstallListener {
+        override fun onProviderInstalled() {
+            CapyLog.info(TAG)
+        }
+
+        override fun onProviderInstallFailed(errorCode: Int, intent: Intent?) {
+            CapyLog.warn(TAG, mapOf("error_code" to errorCode.toString()))
+        }
+    }
+
+    companion object {
+        const val TAG = "sec_update"
+    }
+}

--- a/app/src/main/java/com/capyreader/app/MainActivity.kt
+++ b/app/src/main/java/com/capyreader/app/MainActivity.kt
@@ -9,8 +9,9 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import com.capyreader.app.preferences.AppPreferences
+import com.capyreader.app.common.SecurityUpdater
 import com.capyreader.app.notifications.NotificationHelper
+import com.capyreader.app.preferences.AppPreferences
 import com.capyreader.app.ui.App
 import com.capyreader.app.ui.Route
 import org.koin.android.ext.android.get
@@ -24,6 +25,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         NotificationHelper.openArticle(intent, appPreferences = appPreferences)
+        SecurityUpdater().updateAsync(applicationContext)
 
         val theme = appPreferences.theme
 


### PR DESCRIPTION
Plugs into GMS to keep SSL certificates up-to-date for older devices. 

Only applies to Google Play build.

- https://developer.android.com/privacy-and-security/security-gms-provider