### PR TITLE
Skip audio state JS calls on blank page

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/components/WebView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/components/WebView.kt
@@ -202,6 +202,9 @@ class WebViewState(
     fun updateAudioPlayState(url: String?, isPlaying: Boolean) {
         currentAudioUrl = url
         isAudioPlaying = isPlaying
+        if (htmlId == null) {
+            return
+        }
         webView.post {
             if (url != null) {
                 val escapedUrl = url.replace("'", "\\'")


### PR DESCRIPTION
Avoids "resetAudioPlayState is not defined" error when WebView is displaying `about:blank`.