### PR TITLE
fix: Send client cert in Miniflux calls

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/Account.kt
+++ b/capy/src/main/java/com/jocmp/capy/Account.kt
@@ -82,7 +82,8 @@ data class Account(
             miniflux = Miniflux.forAccount(
                 path = cacheDirectory,
                 preferences = preferences,
-                source = source
+                source = source,
+                clientCertManager = clientCertManager,
             ),
             preferences = preferences,
         )

--- a/capy/src/main/java/com/jocmp/capy/accounts/Credentials.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/Credentials.kt
@@ -30,7 +30,9 @@ interface Credentials {
                     username = username,
                     secret = password,
                     url = normalizeURL(url),
-                    source = source
+                    clientCertAlias = clientCertAlias,
+                    source = source,
+                    clientCertManager = clientCertManager,
                 )
                 Source.FRESHRSS,
                 Source.READER -> ReaderCredentials(

--- a/capy/src/main/java/com/jocmp/capy/accounts/HttpClientBuilder.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/HttpClientBuilder.kt
@@ -1,5 +1,6 @@
 package com.jocmp.capy.accounts
 
+import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.UserAgentInterceptor
 import okhttp3.Cache
 import okhttp3.OkHttpClient
@@ -18,6 +19,14 @@ private fun baseHttpClientBuilder() =
         .connectTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
         .readTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
         .writeTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+
+fun OkHttpClient.Builder.clientCertAlias(manager: ClientCertManager, clientCertAlias: String): OkHttpClient.Builder {
+    if (clientCertAlias.isNotEmpty()) {
+        val clientSSlSocketFactory = manager.buildSslSocketFactory(clientCertAlias)
+        sslSocketFactory(clientSSlSocketFactory.sslSocketFactory, clientSSlSocketFactory.trustManager)
+    }
+    return this
+}
 
 fun httpClientBuilder(cachePath: URI) =
     baseHttpClientBuilder()

--- a/capy/src/main/java/com/jocmp/capy/accounts/MinifluxExt.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/MinifluxExt.kt
@@ -1,14 +1,15 @@
 package com.jocmp.capy.accounts
 
 import com.jocmp.capy.AccountPreferences
+import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.accounts.miniflux.MinifluxOkHttpClient
 import com.jocmp.minifluxclient.Miniflux
 import java.net.URI
 
 
-fun Miniflux.Companion.forAccount(path: URI, preferences: AccountPreferences, source: Source) =
+fun Miniflux.Companion.forAccount(path: URI, preferences: AccountPreferences, source: Source, clientCertManager: ClientCertManager) =
     create(
-        client = MinifluxOkHttpClient.forAccount(path, preferences, source),
+        client = MinifluxOkHttpClient.forAccount(path, preferences, source, clientCertManager),
         baseURL = preferences.url.get()
     )
 

--- a/capy/src/main/java/com/jocmp/capy/accounts/miniflux/MinifluxCredentials.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/miniflux/MinifluxCredentials.kt
@@ -1,22 +1,31 @@
 package com.jocmp.capy.accounts.miniflux
 
+import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.accounts.Credentials
 import com.jocmp.capy.accounts.Source
+import com.jocmp.capy.accounts.baseHttpClient
+import com.jocmp.capy.accounts.clientCertAlias
 import com.jocmp.minifluxclient.Miniflux
 
 internal data class MinifluxCredentials(
     override val username: String,
     override val secret: String,
     override val url: String,
+    override val clientCertAlias: String,
     override val source: Source,
+    private val clientCertManager: ClientCertManager,
 ) : Credentials {
-    override val clientCertAlias: String = ""
-
     override suspend fun verify(): Result<Credentials> {
+        val client = baseHttpClient()
+            .newBuilder()
+            .clientCertAlias(clientCertManager, clientCertAlias)
+            .build()
+
         if (source == Source.MINIFLUX_TOKEN) {
             val response = Miniflux.verifyToken(
                 token = secret,
-                baseURL = url
+                baseURL = url,
+                client = client,
             )
 
             val username = response?.body()?.username
@@ -28,7 +37,8 @@ internal data class MinifluxCredentials(
             val verified = Miniflux.verifyCredentials(
                 username = username,
                 password = secret,
-                baseURL = url
+                baseURL = url,
+                client = client,
             )
 
             if (verified) {

--- a/capy/src/main/java/com/jocmp/capy/accounts/miniflux/MinifluxOkHttpClient.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/miniflux/MinifluxOkHttpClient.kt
@@ -1,8 +1,10 @@
 package com.jocmp.capy.accounts.miniflux
 
 import com.jocmp.capy.AccountPreferences
+import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.accounts.BasicAuthInterceptor
 import com.jocmp.capy.accounts.Source
+import com.jocmp.capy.accounts.clientCertAlias
 import com.jocmp.capy.accounts.httpClientBuilder
 import okhttp3.Credentials
 import okhttp3.Interceptor
@@ -10,9 +12,10 @@ import okhttp3.OkHttpClient
 import java.net.URI
 
 internal object MinifluxOkHttpClient {
-    fun forAccount(path: URI, preferences: AccountPreferences, source: Source): OkHttpClient {
+    fun forAccount(path: URI, preferences: AccountPreferences, source: Source, clientCertManager: ClientCertManager): OkHttpClient {
         return httpClientBuilder(cachePath = path)
             .addInterceptor(authInterceptor(source, preferences))
+            .clientCertAlias(clientCertManager, preferences.clientCertAlias.get())
             .build()
     }
 

--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderCredentials.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderCredentials.kt
@@ -4,7 +4,7 @@ import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.accounts.Credentials
 import com.jocmp.capy.accounts.Source
 import com.jocmp.capy.accounts.baseHttpClient
-import com.jocmp.capy.accounts.reader.ReaderOkHttpClient.clientCertAlias
+import com.jocmp.capy.accounts.clientCertAlias
 import com.jocmp.readerclient.GoogleReader
 import com.jocmp.readerclient.GoogleReader.Companion.UNAUTHORIZED_MESSAGE
 

--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderOkHttpClient.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderOkHttpClient.kt
@@ -3,6 +3,7 @@ package com.jocmp.capy.accounts.reader
 import com.jocmp.capy.AccountPreferences
 import com.jocmp.capy.ClientCertManager
 import com.jocmp.capy.accounts.BasicAuthInterceptor
+import com.jocmp.capy.accounts.clientCertAlias
 import com.jocmp.capy.accounts.httpClientBuilder
 import okhttp3.OkHttpClient
 import java.net.URI
@@ -19,13 +20,5 @@ internal object ReaderOkHttpClient {
             )
             .clientCertAlias(clientCertManager, preferences.clientCertAlias.get())
             .build()
-    }
-
-    fun OkHttpClient.Builder.clientCertAlias(manager: ClientCertManager, clientCertAlias: String): OkHttpClient.Builder {
-        if (clientCertAlias.isNotEmpty()) {
-            val clientSSlSocketFactory = manager.buildSslSocketFactory(clientCertAlias)
-            sslSocketFactory(clientSSlSocketFactory.sslSocketFactory, clientSSlSocketFactory.trustManager)
-        }
-        return this
     }
 }

--- a/minifluxclient/src/main/java/com/jocmp/minifluxclient/Miniflux.kt
+++ b/minifluxclient/src/main/java/com/jocmp/minifluxclient/Miniflux.kt
@@ -145,9 +145,10 @@ interface Miniflux {
         suspend fun verifyCredentials(
             username: String,
             password: String,
-            baseURL: String
+            baseURL: String,
+            client: OkHttpClient = OkHttpClient(),
         ): Boolean {
-            val client = OkHttpClient.Builder()
+            val client = client.newBuilder()
                 .addInterceptor { chain ->
                     val request = chain.request().newBuilder()
                         .header("Authorization", Credentials.basic(username, password))
@@ -168,9 +169,10 @@ interface Miniflux {
 
         suspend fun verifyToken(
             token: String,
-            baseURL: String
+            baseURL: String,
+            client: OkHttpClient = OkHttpClient(),
         ): Response<User>? {
-            val client = OkHttpClient.Builder()
+            val client = client.newBuilder()
                 .addInterceptor { chain ->
                     val request = chain.request().newBuilder()
                         .header("X-Auth-Token", token)


### PR DESCRIPTION
- https://github.com/jocmp/capyreader/discussions/1833
- https://github.com/jocmp/capyreader/issues/1836