### PR TITLE
[bugfix] Disable refresh on switch to manual

### DIFF
--- a/app/src/main/java/com/capyreader/app/refresher/RefreshScheduler.kt
+++ b/app/src/main/java/com/capyreader/app/refresher/RefreshScheduler.kt
@@ -7,6 +7,7 @@ import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.capyreader.app.preferences.AppPreferences
+import com.jocmp.capy.logging.CapyLog
 
 class RefreshScheduler(
     private val context: Context,
@@ -24,7 +25,17 @@ class RefreshScheduler(
 
         val workManager = WorkManager.getInstance(context)
 
-        val (repeatInterval, timeUnit) = interval.toTime ?: return
+        val time = interval.toTime
+
+        if (time == null) {
+            CapyLog.info("cancel_refresh", mapOf("interval" to refreshInterval))
+            workManager.cancelUniqueWork(WORK_NAME)
+            return
+        }
+
+        CapyLog.info("enable_refresh", mapOf("interval" to refreshInterval))
+
+        val (repeatInterval, timeUnit) = time
 
         val request = PeriodicWorkRequestBuilder<RefreshFeedsWorker>(repeatInterval, timeUnit)
             .setConstraints(constraints)

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/GeneralSettingsViewModel.kt
@@ -7,11 +7,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.capyreader.app.preferences.AfterReadAllBehavior
 import com.capyreader.app.preferences.AppPreferences
-import com.jocmp.capy.articles.FullContentParserType
 import com.capyreader.app.refresher.RefreshInterval
 import com.capyreader.app.refresher.RefreshScheduler
 import com.jocmp.capy.Account
 import com.jocmp.capy.accounts.AutoDelete
+import com.jocmp.capy.articles.FullContentParserType
 import com.jocmp.capy.articles.UnreadSortOrder
 import com.jocmp.capy.preferences.getAndSet
 import kotlinx.coroutines.Dispatchers

--- a/fastlane/metadata/android/en-US/changelogs/1163.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1163.txt
@@ -1,2 +1,3 @@
 • Open links adjacent to app on tablets and foldables
 • Clean up unused code and debug logging
+• Fix bug where background refresher was not cancelled when switching to manual or on start from timed option


### PR DESCRIPTION
Fixes a bug where the periodic worker was not disabled when switching from a timed interval (15m, 1h, etc) to a non-periodic option like "on start" or manual.