### PR TITLE
Truncate summary in list

### DIFF
--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByFeed.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByFeed.sq
@@ -5,7 +5,7 @@ SELECT
   articles.title,
   articles.author,
   articles.url,
-  articles.summary,
+  SUBSTR(articles.summary, 1, 250),
   articles.image_url,
   articles.published_at,
   feeds.title AS feed_title,

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articlesBySavedSearch.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articlesBySavedSearch.sq
@@ -5,7 +5,7 @@ SELECT
   articles.title,
   articles.author,
   articles.url,
-  articles.summary,
+  SUBSTR(articles.summary, 1, 250),
   articles.image_url,
   articles.published_at,
   feeds.title AS feed_title,

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByStatus.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByStatus.sq
@@ -5,7 +5,7 @@ SELECT
   articles.title,
   articles.author,
   articles.url,
-  articles.summary,
+  SUBSTR(articles.summary, 1, 250),
   articles.image_url,
   articles.published_at,
   feeds.title AS feed_title,

--- a/capy/src/test/java/com/jocmp/capy/persistence/articles/ByArticleStatusTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/persistence/articles/ByArticleStatusTest.kt
@@ -33,6 +33,28 @@ class ByArticleStatusTest {
     }
 
     @Test
+    fun all_summaryTruncation() = runTest {
+        val summary = """
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent turpis nisi, hendrerit in lobortis ac, cursus quis odio. Etiam gravida lacinia sodales. Ut sodales orci a auctor blandit. Pellentesque ultrices faucibus magna sed rhoncus. Praesent vulputate finibus auctor. Sed a neque nec odio imperdiet finibus vitae ac ipsum. Cras mollis tincidunt suscipit. Donec quis dui eget sem ultrices faucibus eget efficitur lorem. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae;
+        """.trimIndent()
+        val article = articleFixture.create(summary = summary)
+
+        val expectedSummary = summary.take(250)
+
+        val articles = ByArticleStatus(database)
+            .all(
+                status = ArticleStatus.ALL,
+                unreadSort = UnreadSortOrder.NEWEST_FIRST,
+                since = OffsetDateTime.now().minusDays(7),
+                query = null,
+                limit = 1,
+                offset = 0,
+            ).executeAsList()
+
+        assertEquals(expected = expectedSummary, actual = articles[0].summary)
+    }
+
+    @Test
     fun findPages() = runTest {
         val feed = feedFixture.create(feedURL = "https://example.com/${RandomUUID.generate()}")
         val publishedAt = TimeHelpers.nowUTC()

--- a/capy/src/test/java/com/jocmp/capy/persistence/articles/ByFeedTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/persistence/articles/ByFeedTest.kt
@@ -33,6 +33,29 @@ class ByFeedTest {
     }
 
     @Test
+    fun all_summaryTruncation() = runTest {
+        val summary = """
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent turpis nisi, hendrerit in lobortis ac, cursus quis odio. Etiam gravida lacinia sodales. Ut sodales orci a auctor blandit. Pellentesque ultrices faucibus magna sed rhoncus. Praesent vulputate finibus auctor. Sed a neque nec odio imperdiet finibus vitae ac ipsum. Cras mollis tincidunt suscipit. Donec quis dui eget sem ultrices faucibus eget efficitur lorem. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae;
+        """.trimIndent()
+        val article = articleFixture.create(summary = summary)
+
+        val expectedSummary = summary.take(250)
+
+        val articles = ByFeed(database)
+            .all(
+                feedIDs = listOf(article.feedID),
+                status = ArticleStatus.ALL,
+                unreadSort = UnreadSortOrder.NEWEST_FIRST,
+                since = OffsetDateTime.now().minusDays(7),
+                query = null,
+                limit = 1,
+                offset = 0,
+            ).executeAsList()
+
+        assertEquals(expected = expectedSummary, actual = articles[0].summary)
+    }
+
+    @Test
     fun findPages() = runTest {
         val feed = feedFixture.create(feedURL = "https://example.com/${RandomUUID.generate()}")
         val publishedAt = TimeHelpers.nowUTC()

--- a/capy/src/test/java/com/jocmp/capy/persistence/articles/BySavedSearchTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/persistence/articles/BySavedSearchTest.kt
@@ -32,6 +32,34 @@ class BySavedSearchTest {
     }
 
     @Test
+    fun all_summaryTruncation() = runTest {
+        val summary = """
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent turpis nisi, hendrerit in lobortis ac, cursus quis odio. Etiam gravida lacinia sodales. Ut sodales orci a auctor blandit. Pellentesque ultrices faucibus magna sed rhoncus. Praesent vulputate finibus auctor. Sed a neque nec odio imperdiet finibus vitae ac ipsum. Cras mollis tincidunt suscipit. Donec quis dui eget sem ultrices faucibus eget efficitur lorem. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae;
+        """.trimIndent()
+
+        val search = savedSearchFixture.create()
+        val article = articleFixture.create(summary = summary)
+            .apply {
+                savedSearchFixture.createSavedSearchArticle(articleID = id, id = search.id)
+            }
+
+        val expectedSummary = summary.take(250)
+
+        val articles = BySavedSearch(database)
+            .all(
+                savedSearchID = search.id,
+                status = ArticleStatus.ALL,
+                unreadSort = UnreadSortOrder.NEWEST_FIRST,
+                since = OffsetDateTime.now().minusDays(7),
+                query = null,
+                limit = 1,
+                offset = 0,
+            ).executeAsList()
+
+        assertEquals(expected = expectedSummary, actual = articles[0].summary)
+    }
+
+    @Test
     fun findIndex() = runTest {
         val publishedAt = TimeHelpers.nowUTC()
         val search = savedSearchFixture.create()


### PR DESCRIPTION
Cap summaries to 250 characters. Two lines of text is ~100.

Ref

- https://github.com/jocmp/capyreader/issues/1209