### PR TITLE
Skip detail display when hidden

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticlePaneExpansion.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticlePaneExpansion.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
 private val DetailFullscreenAnchor = PaneExpansionAnchor.Proportion(0f)
+private val ListFullscreenAnchor = PaneExpansionAnchor.Proportion(1f)
 
 const val DefaultPaneExpansionIndex = 4
 
@@ -34,6 +35,7 @@ private val ArticlePaneAnchors: List<PaneExpansionAnchor> = buildList {
 class ArticlePaneExpansion(
     val state: PaneExpansionState,
     val isFullscreen: Boolean,
+    val isDetailHidden: Boolean,
     private val anchors: List<PaneExpansionAnchor>,
     private val lastAnchorIndex: Int,
     private val scope: CoroutineScope,
@@ -100,10 +102,14 @@ fun rememberArticlePaneExpansion(
     val isFullscreen = !compact &&
             paneExpansionState.currentAnchor == DetailFullscreenAnchor
 
-    return remember(paneExpansionState, isFullscreen, lastAnchorIndex, anchors, scope) {
+    val isDetailHidden = !compact &&
+            paneExpansionState.currentAnchor == ListFullscreenAnchor
+
+    return remember(paneExpansionState, isFullscreen, isDetailHidden, lastAnchorIndex, anchors, scope) {
         ArticlePaneExpansion(
             state = paneExpansionState,
             isFullscreen = isFullscreen,
+            isDetailHidden = isDetailHidden,
             anchors = anchors,
             lastAnchorIndex = lastAnchorIndex,
             scope = scope,

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -635,7 +635,7 @@ fun ArticleScreen(
                     ) {
                         CapyPlaceholder()
                     }
-                } else if (article != null) {
+                } else if (article != null && !paneExpansion.isDetailHidden) {
                     val isAudioPlaying by audioController.isPlaying.collectAsState()
                     val currentAudio by audioController.currentAudio.collectAsState()
 


### PR DESCRIPTION
Prevents the webview pane from rendering offscreen when the list-detail pane is hidden. This avoids measurement issues when the webview is rendered for the first time.