### PR TITLE
Don't send edit-tag if unchanged

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/Account.kt
+++ b/capy/src/main/java/com/jocmp/capy/Account.kt
@@ -199,15 +199,15 @@ data class Account(
     }
 
     suspend fun markAllRead(articleIDs: List<String>): Result<Unit> {
-        articleRecords.markAllRead(articleIDs)
+        val changesetIDs = articleRecords.filterUnreadStatuses(articleIDs)
 
-        return delegate.markRead(articleIDs)
+        articleRecords.markAllRead(changesetIDs)
+
+        return delegate.markRead(changesetIDs)
     }
 
     suspend fun markRead(articleID: String): Result<Unit> {
-        articleRecords.markAllRead(listOf(articleID))
-
-        return delegate.markRead(listOf(articleID))
+        return markAllRead(listOf(articleID))
     }
 
     suspend fun markUnread(articleID: String): Result<Unit> {

--- a/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
@@ -276,6 +276,10 @@ internal class ArticleRecords internal constructor(
         return max.toDateTimeFromSeconds
     }
 
+    fun filterUnreadStatuses(ids: List<String>): List<String> {
+       return database.articlesQueries.filterUnreadStatuses(ids).executeAsList()
+    }
+
     fun unreadArticleIDs(filter: ArticleFilter, range: MarkRead, unreadSort: UnreadSortOrder): List<String> {
         val ids = when (filter) {
             is ArticleFilter.Articles -> byStatus.unreadArticleIDs(

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articles.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articles.sq
@@ -35,6 +35,12 @@ FROM article_statuses
 LEFT OUTER JOIN articles ON article_statuses.article_id = articles.id
 WHERE articles.id IS NULL;
 
+filterUnreadStatuses:
+SELECT article_id
+FROM article_statuses
+WHERE article_statuses.read = 0
+AND article_statuses.article_id IN :articleIDs;
+
 create:
 INSERT INTO articles(
     id,

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -9,3 +9,4 @@ Some features include:
 • Full content mode
 • Dark mode
 • Big screen support
+• Import and export your saved feeds


### PR DESCRIPTION
Addresses unexpected behavior with Miniflux's Google Reader API where clicking through to a read item will mark it as unread.

This is because the edit-tag endpoint will toggle the item's state instead of persisting it based on the requested state like "mark read."

The fix is to optimistically lock the changest for unread items and only mark items as read against the API if they're changed in the local database.

Ref

- #983 