### PR TITLE
Fix feed list sort for unicode characters

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/common/FeedListExt.kt
+++ b/capy/src/main/java/com/jocmp/capy/common/FeedListExt.kt
@@ -1,6 +1,12 @@
 package com.jocmp.capy.common
 
 import com.jocmp.capy.Feed
+import java.text.Collator
+import java.util.Locale
 
 fun List<Feed>.sortedByTitle() =
-    sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.title })
+    sortedWith(compareBy(Collator.getInstance(Locale.getDefault()).apply {
+        strength = Collator.PRIMARY
+    }) {
+        it.title
+    })

--- a/capy/src/test/java/com/jocmp/capy/common/FeedListExtTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/common/FeedListExtTest.kt
@@ -1,0 +1,39 @@
+package com.jocmp.capy.common
+
+import com.jocmp.capy.InMemoryDatabaseProvider
+import com.jocmp.capy.db.Database
+import com.jocmp.capy.fixtures.FeedFixture
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FeedListExtTest {
+    private lateinit var feedFixture: FeedFixture
+    private lateinit var database: Database
+
+    @BeforeTest
+    fun setUp() {
+        database = InMemoryDatabaseProvider.build("777")
+        feedFixture = FeedFixture(database)
+    }
+
+    @Test
+    fun sortedByTitle_sortsInCaseInsensitiveOrder() {
+        val feeds = listOf(
+            feedFixture.create(title = "Kiwi"),
+            feedFixture.create(title = "apple"),
+            feedFixture.create(title = "Élderberry"),
+            feedFixture.create(title = "Cherry")
+        )
+
+        val sortedTitles = feeds.sortedByTitle().map { it.title }
+        val expected = listOf(
+            "apple",
+            "Cherry",
+            "Élderberry",
+            "Kiwi"
+        )
+
+        assertEquals(expected = expected, actual = sortedTitles)
+    }
+}


### PR DESCRIPTION
Fixes order from

`A, E, Z, É`

to

`A, E, É, Z`