### PR TITLE
Revert pager changes to fix placeholder articles

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.itemKey
 import com.capyreader.app.R
 import com.capyreader.app.preferences.AppPreferences
 import com.jocmp.capy.Article
@@ -52,16 +53,6 @@ fun ArticleList(
     val localDensity = LocalDensity.current
     var listHeight by remember { mutableStateOf(0.dp) }
 
-    val key = { index: Int ->
-        val article = articles[index]
-
-        if (article != null) {
-            "${article.id}:${article.read}:${article.starred}"
-        } else {
-            index
-        }
-    }
-
     LazyScrollbar(state = listState) {
         LazyColumn(
             state = listState,
@@ -71,7 +62,7 @@ fun ArticleList(
                     listHeight = with(localDensity) { coordinates.size.height.toDp() }
                 }
         ) {
-            items(count = articles.itemCount, key = { key(it) }) { index ->
+            items(count = articles.itemCount, key = articles.itemKey { it.id }) { index ->
                 val item = articles[index]
 
                 Box {

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
@@ -55,7 +55,11 @@ fun ArticleList(
     val key = { index: Int ->
         val article = articles[index]
 
-        article?.id ?: index
+        if (article != null) {
+            "${article.id}:${article.read}:${article.starred}"
+        } else {
+            index
+        }
     }
 
     LazyScrollbar(state = listState) {

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -79,8 +79,8 @@ import com.jocmp.capy.Feed
 import com.jocmp.capy.Folder
 import com.jocmp.capy.MarkRead
 import com.jocmp.capy.SavedSearch
+import com.jocmp.capy.common.launchIO
 import com.jocmp.capy.common.launchUI
-import com.jocmp.capy.logging.CapyLog
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
@@ -215,8 +215,16 @@ fun ArticleScreen(
             scrollBehavior = scrollBehavior
         )
 
+
+        val scrollToTop = {
+            coroutineScope.launch {
+                listState.scrollToItem(0)
+                resetScrollBehaviorOffset()
+            }
+        }
+
         suspend fun openNextStatus(action: suspend () -> Unit) {
-            action()
+            scope.launchIO { action() }
             scaffoldNavigator.navigateTo(ListDetailPaneScaffoldRole.List)
         }
 
@@ -244,13 +252,6 @@ fun ArticleScreen(
             }
         }
 
-        val scrollToTop = {
-            coroutineScope.launch {
-                listState.scrollToItem(0)
-                resetScrollBehaviorOffset()
-            }
-        }
-
         val refreshPagination = {
             coroutineScope.launch {
                 resetScrollBehaviorOffset()
@@ -258,8 +259,6 @@ fun ArticleScreen(
         }
 
         val refreshArticleList = {
-            articles.refresh()
-
             if (enableMarkReadOnScroll) {
                 scrollToTop()
             }
@@ -422,9 +421,6 @@ fun ArticleScreen(
                     onRefreshAll = { completion ->
                         viewModel.refreshAll(ArticleFilter.default()) {
                             refreshArticleList()
-                            if (enableMarkReadOnScroll) {
-                                scrollToTop()
-                            }
                             completion()
                         }
                     },

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -81,6 +82,8 @@ import com.jocmp.capy.MarkRead
 import com.jocmp.capy.SavedSearch
 import com.jocmp.capy.common.launchIO
 import com.jocmp.capy.common.launchUI
+import com.jocmp.capy.logging.CapyLog
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
@@ -221,6 +224,16 @@ fun ArticleScreen(
                 listState.scrollToItem(0)
                 resetScrollBehaviorOffset()
             }
+        }
+
+        LaunchedEffect(listState) {
+            snapshotFlow { "$filter:${listState.layoutInfo.totalItemsCount}" }
+                .distinctUntilChanged()
+                .collect {
+                    CapyLog.info("list", mapOf("count" to it))
+                    scrollToTop()
+                    resetScrollBehaviorOffset()
+                }
         }
 
         suspend fun openNextStatus(action: suspend () -> Unit) {
@@ -644,8 +657,14 @@ fun ArticleScreen(
             scaffoldNavigator.navigateTo(ListDetailPaneScaffoldRole.List)
         }
 
-        LaunchedEffect(filter) {
-            resetScrollBehaviorOffset()
+        LaunchedEffect(listState) {
+            snapshotFlow { "$filter:${listState.layoutInfo.totalItemsCount}" }
+                .distinctUntilChanged()
+                .collect {
+                    CapyLog.info("list", mapOf("count" to it))
+                    scrollToTop()
+                    resetScrollBehaviorOffset()
+                }
         }
     }
 }

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -79,7 +79,6 @@ import com.jocmp.capy.Feed
 import com.jocmp.capy.Folder
 import com.jocmp.capy.MarkRead
 import com.jocmp.capy.SavedSearch
-import com.jocmp.capy.common.launchIO
 import com.jocmp.capy.common.launchUI
 import com.jocmp.capy.logging.CapyLog
 import kotlinx.coroutines.launch
@@ -123,6 +122,8 @@ fun ArticleScreen(
         .articleListOptions
         .markReadButtonPosition
         .collectChangesWithCurrent()
+
+    val articles = viewModel.articles.collectAsLazyPagingItems()
 
     val onMarkAllRead = { range: MarkRead ->
         viewModel.markAllRead(
@@ -196,28 +197,6 @@ fun ArticleScreen(
             LazyListState(0, 0)
         }
 
-        val articlesSince by viewModel.articlesSince.collectAsStateWithLifecycle()
-        val unreadSort by viewModel.unreadSort.collectAsStateWithLifecycle()
-
-        val pager = remember(filter, unreadSort, articlesSince, searchQuery) {
-            viewModel.pager(
-                filter,
-                unreadSort,
-                articlesSince,
-                searchQuery,
-            )
-        }
-
-        val articles = pager.flow.collectAsLazyPagingItems()
-
-        LaunchedEffect(currentFeed?.title) {
-            val feed = currentFeed
-
-            if (feed != null) {
-                CapyLog.info("feed", mapOf("title" to feed.title))
-            }
-        }
-
         fun scrollToArticle(index: Int) {
             coroutineScope.launch {
                 if (index > -1) {
@@ -237,7 +216,7 @@ fun ArticleScreen(
         )
 
         suspend fun openNextStatus(action: suspend () -> Unit) {
-            scope.launchIO { action() }
+            action()
             scaffoldNavigator.navigateTo(ListDetailPaneScaffoldRole.List)
         }
 

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
 import com.capyreader.app.R
 import com.capyreader.app.common.toast
 import com.capyreader.app.notifications.NotificationHelper
@@ -27,7 +28,6 @@ import com.jocmp.capy.MarkRead
 import com.jocmp.capy.SavedSearch
 import com.jocmp.capy.articles.ArticleContent
 import com.jocmp.capy.articles.NextFilter
-import com.jocmp.capy.articles.UnreadSortOrder
 import com.jocmp.capy.buildArticlePager
 import com.jocmp.capy.common.UnauthorizedError
 import com.jocmp.capy.common.launchIO
@@ -83,18 +83,20 @@ class ArticleScreenViewModel(
         account.countAll(latestFilter.status)
     }
 
-    fun pager(
-        filter: ArticleFilter,
-        sort: UnreadSortOrder,
-        since: OffsetDateTime,
-        query: String = "",
-    ) =
-        account.buildArticlePager(
-            filter = filter,
-            query = query,
-            unreadSort = sort,
-            since = since
-        )
+    val articles: Flow<PagingData<Article>> =
+        combine(
+            filter,
+            _searchQuery,
+            articlesSince,
+            unreadSort
+        ) { filter, query, since, sort ->
+            account.buildArticlePager(
+                filter = filter,
+                query = query,
+                unreadSort = sort,
+                since = since
+            ).flow
+        }.flatMapLatest { it }
 
     val folders: Flow<List<Folder>> = combine(
         account.folders,

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
@@ -7,9 +7,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
-import androidx.paging.PagingSource
 import com.capyreader.app.R
 import com.capyreader.app.common.toast
 import com.capyreader.app.notifications.NotificationHelper
@@ -31,13 +28,13 @@ import com.jocmp.capy.SavedSearch
 import com.jocmp.capy.articles.ArticleContent
 import com.jocmp.capy.articles.NextFilter
 import com.jocmp.capy.articles.UnreadSortOrder
+import com.jocmp.capy.buildArticlePager
 import com.jocmp.capy.common.UnauthorizedError
 import com.jocmp.capy.common.launchIO
 import com.jocmp.capy.common.launchUI
 import com.jocmp.capy.countAll
 import com.jocmp.capy.findArticlePages
 import com.jocmp.capy.logging.CapyLog
-import com.jocmp.capy.persistence.ArticlePagerFactory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
@@ -73,8 +70,6 @@ class ArticleScreenViewModel(
     var refreshingAll by mutableStateOf(false)
         private set
 
-    var pagerSource: PagingSource<Int, Article>? = null
-
     val articlesSince = MutableStateFlow<OffsetDateTime>(OffsetDateTime.now())
 
     private var _showUnauthorizedMessage by mutableStateOf(UnauthorizedMessageState.HIDE)
@@ -91,25 +86,15 @@ class ArticleScreenViewModel(
     fun pager(
         filter: ArticleFilter,
         sort: UnreadSortOrder,
+        since: OffsetDateTime,
         query: String = "",
-    ): Pager<Int, Article> {
-        return Pager(
-            config = PagingConfig(
-                pageSize = 50,
-                prefetchDistance = 10,
-            ),
-            pagingSourceFactory = {
-                val since = articlesSince.value
-
-                ArticlePagerFactory(account).findArticles(
-                    filter = filter,
-                    query = query,
-                    unreadSort = sort,
-                    since = since
-                )
-            }
+    ) =
+        account.buildArticlePager(
+            filter = filter,
+            query = query,
+            unreadSort = sort,
+            since = since
         )
-    }
 
     val folders: Flow<List<Folder>> = combine(
         account.folders,

--- a/capy/src/main/java/com/jocmp/capy/AccountBuildArticlePagerExt.kt
+++ b/capy/src/main/java/com/jocmp/capy/AccountBuildArticlePagerExt.kt
@@ -1,0 +1,29 @@
+package com.jocmp.capy
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import com.jocmp.capy.articles.UnreadSortOrder
+import com.jocmp.capy.persistence.ArticlePagerFactory
+import java.time.OffsetDateTime
+
+fun Account.buildArticlePager(
+    filter: ArticleFilter,
+    query: String? = null,
+    unreadSort: UnreadSortOrder = UnreadSortOrder.NEWEST_FIRST,
+    since: OffsetDateTime = OffsetDateTime.now()
+): Pager<Int, Article> {
+    return Pager(
+        config = PagingConfig(
+            pageSize = 50,
+            prefetchDistance = 10,
+        ),
+        pagingSourceFactory = {
+            ArticlePagerFactory(database).findArticles(
+                filter = filter,
+                query = query,
+                unreadSort = unreadSort,
+                since = since
+            )
+        }
+    )
+}

--- a/capy/src/main/java/com/jocmp/capy/persistence/ArticlePagerFactory.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/ArticlePagerFactory.kt
@@ -2,15 +2,14 @@ package com.jocmp.capy.persistence
 
 import androidx.paging.PagingSource
 import app.cash.sqldelight.paging3.QueryPagingSource
-import com.jocmp.capy.Account
 import com.jocmp.capy.Article
 import com.jocmp.capy.ArticleFilter
 import com.jocmp.capy.articles.UnreadSortOrder
+import com.jocmp.capy.db.Database
 import kotlinx.coroutines.Dispatchers
 import java.time.OffsetDateTime
 
-class ArticlePagerFactory(account: Account) {
-    private val database = account.database
+class ArticlePagerFactory(private val database: Database) {
     private val articles = ArticleRecords(database)
 
     fun findArticles(


### PR DESCRIPTION
Ref

- https://github.com/jocmp/capyreader/pull/1354
- https://github.com/jocmp/capyreader/issues/1392

The lack of the `articleSince` flag may be causing placeholders to be shown instead of real list data.

The previous implementation was fine except for list reset. Considering both filter AND item count may be close enough.