### PR TITLE
fix(freshrss): Dedupe enclosures from content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ technotes/.obsidian/
 .kotlin/sessions/
 
 TODO.md
+
+tmp/

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -14,7 +14,6 @@
             <option value="$PROJECT_DIR$/capy" />
             <option value="$PROJECT_DIR$/feedbinclient" />
             <option value="$PROJECT_DIR$/feedfinder" />
-            <option value="$PROJECT_DIR$/lib" />
             <option value="$PROJECT_DIR$/minifluxclient" />
             <option value="$PROJECT_DIR$/readerclient" />
             <option value="$PROJECT_DIR$/rssparser" />

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,3 +29,4 @@ Capy Reader is an RSS reader for Android split into several gradle modules
 - When naming accessors, prefer "savedSearches" over `getSavedSearches` unless there's a parameter, in which case use "get"
 - Prefer explicit named parameters when passing arguments to Jetpack Compose functions over positional arguments.
 - JavaScript files are written using JSDoc to ensure typechecking without the overhead of TypeScript.
+- Prefer `orEmpty()` instead of `?: ""`

--- a/capy/src/main/java/com/jocmp/capy/articles/ArticleEnclosuresExt.kt
+++ b/capy/src/main/java/com/jocmp/capy/articles/ArticleEnclosuresExt.kt
@@ -1,6 +1,7 @@
 package com.jocmp.capy.articles
 
 import com.jocmp.capy.Article
+import com.jocmp.capy.common.escapingSpecialHTMLCharacters
 
 fun Article.enclosureHTML(): String {
     val images = imageEnclosureHTML()
@@ -22,8 +23,8 @@ fun Article.audioEnclosureHTML(
     return buildString {
         audioItems.forEach { enclosure ->
             val durationFormatted =
-                enclosure.itunesDurationSeconds?.let { formatDuration(it) } ?: ""
-            val artworkUrl = enclosure.itunesImage ?: ""
+                enclosure.itunesDurationSeconds?.let { formatDuration(it) }.orEmpty()
+            val artworkUrl = enclosure.itunesImage.orEmpty()
             val rawUrl = enclosure.url.toString()
             val escapedTitle = title.escapeForJs()
             val escapedFeedName = feedName.escapeForJs()
@@ -52,7 +53,14 @@ fun Article.audioEnclosureHTML(
 }
 
 private fun Article.imageEnclosureHTML(): String {
-    val images = enclosures.filter { it.type.startsWith("image/") }
+    val images = enclosures
+        .filter { it.type.startsWith("image/") }
+        .filterNot { enclosure ->
+            val url = enclosure.url.toString()
+
+            content.contains(url) ||
+                    content.contains(url.escapingSpecialHTMLCharacters)
+        }
 
     if (images.isEmpty()) {
         return ""

--- a/capy/src/main/java/com/jocmp/capy/common/StringCharactersExt.kt
+++ b/capy/src/main/java/com/jocmp/capy/common/StringCharactersExt.kt
@@ -29,3 +29,6 @@ val String.unescapingHTMLCharacters: String
             .replace("&lt;", "<")
             .replace("&gt;", ">")
     }
+
+val String.escapingSpecialHTMLCharacters: String
+    get() = replace("&", "&amp;")

--- a/capy/src/test/java/com/jocmp/capy/articles/ArticleEnclosuresExtTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/articles/ArticleEnclosuresExtTest.kt
@@ -88,9 +88,67 @@ class ArticleEnclosuresExtTest {
         assertContains(html, "&quot;Episode&quot;")
     }
 
+    @Test
+    fun `enclosureHTML excludes image enclosures already present in content`() {
+        val imageEnclosure = Enclosure(
+            url = URL("https://example.com/image.jpg"),
+            type = "image/jpeg",
+            itunesDurationSeconds = null,
+            itunesImage = null
+        )
+
+        val article = createArticle(
+            contentHTML = """<p>Text</p><img src="https://example.com/image.jpg">""",
+            enclosures = listOf(imageEnclosure)
+        )
+
+        val html = article.enclosureHTML()
+
+        assertEquals("", html)
+    }
+
+    @Test
+    fun `enclosureHTML excludes image enclosures with HTML-encoded URLs in content`() {
+        val imageEnclosure = Enclosure(
+            url = URL("https://example.com/image.jpg?io=1&width=1000"),
+            type = "image/jpeg",
+            itunesDurationSeconds = null,
+            itunesImage = null
+        )
+
+        val article = createArticle(
+            contentHTML = """<img src="https://example.com/image.jpg?io=1&amp;width=1000">""",
+            enclosures = listOf(imageEnclosure)
+        )
+
+        val html = article.enclosureHTML()
+
+        assertEquals("", html)
+    }
+
+    @Test
+    fun `enclosureHTML includes image enclosures not present in content`() {
+        val imageEnclosure = Enclosure(
+            url = URL("https://example.com/other.jpg"),
+            type = "image/jpeg",
+            itunesDurationSeconds = null,
+            itunesImage = null
+        )
+
+        val article = createArticle(
+            contentHTML = """<p>Text</p><img src="https://example.com/image.jpg">""",
+            enclosures = listOf(imageEnclosure)
+        )
+
+        val html = article.enclosureHTML()
+
+        assertContains(html, "https://example.com/other.jpg")
+    }
+
     private fun createArticle(
         title: String = "Test Article",
         feedName: String = "Test Feed",
+        contentHTML: String = "<p>Content</p>",
         enclosures: List<Enclosure> = emptyList(),
     ): Article {
         return Article(
@@ -98,7 +156,7 @@ class ArticleEnclosuresExtTest {
             feedID = "feed-1",
             title = title,
             author = null,
-            contentHTML = "<p>Content</p>",
+            contentHTML = contentHTML,
             url = URL("https://example.com/article"),
             summary = "Summary",
             imageURL = null,


### PR DESCRIPTION
If an image link appears in both enclosures and content, skip the enclosure display

- https://github.com/jocmp/capyreader/discussions/1728
- https://github.com/jocmp/capyreader/issues/1735