### PR TITLE
[FreshRSS] Rework sync

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegate.kt
@@ -238,12 +238,9 @@ internal class ReaderAccountDelegate(
     }
 
     private suspend fun refreshTopLevelArticles() {
-        val since = articleRecords.maxArrivedAt().toEpochSecond()
-
         refreshFeeds()
         refreshAllSavedSearches()
         refreshArticleState()
-        fetchPaginatedArticles(since = since, stream = Stream.Read())
         fetchMissingArticles()
     }
 
@@ -294,15 +291,6 @@ internal class ReaderAccountDelegate(
 
                 savedSearchRecords.deleteOrphaned(excludedIDs = tags.map { it.id })
             }
-        }
-
-        coroutineScope {
-            savedSearchRecords.allIDs()
-                .forEach { savedSearchID ->
-                    launch {
-                        fetchPaginatedArticles(stream = Stream.UserLabel(savedSearchID))
-                    }
-                }
         }
     }
 


### PR DESCRIPTION
Reduces initial fetch from 50s to 12s - **4x faster** - on a debug device with a reading list of 8.2k unread items.

- Skip overfetching tagged items, specifically read items
- Skip fetching all articles "since" using `ot` param

### Reference

- <https://github.com/bazqux/bazqux-api?tab=readme-ov-file#the-right-way-to-sync>

### Issues

- https://github.com/jocmp/capyreader/issues/1485
- https://github.com/jocmp/capyreader/issues/1296
