### PR TITLE
Fix baseUri relative links for images

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/articles/ArticleRenderer.kt
+++ b/capy/src/main/java/com/jocmp/capy/articles/ArticleRenderer.kt
@@ -59,12 +59,18 @@ class ArticleRenderer(
             substitutions = substitutions
         ).renderedText
 
-        val document = Jsoup.parse(html).apply {
-            article.siteURL?.let { setBaseUri(it) }
-        }
+        val document = Jsoup.parse(html)
 
         if (article.parseFullContent) {
             val contentHTML = Jsoup.parse(article.content)
+
+            val baseUri = contentHTML.baseUri()
+
+            if (baseUri.isNotBlank()) {
+                document.setBaseUri(baseUri)
+            } else {
+                article.siteURL?.let { document.setBaseUri(it) }
+            }
 
             HtmlPostProcessor.clean(contentHTML, hideImages = hideImages)
 

--- a/capy/src/main/java/com/jocmp/capy/articles/CleanLinks.kt
+++ b/capy/src/main/java/com/jocmp/capy/articles/CleanLinks.kt
@@ -9,6 +9,8 @@ internal fun cleanLinks(element: Element) {
         } else {
             child.attr("loading", "lazy")
         }
+
+        child.attr("src", child.attr("abs:src"))
     }
 
     element.select("img[data-src]").forEach { child ->


### PR DESCRIPTION
- When parsing an article, use the article's baseURI if present
- Continue to fall back to the site's base URI if not
- Convert images to absolute paths during parsing

Ref

- #1345 