### PR TITLE
Remove 'Launch Adjacent' flag for articles

### DIFF
--- a/app/src/main/java/com/capyreader/app/common/ContextOpenLinkExt.kt
+++ b/app/src/main/java/com/capyreader/app/common/ContextOpenLinkExt.kt
@@ -27,7 +27,7 @@ fun Context.openLinkExternally(url: Uri) {
     Intent(Intent.ACTION_VIEW)
         .apply {
             data = url
-            addFlags(Intent.FLAG_ACTIVITY_LAUNCH_ADJACENT or Intent.FLAG_ACTIVITY_NEW_TASK)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }.also { intent ->
             startActivity(intent)
         }


### PR DESCRIPTION
Avoids split screen on phones

- https://github.com/jocmp/capyreader/discussions/1306#discussioncomment-13967605