### PR TITLE
Fix saving/restoring lastScrollY on system-initiated process death

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleReader.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleReader.kt
@@ -116,19 +116,20 @@ fun ScrollableWebView(webViewState: WebViewState) {
                         .fillMaxWidth()
                         .wrapContentHeight(),
                     state = webViewState,
-                    onDispose = {
-                        lastScrollY = scrollState.value
-                    },
                 )
                 Spacer(modifier = Modifier.height(120.dp))
             }
         }
     }
 
-    LaunchedEffect(lastScrollY, scrollState.maxValue) {
-        if (scrollState.maxValue > 0 && lastScrollY > 0) {
+    LaunchedEffect(scrollState.value) {
+        if (scrollState.value > 0) {
+            lastScrollY = scrollState.value
+        }
+    }
+    LaunchedEffect(scrollState.maxValue) {
+        if (scrollState.maxValue > 0) {
             scrollState.scrollTo(lastScrollY)
-            lastScrollY = 0
         }
     }
 }

--- a/app/src/main/java/com/capyreader/app/ui/components/WebView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/components/WebView.kt
@@ -37,14 +37,10 @@ import org.koin.core.component.KoinComponent
 fun WebView(
     modifier: Modifier,
     state: WebViewState,
-    onDispose: (WebView) -> Unit = {},
 ) {
     AndroidView(
         modifier = modifier,
         factory = { state.webView },
-        onRelease = {
-            onDispose(it)
-        }
     )
 }
 


### PR DESCRIPTION
The reading position being lost was caused by `lastScrollY` not being saved on a [system-initiated process death](https://developer.android.com/topic/libraries/architecture/saving-states#ui-dismissal-system), although it worked fine for [configuration changes](https://developer.android.com/guide/topics/resources/runtime-changes).

`WebView.onDispose()`/`AndroidView.onRelease()` was being called on a system-initiated process death, but I suspect it was being called after the View's instance state was saved, because when the state was being restored  `lastScrollY` had a value of 0 (its initial value).

The proposed fix works by using:
- a `LaunchedEffect` to save the scroll value to `lastScrollY` whenever it changes
- another `LaunchedEffect` to restore the scroll position to the value in `lastScrollY` when the content height is known (`scrollState.maxValue > 0`)

Video demonstration of the fix with the "Don't keep Activities" scenario:
https://github.com/user-attachments/assets/9d61ddaa-475c-4534-bb97-4b050c5771c2

Fixes #1309 