### PR TITLE
chore: Enable audio player, add Miniflux for all builds

### DIFF
--- a/app/src/main/java/com/capyreader/app/preferences/AppPreferences.kt
+++ b/app/src/main/java/com/capyreader/app/preferences/AppPreferences.kt
@@ -82,9 +82,6 @@ class AppPreferences(context: Context) {
     val showTodayFilter: Preference<Boolean>
         get() = preferenceStore.getBoolean("show_today_filter", true)
 
-    val enableAudioPlayer: Preference<Boolean>
-        get() = preferenceStore.getBoolean("enable_audio_player", false)
-
     fun clearAll() {
         preferenceStore.clearAll()
     }

--- a/app/src/main/java/com/capyreader/app/ui/accounts/AddAccountView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/AddAccountView.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.capyreader.app.BuildConfig
 import com.capyreader.app.R
 import com.capyreader.app.setupCommonModules
 import com.capyreader.app.ui.CrashReporting
@@ -70,12 +69,10 @@ fun AddAccountView(
                     onSelectService,
                     source = Source.FRESHRSS
                 )
-                if (BuildConfig.BUILD_TYPE == "debug" || BuildConfig.BUILD_TYPE == "nightly") {
-                    SyncServiceRow(
-                        onSelectService,
-                        source = Source.MINIFLUX
-                    )
-                }
+                SyncServiceRow(
+                    onSelectService,
+                    source = Source.MINIFLUX
+                )
                 SyncServiceRow(
                     onSelectService,
                     source = Source.READER

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
@@ -180,7 +180,6 @@ fun rememberArticleOptions(appPreferences: AppPreferences = koinInject()): Artic
     val fontScale by appPreferences.articleListOptions.fontScale.stateIn(scope).collectAsState()
     val shortenTitles by appPreferences.articleListOptions.shortenTitles.stateIn(scope)
         .collectAsState()
-    val showAudioIcon by appPreferences.enableAudioPlayer.stateIn(scope).collectAsState()
 
     return ArticleRowOptions(
         showSummary = showSummary,
@@ -189,7 +188,6 @@ fun rememberArticleOptions(appPreferences: AppPreferences = koinInject()): Artic
         imagePreview = imagePreview,
         fontScale = fontScale,
         shortenTitles = shortenTitles,
-        showAudioIcon = showAudioIcon,
     )
 }
 

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleRow.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleRow.kt
@@ -75,7 +75,6 @@ data class ArticleRowOptions(
     val imagePreview: ImagePreview = ImagePreview.default,
     val fontScale: ArticleListFontScale = ArticleListFontScale.MEDIUM,
     val shortenTitles: Boolean = true,
-    val showAudioIcon: Boolean = false,
 )
 
 @Composable
@@ -154,7 +153,7 @@ fun ArticleRow(
                                         .width(12.dp.relative(options.fontScale))
                                 )
                             }
