### PR TITLE
Key scrollbar off filter

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -481,18 +482,20 @@ fun ArticleScreen(
                                     requestNextFeed()
                                 },
                             ) {
-                                ArticleList(
-                                    articles = articles,
-                                    selectedArticleKey = article?.id,
-                                    listState = listState,
-                                    enableMarkReadOnScroll = enableMarkReadOnScroll,
-                                    onMarkAllRead = { range ->
-                                        onMarkAllRead(range)
-                                    },
-                                    onSelect = { articleID ->
-                                        selectArticle(articleID)
-                                    },
-                                )
+                                key(filter) {
+                                    ArticleList(
+                                        articles = articles,
+                                        selectedArticleKey = article?.id,
+                                        listState = listState,
+                                        enableMarkReadOnScroll = enableMarkReadOnScroll,
+                                        onMarkAllRead = { range ->
+                                            onMarkAllRead(range)
+                                        },
+                                        onSelect = { articleID ->
+                                            selectArticle(articleID)
+                                        },
+                                    )
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Prevent scrollbar from disappearing after switching filters. The fix is to key the lazy scrollbar off the filter so that it's in sync with the lazy list state's params.

Ref

- #1272 