### PR TITLE
feat(local): Add Mastodon and GitHub patterns to feed finder

### DIFF
--- a/feedfinder/src/main/java/com/jocmp/feedfinder/DefaultRequest.kt
+++ b/feedfinder/src/main/java/com/jocmp/feedfinder/DefaultRequest.kt
@@ -35,7 +35,8 @@ internal class DefaultRequest(private val client: OkHttpClient = OkHttpClient())
         return Response(
             url = url,
             body = body,
-            charset = response.header("content-type")?.toMediaTypeOrNull()?.charset()
+            charset = response.header("content-type")?.toMediaTypeOrNull()?.charset(),
+            headers = response.headers.toMultimap(),
         )
     }
 }

--- a/feedfinder/src/main/java/com/jocmp/feedfinder/Response.kt
+++ b/feedfinder/src/main/java/com/jocmp/feedfinder/Response.kt
@@ -8,7 +8,8 @@ import java.nio.charset.Charset
 internal class Response(
     val url: URL,
     val body: String,
-    val charset: Charset?
+    val charset: Charset?,
+    val headers: Map<String, List<String>> = emptyMap(),
 ) {
     suspend fun parse(validate: Boolean = true): Parser.Result {
         if (parsed == null) {

--- a/feedfinder/src/main/java/com/jocmp/feedfinder/sources/KnownPatterns.kt
+++ b/feedfinder/src/main/java/com/jocmp/feedfinder/sources/KnownPatterns.kt
@@ -48,6 +48,15 @@ internal class KnownPatterns(
                 }
             }
 
+            if (isMastodonServer) {
+                val feedURL = "${response.url}.rss"
+                val feed = createFromURL(feedURL, fetcher = request)
+
+                if (feed != null) {
+                    return listOf(feed)
+                }
+            }
+
             return emptyList()
         } catch (e: Parser.NotFeedError) {
             return emptyList()
@@ -60,6 +69,11 @@ internal class KnownPatterns(
 
     private val isYouTubeDomain: Boolean
         get() = response.url.toString().startsWith("https://www.youtube.com")
+
+    private val isMastodonServer: Boolean
+        get() = response.headers.any { (_, values) ->
+            values.any { it.contains("mastodon", ignoreCase = true) }
+        }
 
     private data class URLTemplate(val template: String, val regex: Regex)
 
@@ -84,6 +98,14 @@ internal class KnownPatterns(
             URLTemplate(
                 template = "https://vimeo.com/%s/videos/rss",
                 regex = Regex("https://vimeo\\.com/([^/#?]*)")
+            ),
+            URLTemplate(
+                template = "https://github.com/%s.atom",
+                regex = Regex("https://github\\.com/(orgs/[^/#?]+/discussions)")
+            ),
+            URLTemplate(
+                template = "https://github.com/%s.atom",
+                regex = Regex("https://github\\.com/([^/#?]+/[^/#?]+/discussions)")
             )
         )
     }

--- a/feedfinder/src/test/java/com/jocmp/feedfinder/sources/KnownPatternsTest.kt
+++ b/feedfinder/src/test/java/com/jocmp/feedfinder/sources/KnownPatternsTest.kt
@@ -17,8 +17,9 @@ class KnownPatternTest {
             "https://www.youtube.com/playlist?list=abc" to "https://www.youtube.com/feeds/videos.xml?playlist_id=abc",
             "https://www.reddit.com/r/abc" to "https://www.reddit.com/r/abc.rss",
             "https://vimeo.com/abc" to "https://vimeo.com/abc/videos/rss",
-
-            )
+            "https://github.com/orgs/miniflux/discussions" to "https://github.com/orgs/miniflux/discussions.atom",
+            "https://github.com/jocmp/capyreader/discussions" to "https://github.com/jocmp/capyreader/discussions.atom",
+        )
 
         urls.forEach { (knownPattern, destination) ->
             val sites = mapOf(
@@ -60,6 +61,50 @@ class KnownPatternTest {
             url = URI(url).toURL(),
             body = documentResult,
             charset = null,
+        )
+        val source = KnownPatterns(response, TestRequest(sites))
+        val feeds = source.find()
+
+        assertEquals(expected = 1, actual = feeds.size)
+        assertEquals(expected = destination, feeds.first().feedURL.toString())
+    }
+
+    @Test
+    fun `should detect Mastodon server from server header`() = runTest {
+        val url = "https://indieweb.social/@NetNewsWire"
+        val destination = "$url.rss"
+
+        val sites = mapOf(
+            destination to testResource("feed.xml"),
+        )
+
+        val response = Response(
+            url = URI(url).toURL(),
+            body = "",
+            charset = null,
+            headers = mapOf("server" to listOf("Mastodon")),
+        )
+        val source = KnownPatterns(response, TestRequest(sites))
+        val feeds = source.find()
+
+        assertEquals(expected = 1, actual = feeds.size)
+        assertEquals(expected = destination, feeds.first().feedURL.toString())
+    }
+
+    @Test
+    fun `should detect Mastodon from other header values`() = runTest {
+        val url = "https://mastodon.social/@_jocmp"
+        val destination = "$url.rss"
+
+        val sites = mapOf(
+            destination to testResource("feed.xml"),
+        )
+
+        val response = Response(
+            url = URI(url).toURL(),
+            body = "",
+            charset = null,
+            headers = mapOf("links" to listOf("<https://mastodon.social/.well-known/webfinger?resource=acct%3A_jocmp%40mastodon.social>; rel=\"lrdd\"; type=\"application/jrd+json\", <https://mastodon.social/users/_jocmp>; rel=\"alternate\"; type=\"application/activity+json\"")),
         )
         val source = KnownPatterns(response, TestRequest(sites))
         val feeds = source.find()


### PR DESCRIPTION
Ref

- https://github.com/feedbin/feedbin/blob/8fe3949371c7b6132815769f08a12cde4c0c2472/app/models/source/known_pattern.rb
- https://github.com/feedbin/feedbin/issues/766