### PR TITLE
fix: Mark read on scroll per-article, not per-time

### DIFF
--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByFeed.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByFeed.sq
@@ -25,7 +25,8 @@ AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
 AND (articles.title LIKE '%' || :query || '%' OR articles.summary  LIKE '%' || :query || '%' OR :query IS NULL)
 AND (feeds.priority IN :priorities OR feeds.priority IS NULL)
 GROUP BY articles.id
-ORDER BY CASE WHEN :newestFirst THEN articles.published_at ELSE (-1 * articles.published_at) END DESC
+ORDER BY CASE WHEN :newestFirst THEN articles.published_at ELSE (-1 * articles.published_at) END DESC,
+  CASE WHEN :newestFirst THEN articles.id ELSE articles.id END DESC
 LIMIT :limit OFFSET :offset;
 
 countAll:
@@ -54,15 +55,23 @@ AND (feeds.priority IN :priorities OR feeds.priority IS NULL)
 AND (
     :afterArticleID IS NULL
     OR CASE WHEN :newestFirst
-        THEN articles.published_at >= (SELECT published_at FROM articles WHERE id = :afterArticleID)
-        ELSE articles.published_at <= (SELECT published_at FROM articles WHERE id = :afterArticleID)
+        THEN (articles.published_at > (SELECT published_at FROM articles WHERE id = :afterArticleID)
+              OR (articles.published_at = (SELECT published_at FROM articles WHERE id = :afterArticleID)
+                  AND articles.id >= :afterArticleID))
+        ELSE (articles.published_at < (SELECT published_at FROM articles WHERE id = :afterArticleID)
+              OR (articles.published_at = (SELECT published_at FROM articles WHERE id = :afterArticleID)
+                  AND articles.id <= :afterArticleID))
     END
 )
 AND (
     :beforeArticleID IS NULL
     OR CASE WHEN :newestFirst
-        THEN articles.published_at <= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
-        ELSE articles.published_at >= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+        THEN (articles.published_at < (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+              OR (articles.published_at = (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+                  AND articles.id <= :beforeArticleID))
+        ELSE (articles.published_at > (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+              OR (articles.published_at = (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+                  AND articles.id >= :beforeArticleID))
     END
 )
 GROUP BY articles.id;

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articlesBySavedSearch.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articlesBySavedSearch.sq
@@ -25,7 +25,8 @@ AND (article_statuses.starred = :starred OR :starred IS NULL)
 AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
 AND (articles.title LIKE '%' || :query || '%' OR articles.summary  LIKE '%' || :query || '%' OR :query IS NULL)
 GROUP BY articles.id
-ORDER BY CASE WHEN :newestFirst THEN articles.published_at ELSE (-1 * articles.published_at) END DESC
+ORDER BY CASE WHEN :newestFirst THEN articles.published_at ELSE (-1 * articles.published_at) END DESC,
+  CASE WHEN :newestFirst THEN articles.id ELSE articles.id END DESC
 LIMIT :limit OFFSET :offset;
 
 countAll:
@@ -53,15 +54,23 @@ AND saved_search_id = :savedSearchID
 AND (
     :afterArticleID IS NULL
     OR CASE WHEN :newestFirst
-        THEN articles.published_at >= (SELECT published_at FROM articles WHERE id = :afterArticleID)
-        ELSE articles.published_at <= (SELECT published_at FROM articles WHERE id = :afterArticleID)
+        THEN (articles.published_at > (SELECT published_at FROM articles WHERE id = :afterArticleID)
+              OR (articles.published_at = (SELECT published_at FROM articles WHERE id = :afterArticleID)
+                  AND articles.id >= :afterArticleID))
+        ELSE (articles.published_at < (SELECT published_at FROM articles WHERE id = :afterArticleID)
+              OR (articles.published_at = (SELECT published_at FROM articles WHERE id = :afterArticleID)
+                  AND articles.id <= :afterArticleID))
     END
 )
 AND (
     :beforeArticleID IS NULL
     OR CASE WHEN :newestFirst
-        THEN articles.published_at <= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
-        ELSE articles.published_at >= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+        THEN (articles.published_at < (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+              OR (articles.published_at = (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+                  AND articles.id <= :beforeArticleID))
+        ELSE (articles.published_at > (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+              OR (articles.published_at = (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+                  AND articles.id >= :beforeArticleID))
     END
 )
 GROUP BY articles.id;

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByStatus.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByStatus.sq
@@ -24,7 +24,8 @@ AND (article_statuses.starred = :starred OR :starred IS NULL)
 AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
 AND (articles.title LIKE '%' || :query || '%' OR articles.summary  LIKE '%' || :query || '%' OR :query IS NULL)
 GROUP BY articles.id
-ORDER BY CASE WHEN :newestFirst THEN articles.published_at ELSE (-1 * articles.published_at) END DESC
+ORDER BY CASE WHEN :newestFirst THEN articles.published_at ELSE (-1 * articles.published_at) END DESC,
+  CASE WHEN :newestFirst THEN articles.id ELSE articles.id END DESC
 LIMIT :limit OFFSET :offset;
 
 countAll:
@@ -51,15 +52,23 @@ AND (articles.title LIKE '%' || :query || '%' OR articles.summary  LIKE '%' || :
 AND (
     :afterArticleID IS NULL
     OR CASE WHEN :newestFirst
-        THEN articles.published_at >= (SELECT published_at FROM articles WHERE id = :afterArticleID)
-        ELSE articles.published_at <= (SELECT published_at FROM articles WHERE id = :afterArticleID)
+        THEN (articles.published_at > (SELECT published_at FROM articles WHERE id = :afterArticleID)
+              OR (articles.published_at = (SELECT published_at FROM articles WHERE id = :afterArticleID)
+                  AND articles.id >= :afterArticleID))
+        ELSE (articles.published_at < (SELECT published_at FROM articles WHERE id = :afterArticleID)
+              OR (articles.published_at = (SELECT published_at FROM articles WHERE id = :afterArticleID)
+                  AND articles.id <= :afterArticleID))
     END
 )
 AND (
     :beforeArticleID IS NULL
     OR CASE WHEN :newestFirst
-        THEN articles.published_at <= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
-        ELSE articles.published_at >= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+        THEN (articles.published_at < (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+              OR (articles.published_at = (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+                  AND articles.id <= :beforeArticleID))
+        ELSE (articles.published_at > (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+              OR (articles.published_at = (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+                  AND articles.id >= :beforeArticleID))
     END
 )
 GROUP BY articles.id;


### PR DESCRIPTION
Previously, articles with the same published_at timestamp would all be marked as read together when scrolling past just one of them. Now uses compound (published_at, id) comparisons to mark articles individually.

- Add secondary sort by id for deterministic ordering
- Update findArticleIDs queries with compound comparisons
- Add tests for same-timestamp edge cases

Ref

- #1557 