### PR TITLE
Improve Horizontal Paging speed

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.itemKey
 import com.capyreader.app.R
 import com.capyreader.app.preferences.AppPreferences
 import com.jocmp.capy.Article
@@ -52,12 +53,6 @@ fun ArticleList(
     val localDensity = LocalDensity.current
     var listHeight by remember { mutableStateOf(0.dp) }
 
-    val key = { index: Int ->
-        val article = articles[index]
-
-        article?.id ?: index
-    }
-
     LazyScrollbar(state = listState) {
         LazyColumn(
             state = listState,
@@ -67,7 +62,7 @@ fun ArticleList(
                     listHeight = with(localDensity) { coordinates.size.height.toDp() }
                 }
         ) {
-            items(count = articles.itemCount, key = { key(it) }) { index ->
+            items(count = articles.itemCount, key = articles.itemKey { it.id }) { index ->
                 val item = articles[index]
 
                 Box {

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -563,14 +563,9 @@ fun ArticleScreen(
                         CapyPlaceholder()
                     }
                 } else if (article != null) {
-//                    val pagination = rememberArticlePagination(
-//                        article,
-//
-//                    )
                     ArticleView(
                         article = article,
                         articles = articles,
-//                        pagination = pagination,
                         onBackPressed = {
                             clearArticle()
                         },
@@ -578,9 +573,8 @@ fun ArticleScreen(
                         onToggleStar = viewModel::toggleArticleStar,
                         enableBackHandler = media == null,
                         onSelectMedia = { media = it },
-                        onSelectArticle = { index, articleID ->
+                        onSelectArticle = { articleID ->
                             setArticle(articleID)
-                            scrollToArticle(index)
                         },
                         onScrollToArticle = { index ->
                             scrollToArticle(index)

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -55,7 +55,6 @@ import com.capyreader.app.ui.LocalConnectivity
 import com.capyreader.app.ui.LocalMarkAllReadButtonPosition
 import com.capyreader.app.ui.articles.detail.ArticleView
 import com.capyreader.app.ui.articles.detail.CapyPlaceholder
-import com.capyreader.app.ui.articles.detail.rememberArticlePagination
 import com.capyreader.app.ui.articles.feeds.FeedActions
 import com.capyreader.app.ui.articles.feeds.FeedList
 import com.capyreader.app.ui.articles.feeds.FolderActions
@@ -564,16 +563,14 @@ fun ArticleScreen(
                         CapyPlaceholder()
                     }
                 } else if (article != null) {
-                    val pagination = rememberArticlePagination(
-                        article,
-                        onSelectArticle = { index, articleID ->
-                            setArticle(articleID)
-                            scrollToArticle(index)
-                        }
-                    )
+//                    val pagination = rememberArticlePagination(
+//                        article,
+//
+//                    )
                     ArticleView(
                         article = article,
-                        pagination = pagination,
+                        articles = articles,
+//                        pagination = pagination,
                         onBackPressed = {
                             clearArticle()
                         },
@@ -581,6 +578,10 @@ fun ArticleScreen(
                         onToggleStar = viewModel::toggleArticleStar,
                         enableBackHandler = media == null,
                         onSelectMedia = { media = it },
+                        onSelectArticle = { index, articleID ->
+                            setArticle(articleID)
+                            scrollToArticle(index)
+                        },
                         onScrollToArticle = { index ->
                             scrollToArticle(index)
                         }


### PR DESCRIPTION
Uses `itemSnapshotList` instead of using a SQL query. This means sibling articles will already be loaded in memory.

The trade-off is that an article selected from the widget, or saved as the current article, may not have siblings on open.