### PR TITLE
Clear read articles before refresh

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -194,6 +194,7 @@ fun ArticleScreen(
         }
 
         val unreadSort by viewModel.unreadSort.collectAsStateWithLifecycle()
+        val since by viewModel.articlesSince.collectAsStateWithLifecycle()
 
         val pager = remember(filter, unreadSort, searchQuery) {
             viewModel.pager(
@@ -204,6 +205,10 @@ fun ArticleScreen(
         }
 
         val articles = pager.flow.collectAsLazyPagingItems()
+
+        LaunchedEffect(since) {
+            articles.refresh()
+        }
 
         fun scrollToArticle(index: Int) {
             coroutineScope.launch {
@@ -265,10 +270,6 @@ fun ArticleScreen(
             }
         }
 
-        val refreshArticleList = {
-            articles.refresh()
-            refreshPagination()
-        }
 
         fun refreshAll() {
             if (refreshAllState == AngleRefreshState.RUNNING) {
@@ -279,8 +280,7 @@ fun ArticleScreen(
 
             viewModel.refreshAll {
                 refreshAllState = AngleRefreshState.SETTLING
-
-                refreshArticleList()
+                refreshPagination()
 
                 if (!isRefreshInitialized) {
                     setRefreshInitialized(true)
@@ -293,7 +293,7 @@ fun ArticleScreen(
 
             viewModel.refresh(filter) {
                 isPullToRefreshing = false
-                refreshArticleList()
+                refreshPagination()
             }
         }
 

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
@@ -332,6 +332,8 @@ class ArticleScreenViewModel(
     }
 
     fun refresh(filter: ArticleFilter, onComplete: () -> Unit) {
+        updateArticlesSince()
+
         refreshFilter(filter) {
             updateArticlesSince()
             onComplete()


### PR DESCRIPTION
Marks the "updated since" timestamp to the latest time before update to ensure the list jumps to the first index immediately.

After refresh, the "updated since" timestamp is updated again avoid any missing read articles that are newly arrived.

Ref 

- https://github.com/jocmp/capyreader/issues/1419