### PR TITLE
Temporarily hide Miniflux option on 'Add Account'

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/accounts/AddAccountView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/AddAccountView.kt
@@ -71,10 +71,6 @@ fun AddAccountView(
                 )
                 SyncServiceRow(
                     onSelectService,
-                    source = Source.MINIFLUX,
-                )
-                SyncServiceRow(
-                    onSelectService,
                     source = Source.READER
                 )
             }


### PR DESCRIPTION
Miniflux is still available via the Google Reader API option.