### PR TITLE
Make title shortening optional

### DIFF
--- a/app/src/main/java/com/capyreader/app/preferences/AppPreferences.kt
+++ b/app/src/main/java/com/capyreader/app/preferences/AppPreferences.kt
@@ -142,6 +142,9 @@ class AppPreferences(context: Context) {
         val imagePreview: Preference<ImagePreview>
             get() = preferenceStore.getEnum("article_display_image_preview", ImagePreview.default)
 
+        val shortenTitles: Preference<Boolean>
+            get() = preferenceStore.getBoolean("article_display_shorten_titles", true)
+
         val fontScale: Preference<ArticleListFontScale>
             get() = preferenceStore.getEnum(
                 "article_display_font_scale",

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
@@ -172,6 +172,8 @@ fun rememberArticleOptions(appPreferences: AppPreferences = koinInject()): Artic
     val imagePreview by appPreferences.articleListOptions.imagePreview.stateIn(scope)
         .collectAsState()
     val fontScale by appPreferences.articleListOptions.fontScale.stateIn(scope).collectAsState()
+    val shortenTitles by appPreferences.articleListOptions.shortenTitles.stateIn(scope)
+        .collectAsState()
 
     return ArticleRowOptions(
         showSummary = showSummary,
@@ -179,6 +181,7 @@ fun rememberArticleOptions(appPreferences: AppPreferences = koinInject()): Artic
         showFeedName = showFeedName,
         imagePreview = imagePreview,
         fontScale = fontScale,
+        shortenTitles = shortenTitles,
     )
 }
 

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleRow.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleRow.kt
@@ -70,7 +70,8 @@ data class ArticleRowOptions(
     val showSummary: Boolean = true,
     val showFeedName: Boolean = true,
     val imagePreview: ImagePreview = ImagePreview.default,
-    val fontScale: ArticleListFontScale = ArticleListFontScale.MEDIUM
+    val fontScale: ArticleListFontScale = ArticleListFontScale.MEDIUM,
+    val shortenTitles: Boolean = true,
 )
 
 @Composable
@@ -106,7 +107,7 @@ fun ArticleRow(
                     if (article.title.isNotBlank()) {
                         Text(
                             article.title,
-                            maxLines = 3,
+                            maxLines = if (options.shortenTitles) 3 else Int.MAX_VALUE,
                             overflow = TextOverflow.Ellipsis,
                             fontWeight = FontWeight.Bold,
                         )

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/ArticleListSettings.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/ArticleListSettings.kt
@@ -25,12 +25,14 @@ data class ArticleListOptions(
     val showFeedIcons: Boolean,
     val showFeedName: Boolean,
     val showSummary: Boolean,
+    val shortenTitles: Boolean,
     val fontScale: ArticleListFontScale,
     val updateFeedIcons: (show: Boolean) -> Unit,
     val updateFeedName: (show: Boolean) -> Unit,
     val updateImagePreview: (preview: ImagePreview) -> Unit,
     val updateSummary: (show: Boolean) -> Unit,
     val updateFontScale: (scale: ArticleListFontScale) -> Unit,
+    val updateShortenTitles: (show: Boolean) -> Unit,
 )
 
 @Composable
@@ -55,6 +57,11 @@ fun ArticleListSettings(
                 onCheckedChange = options.updateSummary,
                 checked = options.showSummary,
                 title = stringResource(R.string.settings_article_list_summary)
+            )
+            TextSwitch(
+                onCheckedChange = options.updateShortenTitles,
+                checked = options.shortenTitles,
+                title = stringResource(R.string.settings_article_list_shorten_titles)
             )
         }
 
@@ -103,6 +110,8 @@ private fun ArticleListSettingsPreview() {
             updateFeedName = {},
             updateFeedIcons = {},
             updateFontScale = {},
+            shortenTitles = true,
+            updateShortenTitles = {},
         )
     )
 }

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/ArticleListSettings.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/ArticleListSettings.kt
@@ -105,12 +105,12 @@ private fun ArticleListSettingsPreview() {
             showFeedIcons = true,
             fontScale = ArticleListFontScale.LARGE,
             showFeedName = false,
+            shortenTitles = true,
             updateImagePreview = {},
             updateSummary = {},
             updateFeedName = {},
             updateFeedIcons = {},
             updateFontScale = {},
-            shortenTitles = true,
             updateShortenTitles = {},
         )
     )

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/DisplaySettingsPanel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/DisplaySettingsPanel.kt
@@ -58,11 +58,13 @@ fun DisplaySettingsPanel(
             fontScale = viewModel.fontScale,
             showFeedIcons = viewModel.showFeedIcons,
             showFeedName = viewModel.showFeedName,
+            shortenTitles = viewModel.shortenTitles,
             updateImagePreview = viewModel::updateImagePreview,
             updateSummary = viewModel::updateSummary,
             updateFeedName = viewModel::updateFeedName,
             updateFeedIcons = viewModel::updateFeedIcons,
             updateFontScale = viewModel::updateFontScale,
+            updateShortenTitles = viewModel::updateShortenTitles,
         )
     )
 }