-                            if (options.showAudioIcon && article.enclosureType == EnclosureType.AUDIO) {
+                            if (article.enclosureType == EnclosureType.AUDIO) {
                                 Icon(
                                     Icons.Rounded.PlayArrow,
                                     contentDescription = null,
@@ -396,7 +395,6 @@ fun ArticleRowPreview_Selected_DarkMode() {
                     selected = true,
                     onSelect = {},
                     currentTime = LocalDateTime.now(),
-                    options = ArticleRowOptions(showAudioIcon = true),
                 )
                 ArticleRow(
                     article = article.copy(read = false),
@@ -404,7 +402,6 @@ fun ArticleRowPreview_Selected_DarkMode() {
                     selected = false,
                     onSelect = {},
                     currentTime = LocalDateTime.now(),
-                    options = ArticleRowOptions(showAudioIcon = true),
                 )
             }
         }
@@ -464,7 +461,6 @@ fun ArticleRowPreview_Medium(@PreviewParameter(ArticleSample::class) article: Ar
                 currentTime = LocalDateTime.now(),
                 options = ArticleRowOptions(
                     imagePreview = ImagePreview.MEDIUM,
-                    showAudioIcon = true,
                 )
             )
         }

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticlesModule.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticlesModule.kt
@@ -34,7 +34,6 @@ internal val articlesModule = module {
             titleFollowsBodyFont = get<AppPreferences>().readerOptions.titleFollowsBodyFont,
             hideTopMargin = get<AppPreferences>().readerOptions.pinTopToolbar,
             enableHorizontalScroll = get<AppPreferences>().readerOptions.enableHorizontaPagination,
-            enableAudioPlayer = get<AppPreferences>().enableAudioPlayer,
             audioPlayerLabels = AudioPlayerLabels(
                 play = context.getString(R.string.audio_player_play),
                 pause = context.getString(R.string.audio_player_pause),

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/GeneralSettingsPanel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/GeneralSettingsPanel.kt
@@ -99,8 +99,6 @@ fun GeneralSettingsPanel(
             enableStickyFullContent = viewModel.enableStickyFullContent,
             showTodayFilter = viewModel.showTodayFilter,
             updateShowTodayFilter = viewModel::updateShowTodayFilter,
-            enableAudioPlayer = viewModel.enableAudioPlayer,
-            updateEnableAudioPlayer = viewModel::updateEnableAudioPlayer,
         )
     }
 }
@@ -128,8 +126,6 @@ fun GeneralSettingsPanelView(
     markReadOnScroll: Boolean,
     showTodayFilter: Boolean,
     updateShowTodayFilter: (show: Boolean) -> Unit,
-    enableAudioPlayer: Boolean,
-    updateEnableAudioPlayer: (enable: Boolean) -> Unit,
 ) {
     val (isClearArticlesDialogOpen, setClearArticlesDialogOpen) = remember { mutableStateOf(false) }
 
@@ -230,16 +226,6 @@ fun GeneralSettingsPanelView(
                     optionText = {
                         stringResource(id = it.translationKey)
                     }
-                )
-            }
-        }
-
-        FormSection(title = stringResource(R.string.settings_section_experimental)) {
-            RowItem {
-                TextSwitch(
-                    checked = enableAudioPlayer,
-                    onCheckedChange = updateEnableAudioPlayer,
-                    title = stringResource(R.string.settings_option_enable_audio_player)
                 )
             }
         }
@@ -387,8 +373,6 @@ private fun GeneralSettingsPanelPreview() {
                 updateAfterReadAll = {},
                 showTodayFilter = true,
                 updateShowTodayFilter = {},
-                enableAudioPlayer = false,
-                updateEnableAudioPlayer = {}
             )
         }
     }

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/GeneralSettingsViewModel.kt
@@ -50,9 +50,6 @@ class GeneralSettingsViewModel(
     var showTodayFilter by mutableStateOf(appPreferences.showTodayFilter.get())
         private set
 
-    var enableAudioPlayer by mutableStateOf(appPreferences.enableAudioPlayer.get())
-        private set
-
     val keywordBlocklist = account
         .preferences
         .keywordBlocklist
@@ -134,11 +131,5 @@ class GeneralSettingsViewModel(
         appPreferences.showTodayFilter.set(show)
 
         showTodayFilter = show
-    }
-
-    fun updateEnableAudioPlayer(enable: Boolean) {
-        appPreferences.enableAudioPlayer.set(enable)
-
-        enableAudioPlayer = enable
     }
 }

--- a/capy/src/main/java/com/jocmp/capy/articles/ArticleRenderer.kt
+++ b/capy/src/main/java/com/jocmp/capy/articles/ArticleRenderer.kt
@@ -15,7 +15,6 @@ class ArticleRenderer(
     private val titleFollowsBodyFont: Preference<Boolean>,
     private val hideTopMargin: Preference<Boolean>,
     private val enableHorizontalScroll: Preference<Boolean>,
-    private val enableAudioPlayer: Preference<Boolean>,
     private val audioPlayerLabels: AudioPlayerLabels = AudioPlayerLabels(),
 ) {
     private val template by lazy {
@@ -76,14 +75,10 @@ class ArticleRenderer(
         return if (article.parseFullContent) {
             parseHtml(article, hideImages)
         } else {
-            val audioEnclosures = if (enableAudioPlayer.get()) {
-                article.audioEnclosureHTML(
-                    playLabel = audioPlayerLabels.play,
-                    pauseLabel = audioPlayerLabels.pause,
-                )
-            } else {
-                ""
-            }
+            val audioEnclosures = article.audioEnclosureHTML(
+                playLabel = audioPlayerLabels.play,
+                pauseLabel = audioPlayerLabels.pause,
+            )
             val otherEnclosures = article.enclosureHTML()
             audioEnclosures + article.content + otherEnclosures + postProcessScript(article, hideImages)
         }


### PR DESCRIPTION
- Remove audio player preference (always enabled)
- Remove experimental settings section
- Show Miniflux account option for all build types