### PR TITLE
Fix tooltip overlap with status bar

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/components/ToolbarTooltip.kt
+++ b/app/src/main/java/com/capyreader/app/ui/components/ToolbarTooltip.kt
@@ -3,11 +3,11 @@ package com.capyreader.app.ui.components
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
-import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.TooltipDefaults.rememberTooltipPositionProvider
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -18,8 +18,8 @@ fun ToolbarTooltip(
     val tooltipState = rememberTooltipState()
 
     TooltipBox(
-        positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(
-            spacingBetweenTooltipAndAnchor = 16.dp
+        positionProvider = rememberTooltipPositionProvider(
+            positioning = TooltipAnchorPosition.Below
         ),
         tooltip = {
             PlainTooltip {


### PR DESCRIPTION
Position toolbar tooltips below the anchor buttons instead of above to prevent overlap with the status bar on article view actions.

Ref #1631 