### PR TITLE
feat: Add browser-like headers for requests

### DIFF
--- a/app/src/main/java/com/capyreader/app/CommonModule.kt
+++ b/app/src/main/java/com/capyreader/app/CommonModule.kt
@@ -1,5 +1,6 @@
 package com.capyreader.app
 
+import android.webkit.WebSettings
 import com.capyreader.app.common.AndroidClientCertManager
 import com.capyreader.app.common.AndroidDatabaseProvider
 import com.capyreader.app.common.AppFaviconFetcher
@@ -11,6 +12,7 @@ import com.jocmp.capy.DatabaseProvider
 import com.jocmp.capy.PreferenceStoreProvider
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
+import java.util.Locale
 
 internal val common = module {
     single<PreferenceStoreProvider> { SharedPreferenceStoreProvider(get()) }
@@ -24,7 +26,19 @@ internal val common = module {
             preferenceStoreProvider = get(),
             faviconFetcher = AppFaviconFetcher(get()),
             clientCertManager = get(),
+            userAgent = WebSettings.getDefaultUserAgent(androidContext()),
+            acceptLanguage = Locale.getDefault().toAcceptLanguageTag(),
         )
     }
     single { AppPreferences(get()) }
+}
+
+private fun Locale.toAcceptLanguageTag(): String {
+    val primary = toLanguageTag()
+    val language = language
+    return if (primary != language) {
+        "$primary,$language;q=0.9"
+    } else {
+        primary
+    }
 }

--- a/capy/src/main/java/com/jocmp/capy/Account.kt
+++ b/capy/src/main/java/com/jocmp/capy/Account.kt
@@ -51,6 +51,8 @@ data class Account(
     val source: Source = Source.LOCAL,
     val faviconFetcher: FaviconFetcher,
     private val clientCertManager: ClientCertManager,
+    private val userAgent: String,
+    private val acceptLanguage: String,
     private val localHttpClient: OkHttpClient = LocalOkHttpClient.forAccount(path = cacheDirectory),
     val delegate: AccountDelegate = when (source) {
         Source.LOCAL -> LocalAccountDelegate(
@@ -86,7 +88,7 @@ data class Account(
     private val taggingRecords = TaggingRecords(database)
     private val savedSearchRecords = SavedSearchRecords(database)
 
-    private val articleContent = ArticleContent(localHttpClient)
+    private val articleContent = ArticleContent(localHttpClient, userAgent, acceptLanguage)
 
     val taggedFeeds = feedRecords.taggedFeeds().map {
         it.sortedByTitle()

--- a/capy/src/main/java/com/jocmp/capy/AccountManager.kt
+++ b/capy/src/main/java/com/jocmp/capy/AccountManager.kt
@@ -15,6 +15,8 @@ class AccountManager(
     private val preferenceStoreProvider: PreferenceStoreProvider,
     private val faviconFetcher: FaviconFetcher,
     private val clientCertManager: ClientCertManager,
+    private val userAgent: String,
+    private val acceptLanguage: String,
 ) {
     fun findByID(
         id: String,
@@ -92,6 +94,8 @@ class AccountManager(
             preferences = preferences,
             faviconFetcher = faviconFetcher,
             clientCertManager = clientCertManager,
+            userAgent = userAgent,
+            acceptLanguage = acceptLanguage,
         )
     }
 

--- a/capy/src/main/java/com/jocmp/capy/UserAgentInterceptor.kt
+++ b/capy/src/main/java/com/jocmp/capy/UserAgentInterceptor.kt
@@ -17,3 +17,24 @@ class UserAgentInterceptor(private val userAgent: String = USER_AGENT) : Interce
         const val USER_AGENT = "CapyReader (RSS Reader; https://capyreader.com/)"
     }
 }
+
+class BrowserHeadersInterceptor(
+    private val userAgent: String,
+    private val acceptLanguage: String,
+) : Interceptor {
+    override fun intercept(chain: Chain): Response {
+        val originalRequest = chain.request()
+        val request = originalRequest.newBuilder()
+            .header("User-Agent", userAgent)
+            .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8")
+            .header("Accept-Language", acceptLanguage)
+            .header("Accept-Encoding", "gzip, deflate, br")
+            .header("Sec-Fetch-Dest", "document")
+            .header("Sec-Fetch-Mode", "navigate")
+            .header("Sec-Fetch-Site", "none")
+            .header("Sec-Fetch-User", "?1")
+            .header("Upgrade-Insecure-Requests", "1")
+            .build()
+        return chain.proceed(request)
+    }
+}

--- a/capy/src/main/java/com/jocmp/capy/articles/ArticleContent.kt
+++ b/capy/src/main/java/com/jocmp/capy/articles/ArticleContent.kt
@@ -1,6 +1,6 @@
 package com.jocmp.capy.articles
 
-import com.jocmp.capy.UserAgentInterceptor
+import com.jocmp.capy.BrowserHeadersInterceptor
 import com.jocmp.capy.common.await
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -9,10 +9,12 @@ import java.io.IOException
 import java.net.URL
 
 class ArticleContent(
-    client: OkHttpClient
+    client: OkHttpClient,
+    userAgent: String,
+    acceptLanguage: String,
 ) {
     private val httpClient =
-        client.newBuilder().addInterceptor(UserAgentInterceptor(USER_AGENT)).build()
+        client.newBuilder().addInterceptor(BrowserHeadersInterceptor(userAgent, acceptLanguage)).build()
 
     internal suspend fun fetch(url: URL?): Result<String> {
         url ?: return Result.failure(MissingURLError())
@@ -60,9 +62,4 @@ class ArticleContent(
     class MissingURLError : Throwable()
 
     class HttpError(val code: Int) : Throwable()
-
-    companion object {
-        const val USER_AGENT =
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
-    }
 }

--- a/capy/src/test/java/com/jocmp/capy/AccountManagerTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/AccountManagerTest.kt
@@ -23,6 +23,8 @@ class AccountManagerTest {
             databaseProvider = InMemoryDatabaseProvider,
             faviconFetcher = FakeFaviconFetcher,
             clientCertManager = FakeClientCertManager,
+            userAgent = "TestUserAgent",
+            acceptLanguage = "en-US",
         )
     }
 

--- a/capy/src/test/java/com/jocmp/capy/accounts/ArticleContentTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/ArticleContentTest.kt
@@ -38,7 +38,11 @@ class ArticleContentTest {
 
     @Before
     fun setup() {
-        extractor = ArticleContent(client)
+        extractor = ArticleContent(
+            client = client,
+            userAgent = "TestUserAgent",
+            acceptLanguage = "en-US",
+        )
     }
 
     @Test

--- a/capy/src/test/java/com/jocmp/capy/fixtures/AccountFixture.kt
+++ b/capy/src/test/java/com/jocmp/capy/fixtures/AccountFixture.kt
@@ -28,6 +28,8 @@ object AccountFixture {
             delegate = accountDelegate,
             faviconFetcher = FakeFaviconFetcher,
             clientCertManager = FakeClientCertManager,
+            userAgent = "TestUserAgent",
+            acceptLanguage = "en-US",
         )
     }
 }


### PR DESCRIPTION
Add BrowserHeadersInterceptor with User-Agent, Accept-Language, and Sec-Fetch headers to reduce bot detection. Uses device's actual WebView user agent and locale.

Ref

- https://github.com/jocmp/capyreader/issues/1713