### PR TITLE
Fix Android 14 status bar color in media viewer

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/LocalMediaViewer.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/LocalMediaViewer.kt
@@ -1,9 +1,0 @@
-package com.capyreader.app.ui.articles.detail
-
-import androidx.compose.runtime.compositionLocalOf
-
-val LocalMediaViewer = compositionLocalOf { MediaViewer() }
-
-data class MediaViewer(
-    val open: (url: String) -> Unit = {}
-)

--- a/app/src/main/java/com/capyreader/app/ui/articles/media/ArticleMediaView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/media/ArticleMediaView.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
@@ -25,7 +26,6 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -42,23 +42,28 @@ import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import coil.request.ImageRequest
 import com.capyreader.app.common.Media
+import com.capyreader.app.preferences.AppPreferences
 import com.capyreader.app.preferredMaxWidth
 import com.capyreader.app.ui.EdgeToEdgeHelper.isEdgeToEdgeAvailable
+import com.capyreader.app.ui.collectChangesWithCurrent
 import com.capyreader.app.ui.components.LoadingView
 import com.capyreader.app.ui.components.Swiper
 import com.capyreader.app.ui.components.rememberSwiperState
 import com.capyreader.app.ui.isCompact
 import com.capyreader.app.ui.settings.LocalSnackbarHost
 import com.capyreader.app.ui.theme.CapyTheme
+import com.capyreader.app.ui.theme.showAppearanceLightStatusBars
 import me.saket.telephoto.zoomable.ZoomSpec
 import me.saket.telephoto.zoomable.coil.ZoomableAsyncImage
 import me.saket.telephoto.zoomable.rememberZoomableImageState
 import me.saket.telephoto.zoomable.rememberZoomableState
+import org.koin.compose.koinInject
 
 @Composable
 fun ArticleMediaView(
     onDismissRequest: () -> Unit,
     media: Media?,
+    appPreferences: AppPreferences = koinInject()
 ) {
     val url = media?.url ?: return
     val view = LocalView.current
@@ -107,36 +112,29 @@ fun ArticleMediaView(
         }
     }
 
-
-    SideEffect {
-        val window = (view.context as Activity).window
-
-        window.navigationBarColor = Color.Black.toArgb()
-        window.statusBarColor = Color.Black.toArgb()
-        WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = false
-    }
+    val colorScheme = MaterialTheme.colorScheme
+    val theme by appPreferences.theme.collectChangesWithCurrent()
+    val showAppearanceLightStatusBars = theme.showAppearanceLightStatusBars()
 
     DisposableEffect(url) {
         val window = (view.context as Activity).window
+        val previousNavigationBarColor = window.navigationBarColor
 
-        val previousColor = window.navigationBarColor
-
-        var previousStatusBarColor: Int? = null
-
+        window.navigationBarColor = Color.Black.toArgb()
         if (!isEdgeToEdgeAvailable()) {
-            previousStatusBarColor = window.statusBarColor
+            window.statusBarColor = Color.Black.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = false
         }
 
-        val previousAppearanceLightStatusBars =
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars
-
         onDispose {
-            window.navigationBarColor = previousColor
-            previousStatusBarColor?.let {
-                window.statusBarColor = it
+            window.navigationBarColor = previousNavigationBarColor
+
+            if (!isEdgeToEdgeAvailable()) {
+                window.statusBarColor = colorScheme.surfaceContainer.toArgb()
+                WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars =
+                    showAppearanceLightStatusBars
+
             }
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars =
-                previousAppearanceLightStatusBars
         }
     }
 }

--- a/app/src/main/java/com/capyreader/app/ui/theme/Theme.kt
+++ b/app/src/main/java/com/capyreader/app/ui/theme/Theme.kt
@@ -77,9 +77,7 @@ fun CapyTheme(
     theme: ThemeOption = ThemeOption.SYSTEM_DEFAULT,
     content: @Composable () -> Unit
 ) {
-    val showAppearanceLightStatusBars =
-        !(theme == ThemeOption.DARK ||
-                theme == ThemeOption.SYSTEM_DEFAULT && isSystemInDarkTheme())
+    val showAppearanceLightStatusBars = theme.showAppearanceLightStatusBars()
 
     val colorScheme = when (theme) {
         ThemeOption.LIGHT -> lightScheme()
@@ -107,6 +105,13 @@ fun CapyTheme(
         content = content
     )
 }
+
+@Composable
+fun ThemeOption.showAppearanceLightStatusBars(): Boolean {
+    return !(this == ThemeOption.DARK ||
+            this == ThemeOption.SYSTEM_DEFAULT && isSystemInDarkTheme())
+}
+
 
 @Composable
 private fun lightScheme(): ColorScheme {


### PR DESCRIPTION
On media viewer exit, always reset to the theme's color instead of the "previous" color which could be wrong.

Ref

- https://github.com/jocmp/capyreader/issues/1433