### PR TITLE
Fix toolbar hiding when not pinned

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleView.kt
@@ -319,7 +319,7 @@ fun rememberTopToolbarPreference(
     val scrollBehavior = if (pinTopToolbar) {
         TopAppBarDefaults.pinnedScrollBehavior()
     } else {
-        TopAppBarDefaults.enterAlwaysScrollBehavior()
+        TopAppBarDefaults.enterAlwaysScrollBehavior(reverseLayout = true)
     }
 
     val showToolbars = scrollBehavior.state.collapsedFraction == 0f


### PR DESCRIPTION
Closes #1637

I'm honestly not sure why setting reverseLayout to true fixed the issue referenced in #1637, but it does seem to work.