### PR TITLE
Do not dim starred articles

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleRow.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleRow.kt
@@ -87,9 +87,10 @@ fun ArticleRow(
     val imageURL = article.imageURL
     val colors = listItemColors(
         selected = selected,
-        read = article.read
+        read = article.read,
+        starred = article.starred,
     )
-    val feedNameColor = findFeedNameColor(read = article.read)
+    val feedNameColor = findFeedNameColor(read = article.read, starred = article.starred)
     val haptics = LocalHapticFeedback.current
     val (isArticleMenuOpen, setArticleMenuOpen) = remember { mutableStateOf(false) }
     val openArticleMenu = {
@@ -274,22 +275,24 @@ fun PlaceholderArticleRow(imagePreview: ImagePreview = ImagePreview.NONE) {
 private fun listItemColors(
     selected: Boolean,
     read: Boolean,
+    starred: Boolean,
 ): ListItemColors {
     val defaults = ListItemDefaults.colors()
     val colorScheme = MaterialTheme.colorScheme
+    val shouldDisable = read && !starred
 
     return ListItemDefaults.colors(
         containerColor = if (selected) colorScheme.surfaceVariant else defaults.containerColor,
-        headlineColor = if (read) defaults.disabledHeadlineColor else defaults.headlineColor,
-        supportingColor = if (read) defaults.disabledHeadlineColor else defaults.supportingTextColor
+        headlineColor = if (shouldDisable) defaults.disabledHeadlineColor else defaults.headlineColor,
+        supportingColor = if (shouldDisable) defaults.disabledHeadlineColor else defaults.supportingTextColor
     )
 }
 
 @Composable
-fun findFeedNameColor(read: Boolean): Color {
+fun findFeedNameColor(read: Boolean, starred: Boolean): Color {
     val defaults = ListItemDefaults.colors()
 
-    return if (read) {
+    return if (read && !starred) {
         defaults.disabledHeadlineColor
     } else {
         defaults.overlineColor


### PR DESCRIPTION
Dimming is mostly useful as a way to tell visually which articles can be "forgotten," but this is not the case for starred articles. One common workflow for example is to go through all your unread articles, star interesting ones, and then mark everything as read (with the intention to go back and read starred articles later). But this causes every item in your starred section to be dimmed which looks strange.

This PR attempts to update the app to only dim articles that are both read and not starred.

(Full disclosure: this patch was suggested by AI and I'm not sure if it's correct or not. Please suggest other edits if this is not the right fix.)