### PR TITLE
Fix 'mark as read on scroll' offset bug

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
@@ -140,16 +140,7 @@ fun MarkReadOnScroll(
             .debounce(500)
             .collect { firstVisibleIndex ->
                 val offscreenIndex = firstVisibleIndex - 1
-                val markAsRead = offscreenIndex > 1 && articles.itemCount > 0
-
-                CapyLog.info(
-                    "index",
-                    mapOf(
-                        "index" to firstVisibleIndex,
-                        "enabled" to enabled,
-                        "markRead" to markAsRead
-                    )
-                )
+                val markAsRead = offscreenIndex > 0 && articles.itemCount > 0
 
                 if (!markAsRead) {
                     return@collect


### PR DESCRIPTION
Ensures that 'mark as read on scroll' works correctly on lists short than 3 elements