### PR TITLE
Add checking for blocked keywords in author field

### DIFF
--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -231,7 +231,7 @@
     <string name="settings_enable_refresh_call_to_action">Najpierw włącz cykliczne odświeżanie</string>
     <string name="settings_gestures_reader_tap_to_page_title">Dotknij, aby przewinąć (wyświetlacz E Ink)</string>
     <string name="image_preview_menu_option_medium">Średni</string>
-    <string name="blocked_keywords_supporting_text">Usuń artykuły, których tytuł lub treść pasują do słów kluczowych</string>
+    <string name="blocked_keywords_supporting_text">Usuń artykuły, których tytuł, autor lub treść pasują do słów kluczowych</string>
     <string name="blocked_keywords">Lista zablokowanych</string>
     <string name="blocked_keywords_remove_keyword">Usuń słowo kluczowe</string>
     <string name="blocked_keywords_add_keyword">Dodaj słowo kluczowe</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -263,7 +263,7 @@
     <string name="media_share">Share</string>
     <string name="feed_nav_drawer_refresh_all">Refresh all</string>
     <string name="blocked_keywords">Blocklist</string>
-    <string name="blocked_keywords_supporting_text">Remove articles with title or content keyword matches</string>
+    <string name="blocked_keywords_supporting_text">Remove articles with title, author or content keyword matches</string>
     <string name="blocked_keywords_remove_keyword">Remove keyword</string>
     <string name="blocked_keywords_add_keyword">Add keyword</string>
     <string name="tag_action_delete_title">Delete</string>

--- a/capy/src/main/java/com/jocmp/capy/accounts/local/LocalAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/local/LocalAccountDelegate.kt
@@ -233,7 +233,7 @@ internal class LocalAccountDelegate(
                         id = parsedItem.id,
                         feed_id = feed.id,
                         title = parsedItem.title,
-                        author = item.author,
+                        author = parsedItem.author,
                         content_html = parsedItem.contentHTML,
                         url = parsedItem.url,
                         summary = item.summary,
@@ -263,6 +263,7 @@ internal class LocalAccountDelegate(
     private fun containsBlockedText(parsedItem: ParsedItem, blocklist: Set<String>): Boolean {
         return blocklist.any { keyword ->
             parsedItem.title.contains(keyword, ignoreCase = true) ||
+                    parsedItem.author.contains(keyword, ignoreCase = true) ||
                     parsedItem.summary.orEmpty().contains(keyword, ignoreCase = true) ||
                     parsedItem.contentHTML.orEmpty().contains(keyword, ignoreCase = true)
         }

--- a/capy/src/main/java/com/jocmp/capy/accounts/local/ParsedItem.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/local/ParsedItem.kt
@@ -51,6 +51,13 @@ internal class ParsedItem(private val item: RssItem, private val siteURL: String
             return cleaner.clean(Jsoup.parse(item.title.orEmpty())).text()
         }
 
+    val author: String
+        get() {
+            val cleaner = Cleaner(Safelist.none())
+
+            return cleaner.clean(Jsoup.parse(item.author.orEmpty())).text()
+        }
+
     val imageURL: String?
         get() = item.media?.thumbnailUrl ?: cleanedURL(item.image)?.toString()
 


### PR DESCRIPTION
I've seen that you "don't like" PRs, but I wrote it for myself, so might as well share it here.

This PR is extending keywords blocking to include the author field. I added it because one of the feeds that I subscribe to have posts with authors like "Sponsored by Nakivo". Because I don't enjoy ads in my feeds I wanted to remove these posts and they don't have a mention of being sponsored in title, summary or contentHTML. Now I can just block the keyword "Sponsored".

The feed is: https://www.bleepingcomputer.com/feed/
And the [attached file](https://github.com/user-attachments/files/23441517/www.bleepingcomputer.com.xml) is its state at the time of writing this PR.

I wasn't sure if the author field should be "cleaned" or not because you don't save it cleaned. But you also don't save cleaned summary even though you cleaned it. I'm also not sure if it should be an optional field or not because title is not optional, but summary is even though both are optional in rss specs, so I wasn't sure how it should be done there.

Therefore if you are interested in this change then tell me if I should fix something or feel free to change it yourself if that would mean less time spent on it.
