### PR TITLE
Fix share sheet jump on Xiaomi phones

### DIFF
--- a/app/src/main/java/com/capyreader/app/BaseActivity.kt
+++ b/app/src/main/java/com/capyreader/app/BaseActivity.kt
@@ -5,12 +5,16 @@ import android.os.StrictMode
 import android.os.StrictMode.setThreadPolicy
 import androidx.activity.ComponentActivity
 import androidx.activity.enableEdgeToEdge
+import com.capyreader.app.ui.EdgeToEdgeHelper.isEdgeToEdgeAvailable
 
 abstract class BaseActivity: ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableStrictModeOnDebug()
-        enableEdgeToEdge()
+
+        if (isEdgeToEdgeAvailable()) {
+            enableEdgeToEdge()
+        }
     }
 }
 

--- a/app/src/main/java/com/capyreader/app/ui/EdgeToEdgeHelper.kt
+++ b/app/src/main/java/com/capyreader/app/ui/EdgeToEdgeHelper.kt
@@ -1,0 +1,16 @@
+package com.capyreader.app.ui
+
+import android.os.Build
+
+object EdgeToEdgeHelper {
+    /**
+     * Attempts to solve issues on MIUI where the share sheet will jump
+     * due to the edge-to-edge mode.
+     *
+     * MIUI 14 is built against Android 12 and 13, so any check below
+     * UPSIDE_DOWN_CAKE (SDK 34/Android 14) will suffice.
+     */
+    fun isEdgeToEdgeAvailable(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+    }
+}

--- a/app/src/main/java/com/capyreader/app/ui/articles/media/ArticleMediaView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/media/ArticleMediaView.kt
@@ -43,6 +43,7 @@ import androidx.core.view.WindowCompat
 import coil.request.ImageRequest
 import com.capyreader.app.common.Media
 import com.capyreader.app.preferredMaxWidth
+import com.capyreader.app.ui.EdgeToEdgeHelper.isEdgeToEdgeAvailable
 import com.capyreader.app.ui.components.LoadingView
 import com.capyreader.app.ui.components.Swiper
 import com.capyreader.app.ui.components.rememberSwiperState
@@ -111,6 +112,7 @@ fun ArticleMediaView(
         val window = (view.context as Activity).window
 
         window.navigationBarColor = Color.Black.toArgb()
+        window.statusBarColor = Color.Black.toArgb()
         WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = false
     }
 
@@ -118,11 +120,21 @@ fun ArticleMediaView(
         val window = (view.context as Activity).window
 
         val previousColor = window.navigationBarColor
+
+        var previousStatusBarColor: Int? = null
+
+        if (!isEdgeToEdgeAvailable()) {
+            previousStatusBarColor = window.statusBarColor
+        }
+
         val previousAppearanceLightStatusBars =
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars
 
         onDispose {
             window.navigationBarColor = previousColor
+            previousStatusBarColor?.let {
+                window.statusBarColor = it
+            }
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars =
                 previousAppearanceLightStatusBars
         }

--- a/app/src/main/java/com/capyreader/app/ui/theme/Theme.kt
+++ b/app/src/main/java/com/capyreader/app/ui/theme/Theme.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import com.capyreader.app.preferences.AppPreferences
 import com.capyreader.app.preferences.ThemeOption
+import com.capyreader.app.ui.EdgeToEdgeHelper.isEdgeToEdgeAvailable
 import org.koin.compose.koinInject
 
 private val DarkColorScheme = darkColorScheme(
@@ -90,7 +91,11 @@ fun CapyTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.navigationBarColor = colorScheme.background.toArgb()
+
+            if (!isEdgeToEdgeAvailable()) {
+                window.statusBarColor = colorScheme.surfaceContainer.toArgb()
+            }
+
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars =
                 showAppearanceLightStatusBars
         }

--- a/fastlane/metadata/android/en-US/changelogs/1152.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1152.txt
@@ -1,0 +1,1 @@
+• Fix share sheet jump bug on Xiaomi/MIUI 14 devices


### PR DESCRIPTION
Disables edge-to-edge on Android 13 and below to ensure that it doesn't interfere with the webview when the share sheet is open.

Ref

- https://github.com/jocmp/capyreader/issues/1059

