### PR TITLE
Revert "[Local] Move database transaction to per-item level (#1346)"

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/accounts/local/LocalAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/local/LocalAccountDelegate.kt
@@ -217,8 +217,8 @@ internal class LocalAccountDelegate(
     ) {
         val blocklist = preferences.keywordBlocklist.get()
 
-        items.forEach { item ->
-            database.transactionWithErrorHandling {
+        database.transactionWithErrorHandling {
+            items.forEach { item ->
                 val publishedAt = published(item.pubDate, fallback = updatedAt).toEpochSecond()
                 val parsedItem = ParsedItem(
                     item,

--- a/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
@@ -138,7 +138,9 @@ internal class ArticleRecords internal constructor(
             notificationQueries.articlesToNotify(since = since.toEpochSecond()).executeAsList()
 
         articleIDs.forEach {
-            notificationQueries.createNotification(article_id = it)
+            database.transactionWithErrorHandling {
+                notificationQueries.createNotification(article_id = it)
+            }
         }
 
         return notifications(articleIDs)


### PR DESCRIPTION
This reverts commit 96dda83898073cf43818299a8ea0ea197462f281.

Ref

- https://github.com/jocmp/capyreader/issues/1379