### PR TITLE
Re-add behavior to clear read articles on refresh

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
@@ -316,6 +316,7 @@ class ArticleScreenViewModel(
 
     fun refresh(filter: ArticleFilter, onComplete: () -> Unit) {
         initialize(filter) {
+            updateArticlesSince()
             onComplete()
         }
     }
@@ -506,7 +507,7 @@ class ArticleScreenViewModel(
     }
 
     private fun updateArticlesSince() {
-        articlesSince.value = OffsetDateTime.now()
+        articlesSince.value = OffsetDateTime.now().plusSeconds(1)
     }
 
     private fun copyFolderCounts(

--- a/fastlane/metadata/android/en-US/changelogs/1147.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1147.txt
@@ -1,0 +1,2 @@
+• Readd behavior to clear articles on refresh for the unread filter
+• Update translations for Estonian thanks to a volunteer


### PR DESCRIPTION
On refresh, read articles will now disappear. This behavior was previously removed in the latest dev release.

Ref

- https://github.com/jocmp/capyreader/issues/1340