### PR TITLE
Only refresh on start when "On Start" is selected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ app/gplay/release/
 # Cruft
 technotes/.obsidian/
 .idea/runConfigurations.xml
+.kotlin/sessions/

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -162,7 +162,7 @@ fun ArticleScreen(
     ) {
         val openNextFeedOnReadAll = afterReadAll == AfterReadAllBehavior.OPEN_NEXT_FEED
 
-        val skipInitialRefresh = refreshInterval == RefreshInterval.MANUALLY_ONLY
+        val skipInitialRefresh = refreshInterval != RefreshInterval.ON_START
 
         val (isRefreshInitialized, setRefreshInitialized) = rememberSaveable {
             mutableStateOf(skipInitialRefresh)


### PR DESCRIPTION
Skips refresh when "Manually" or a periodic interval is set.

Ref

- https://github.com/jocmp/capyreader/issues/1402