@@ -189,11 +191,13 @@ private fun DisplaySettingsPanelViewPreview() {
                 fontScale = ArticleListFontScale.MEDIUM,
                 showFeedIcons = true,
                 showFeedName = false,
+                shortenTitles = true,
                 updateImagePreview = {},
                 updateSummary = {},
                 updateFeedName = {},
                 updateFeedIcons = {},
                 updateFontScale = {},
+                updateShortenTitles = {},
             ),
             updatePinArticleBars = {},
             pinArticleBars = false,

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/DisplaySettingsViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/DisplaySettingsViewModel.kt
@@ -29,6 +29,8 @@ class DisplaySettingsViewModel(
     private val _showFeedIcons =
         mutableStateOf(appPreferences.articleListOptions.showFeedIcons.get())
 
+    private val _shortenTitles = mutableStateOf(appPreferences.articleListOptions.shortenTitles.get())
+
     var fontScale by mutableStateOf(appPreferences.articleListOptions.fontScale.get())
         private set
 
@@ -45,6 +47,9 @@ class DisplaySettingsViewModel(
 
     val showFeedIcons: Boolean
         get() = _showFeedIcons.value
+
+    val shortenTitles: Boolean
+        get() = _shortenTitles.value
 
     var enableHighContrastDarkTheme by mutableStateOf(appPreferences.enableHighContrastDarkTheme.get())
         private set
@@ -125,5 +130,11 @@ class DisplaySettingsViewModel(
         appPreferences.articleListOptions.showFeedName.set(show)
 
         _showFeedName.value = show
+    }
+
+    fun updateShortenTitles(shortenTitles: Boolean) {
+        appPreferences.articleListOptions.shortenTitles.set(shortenTitles)
+
+        _shortenTitles.value = shortenTitles
     }
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -97,7 +97,8 @@
     <string name="image_preview_label">معاينة الصورة</string>
     <string name="settings_article_list_feed_name">إسم الموجز</string>
     <string name="settings_article_list_feed_icons">أيقونة الموجز</string>
-    <string name="settings_article_list_summary">ملخص من المقال</string>
+    <string name="settings_article_list_summary">ملخص</string>
+    <string name="settings_article_list_shorten_titles">تقصير العناوين</string>
     <string name="settings_section_version">الإصدار</string>
     <string name="settings_option_copy_version">نسخ الإصدار</string>
     <string name="settings_option_full_content_title">تحميل المحتوى الكامل دائماً</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -97,7 +97,7 @@
     <string name="image_preview_label">معاينة الصورة</string>
     <string name="settings_article_list_feed_name">إسم الموجز</string>
     <string name="settings_article_list_feed_icons">أيقونة الموجز</string>
-    <string name="settings_article_list_summary">ملخص</string>
+    <string name="settings_article_list_summary">ملخص من المقال</string>
     <string name="settings_article_list_shorten_titles">تقصير العناوين</string>
     <string name="settings_section_version">الإصدار</string>
     <string name="settings_option_copy_version">نسخ الإصدار</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -106,6 +106,7 @@
     <string name="settings_article_list_feed_name">Naziv Izvora</string>
     <string name="settings_article_list_feed_icons">Ikonice Izvora</string>
     <string name="settings_article_list_summary">Rezime</string>
+    <string name="settings_article_list_shorten_titles">Skrati naslove</string>
     <string name="settings_section_version">Verzija</string>
     <string name="settings_option_copy_version">Kopiraj verziju</string>
     <string name="settings_option_full_content_title">Lepljivi puni sadržaj</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -119,6 +119,7 @@
     <string name="settings_article_list_feed_name">Име на емисия</string>
     <string name="settings_article_list_feed_icons">Икони на емисия</string>
     <string name="settings_article_list_summary">Резюме</string>
+    <string name="settings_article_list_shorten_titles">Съкращаване на заглавията</string>
     <string name="settings_section_version">Версия</string>
     <string name="settings_option_full_content_title">Приложи пълно съдържание</string>
     <string name="refresh_on_start">При стартиране</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -117,7 +117,7 @@
     <string name="opml_import_progress_content_text_start">Začíná import</string>
     <string name="opml_import_toast_complete">Import dokončen</string>
     <string name="opml_import_notification_cancel">Stop</string>
-    <string name="settings_article_list_summary">Shrnutí</string>
+    <string name="settings_article_list_summary">Souhrn</string>
     <string name="settings_article_list_shorten_titles">Zkrátit názvy</string>
     <string name="article_style_options">Nastavení fontu</string>
     <string name="font_option_vollkorn">Vollkorn</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -117,7 +117,8 @@
     <string name="opml_import_progress_content_text_start">Začíná import</string>
     <string name="opml_import_toast_complete">Import dokončen</string>
     <string name="opml_import_notification_cancel">Stop</string>
-    <string name="settings_article_list_summary">Souhrn</string>
+    <string name="settings_article_list_summary">Shrnutí</string>
+    <string name="settings_article_list_shorten_titles">Zkrátit názvy</string>
     <string name="article_style_options">Nastavení fontu</string>
     <string name="font_option_vollkorn">Vollkorn</string>
     <string name="font_option_atkinson_hyperlegible">Atkinson Hyperlegible</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -85,6 +85,7 @@
     <string name="settings_article_list_feed_name">Feed Name</string>
     <string name="settings_article_list_feed_icons">Feed Icons</string>
     <string name="settings_article_list_summary">Zusammenfassung</string>
+    <string name="settings_article_list_shorten_titles">Titel kürzen</string>
     <string name="settings_section_version">Version</string>
     <string name="settings_option_copy_version">Version kopieren</string>
     <string name="settings_option_full_content_title">Permanent vollständigen Text zeigen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -72,7 +72,7 @@
     <string name="settings_article_list_feed_name">Όνομα Ροής</string>
     <string name="filter_action_menu_search_articles">Αναζήτηση άρθρων</string>
     <string name="settings_auto_delete_option_keep_for_three_month">3 μήνες</string>
-    <string name="settings_article_list_summary">Περίληψη</string>
+    <string name="settings_article_list_summary">Σύνοψη</string>
     <string name="settings_article_list_shorten_titles">Συντόμευση τίτλων</string>
     <string name="settings_section_version">Έκδοση</string>
     <string name="font_option_system_default">Προεπιλογή συστήματος</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -72,7 +72,8 @@
     <string name="settings_article_list_feed_name">Όνομα Ροής</string>
     <string name="filter_action_menu_search_articles">Αναζήτηση άρθρων</string>
     <string name="settings_auto_delete_option_keep_for_three_month">3 μήνες</string>
-    <string name="settings_article_list_summary">Σύνοψη</string>
+    <string name="settings_article_list_summary">Περίληψη</string>
+    <string name="settings_article_list_shorten_titles">Συντόμευση τίτλων</string>
     <string name="settings_section_version">Έκδοση</string>
     <string name="font_option_system_default">Προεπιλογή συστήματος</string>
     <string name="article_font_menu_label">Γραμματοσειρά</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -106,6 +106,7 @@
     <string name="settings_article_list_feed_name">Nombre del feed</string>
     <string name="settings_article_list_feed_icons">Iconos del feed</string>
     <string name="settings_article_list_summary">Resumen</string>
+    <string name="settings_article_list_shorten_titles">Acortar títulos</string>
     <string name="settings_section_version">Versión</string>
     <string name="settings_option_copy_version">Copiar versión</string>
     <string name="settings_option_full_content_title">Contenido completado fijado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -90,6 +90,7 @@
     <string name="settings_article_list_feed_name">Nom du flux</string>
     <string name="settings_article_list_feed_icons">Icônes du flux</string>
     <string name="settings_article_list_summary">Résumé</string>
+    <string name="settings_article_list_shorten_titles">Raccourcir les titres</string>
     <string name="settings_option_copy_version">Copier la version</string>
     <string name="settings_option_full_content_title">Maintenir l\'affichage complet</string>
     <string name="refresh_on_start">Au démarrage</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -134,6 +134,7 @@
     <string name="settings_section_refresh">Segarkan</string>
     <string name="opml_import_toast_failed">Impor gagal</string>
     <string name="settings_article_list_summary">Ringkasan</string>
+    <string name="settings_article_list_shorten_titles">Perpendek judul</string>
     <string name="settings_section_version">Versi</string>
     <string name="settings_option_copy_version">Salin versi</string>
     <string name="empty_onboarding_prompt">Mulai dengan menambahkan umpan</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -69,6 +69,7 @@
     <string name="settings_article_list_feed_name">Nome del feed</string>
     <string name="settings_article_list_feed_icons">Icone dei feed</string>
     <string name="settings_article_list_summary">Sommario</string>
+    <string name="settings_article_list_shorten_titles">Accorciare i titoli</string>
     <string name="settings_panel_display_title">Visualizzazione e aspetto</string>
     <string name="settings_section_version">Versione</string>
     <string name="image_preview_menu_option_large">Grande</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -61,6 +61,5 @@
     <string name="nav_add_feed">הוסף פיד</string>
     <string name="add_feed_network_error">לא ניתן למצוא את הפיד. בדוק את החיבור שלך.</string>
     <string name="edit_feed_error">שגיאה בשמירת הפיד</string>
-    <string name="settings_article_list_summary">סיכום</string>
     <string name="settings_article_list_shorten_titles">קצר כותרות</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -61,4 +61,6 @@
     <string name="nav_add_feed">הוסף פיד</string>
     <string name="add_feed_network_error">לא ניתן למצוא את הפיד. בדוק את החיבור שלך.</string>
     <string name="edit_feed_error">שגיאה בשמירת הפיד</string>
+    <string name="settings_article_list_summary">סיכום</string>
+    <string name="settings_article_list_shorten_titles">קצר כותרות</string>
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -62,7 +62,8 @@
     <string name="theme_menu_option_light">Lyst</string>
     <string name="theme_menu_option_dark">Mørkt</string>
     <string name="image_preview_menu_option_large">Stor</string>
-    <string name="settings_article_list_summary">Oppsummering</string>
+    <string name="settings_article_list_summary">Sammendrag</string>
+    <string name="settings_article_list_shorten_titles">Forkort titler</string>
     <string name="settings_section_version">Versjon</string>
     <string name="settings_option_copy_version">Kopier versjonsnummer</string>
     <string name="edit_feed_tags">Etiketter</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -62,7 +62,7 @@
     <string name="theme_menu_option_light">Lyst</string>
     <string name="theme_menu_option_dark">Mørkt</string>
     <string name="image_preview_menu_option_large">Stor</string>
-    <string name="settings_article_list_summary">Sammendrag</string>
+    <string name="settings_article_list_summary">Oppsummering</string>
     <string name="settings_article_list_shorten_titles">Forkort titler</string>
     <string name="settings_section_version">Versjon</string>
     <string name="settings_option_copy_version">Kopier versjonsnummer</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -12,6 +12,7 @@
     <string name="relative_time_hours">%1$dh</string>
     <string name="settings_remove_account_title_local">Usuń konto</string>
     <string name="settings_article_list_summary">Podsumowanie</string>
+    <string name="settings_article_list_shorten_titles">Skróć tytuły</string>
     <string name="settings_panel_notifications_title">Powiadomienia</string>
     <string name="settings_about_title">O aplikacji</string>
     <string name="settings_clear_all_articles_confirm">Potwierdź</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -106,6 +106,7 @@
     <string name="settings_article_list_feed_name">Nome do Feed</string>
     <string name="settings_article_list_feed_icons">Ícone do Feed</string>
     <string name="settings_article_list_summary">Resumo</string>
+    <string name="settings_article_list_shorten_titles">Encurtar títulos</string>
     <string name="settings_section_version">Versão</string>
     <string name="settings_option_copy_version">Copiar versão</string>
     <string name="settings_option_full_content_title">Conteúdo Completo Fixo</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -161,6 +161,7 @@
     <string name="image_preview_menu_option_large">Mare</string>
     <string name="image_preview_label">Previzualizare imagine</string>
     <string name="settings_article_list_summary">Rezumat</string>
+    <string name="settings_article_list_shorten_titles">Scurtează titlurile</string>
     <string name="settings_option_copy_version">Copiază versiunea</string>
     <string name="empty_onboarding_prompt">Începe prin a adăuga un flux</string>
     <string name="article_style_options">Opțiuni pentru stilul de font</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -169,6 +169,7 @@
     <string name="notifications_channel_title_feed_update">Обновления ленты</string>
     <string name="theme_menu_option_system_default">Системная по умолчанию</string>
     <string name="settings_article_list_summary">Резюме</string>
+    <string name="settings_article_list_shorten_titles">Сокращать заголовки</string>
     <string name="settings_option_full_content_title">Закрепить полное содержание</string>
     <string name="font_option_atkinson_hyperlegible">Atkinson Hyperlegible</string>
     <string name="font_option_poppins">Poppins</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -108,6 +108,7 @@
     <string name="image_preview_menu_option_none">Ingen</string>
     <string name="add_account_reader_subtitle">Självhanterad hosting av Google Reader API</string>
     <string name="settings_article_list_summary">Sammanfattning</string>
+    <string name="settings_article_list_shorten_titles">Förkorta titlar</string>
     <string name="settings_option_copy_version">Kopiera version</string>
     <string name="empty_onboarding_title">Inga flöden än</string>
     <string name="empty_onboarding_prompt">Kom igång genom att lägga till ett flöde</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -31,6 +31,7 @@
     <string name="image_preview_menu_option_small">Küçük</string>
     <string name="settings_article_list_feed_icons">Yayın İkonu</string>
     <string name="settings_article_list_summary">Özet</string>
+    <string name="settings_article_list_shorten_titles">Başlıkları kısalt</string>
     <string name="settings_option_copy_version">Kopya sürümü</string>
     <string name="settings_option_full_content_title">Yapışkan Tam İçerik</string>
     <string name="settings_option_full_content_subtitle">Tam makale içeriğini yükleme seçeneğini hatırla</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -67,6 +67,7 @@
     <string name="theme_menu_option_dark">深色</string>
     <string name="settings_option_in_app_browser">使用应用内浏览器</string>
     <string name="settings_article_list_summary">概括</string>
+    <string name="settings_article_list_shorten_titles">缩短标题</string>
     <string name="settings_section_version">版本</string>
     <string name="settings_option_copy_version">复制版本</string>
     <string name="settings_option_full_content_title">固定显示全文内容</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -149,6 +149,7 @@
     <string name="opml_import_toast_complete">匯入完成</string>
     <string name="theme_menu_label">主題</string>
     <string name="settings_article_list_summary">摘要</string>
+    <string name="settings_article_list_shorten_titles">縮短標題</string>
     <string name="settings_section_version">版本</string>
     <string name="settings_option_full_content_title">保持全文加載</string>
     <string name="refresh_on_start">啓動時</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,7 @@
     <string name="settings_article_list_feed_name">Feed Name</string>
     <string name="settings_article_list_feed_icons">Feed Icons</string>
     <string name="settings_article_list_summary">Summary</string>
+    <string name="settings_article_list_shorten_titles">Shorten titles</string>
     <string name="settings_section_version">Version</string>
     <string name="settings_option_copy_version">Copy version</string>
     <string name="settings_option_full_content_title">Sticky Full Content</string>


### PR DESCRIPTION
As discussed here: https://github.com/jocmp/capyreader/discussions/1330

- Make title shortening optional with a boolean toggle in settings
- Keeps current behavior as default

![shortentitles1](https://github.com/user-attachments/assets/5e0a45d0-2b5e-4e1c-a2c2-57b4a36af91a)
![shortentitles2](https://github.com/user-attachments/assets/6a4e05c9-23d3-4513-9e8b-8e00b7a177ff)
![shortentitles3](https://github.com/user-attachments/assets/40790876-69f1-49ae-99e7-86ee7ceded35)