### PR TITLE
Improve SQL query performance

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/persistence/articles/ByArticleStatus.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/articles/ByArticleStatus.kt
@@ -20,20 +20,33 @@ class ByArticleStatus(private val database: Database) {
         since: OffsetDateTime? = null
     ): Query<Article> {
         val (read, starred) = status.toStatusPair
-        val newestFirst = isNewestFirst(sortOrder)
+        val queries = database.articlesByStatusQueries
 
-        return database.articlesByStatusQueries.all(
-            read = read,
-            starred = starred,
-            limit = limit,
-            offset = offset,
-            lastReadAt = mapLastRead(read, since),
-            lastStarredAt = mapLastStarred(starred, since),
-            publishedSince = null,
-            query = query,
-            newestFirst = newestFirst,
-            mapper = ::listMapper
-        )
+        return if (isNewestFirst(sortOrder)) {
+            queries.allNewestFirst(
+                read = read,
+                starred = starred,
+                limit = limit,
+                offset = offset,
+                lastReadAt = mapLastRead(read, since),
+                lastStarredAt = mapLastStarred(starred, since),
+                publishedSince = null,
+                query = query,
+                mapper = ::listMapper
+            )
+        } else {
+            queries.allOldestFirst(
+                read = read,
+                starred = starred,
+                limit = limit,
+                offset = offset,
+                lastReadAt = mapLastRead(read, since),
+                lastStarredAt = mapLastStarred(starred, since),
+                publishedSince = null,
+                query = query,
+                mapper = ::listMapper
+            )
+        }
     }
 
     fun unreadArticleIDs(

--- a/capy/src/main/java/com/jocmp/capy/persistence/articles/ByFeed.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/articles/ByFeed.kt
@@ -24,20 +24,37 @@ class ByFeed(private val database: Database) {
     ): Query<Article> {
         val (read, starred) = status.toStatusPair
 
-        return database.articlesByFeedQueries.all(
-            feedIDs = feedIDs,
-            query = query,
-            read = read,
-            starred = starred,
-            limit = limit,
-            offset = offset,
-            lastReadAt = mapLastRead(read, since),
-            lastStarredAt = mapLastStarred(starred, since),
-            publishedSince = null,
-            newestFirst = isDescendingOrder(sortOrder),
-            priorities = priority.inclusivePriorities,
-            mapper = ::listMapper
-        )
+        val queries = database.articlesByFeedQueries
+
+        return if (isDescendingOrder(sortOrder)) {
+            queries.allNewestFirst(
+                feedIDs = feedIDs,
+                query = query,
+                read = read,
+                starred = starred,
+                limit = limit,
+                offset = offset,
+                lastReadAt = mapLastRead(read, since),
+                lastStarredAt = mapLastStarred(starred, since),
+                publishedSince = null,
+                priorities = priority.inclusivePriorities,
+                mapper = ::listMapper
+            )
+        } else {
+            queries.allOldestFirst(
+                feedIDs = feedIDs,
+                query = query,
+                read = read,
+                starred = starred,
+                limit = limit,
+                offset = offset,
+                lastReadAt = mapLastRead(read, since),
+                lastStarredAt = mapLastStarred(starred, since),
+                publishedSince = null,
+                priorities = priority.inclusivePriorities,
+                mapper = ::listMapper
+            )
+        }
     }
 
     fun unreadArticleIDs(

--- a/capy/src/main/java/com/jocmp/capy/persistence/articles/BySavedSearch.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/articles/BySavedSearch.kt
@@ -22,19 +22,35 @@ class BySavedSearch(private val database: Database) {
     ): Query<Article> {
         val (read, starred) = status.toStatusPair
 
-        return database.articlesBySavedSearchQueries.all(
-            savedSearchID = savedSearchID,
-            query = query,
-            read = read,
-            starred = starred,
-            limit = limit,
-            offset = offset,
-            lastReadAt = mapLastRead(read, since),
-            lastStarredAt = mapLastStarred(starred, since),
-            publishedSince = null,
-            newestFirst = isDescendingOrder(sortOrder),
-            mapper = ::listMapper
-        )
+        val queries = database.articlesBySavedSearchQueries
+
+        return if (isDescendingOrder(sortOrder)) {
+            queries.allNewestFirst(
+                savedSearchID = savedSearchID,
+                query = query,
+                read = read,
+                starred = starred,
+                limit = limit,
+                offset = offset,
+                lastReadAt = mapLastRead(read, since),
+                lastStarredAt = mapLastStarred(starred, since),
+                publishedSince = null,
+                mapper = ::listMapper
+            )
+        } else {
+            queries.allOldestFirst(
+                savedSearchID = savedSearchID,
+                query = query,
+                read = read,
+                starred = starred,
+                limit = limit,
+                offset = offset,
+                lastReadAt = mapLastRead(read, since),
+                lastStarredAt = mapLastStarred(starred, since),
+                publishedSince = null,
+                mapper = ::listMapper
+            )
+        }
     }
 
     fun unreadArticleIDs(

--- a/capy/src/main/java/com/jocmp/capy/persistence/articles/ByToday.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/articles/ByToday.kt
@@ -20,20 +20,33 @@ class ByToday(private val database: Database) {
         since: OffsetDateTime?,
     ): Query<Article> {
         val (read, starred) = status.toStatusPair
-        val newestFirst = isNewestFirst(sortOrder)
+        val queries = database.articlesByStatusQueries
 
-        return database.articlesByStatusQueries.all(
-            read = read,
-            starred = starred,
-            limit = limit,
-            offset = offset,
-            lastReadAt = mapLastRead(read, since),
-            lastStarredAt = mapLastStarred(starred, since),
-            publishedSince = mapTodayStartDate(),
-            query = query,
-            newestFirst = newestFirst,
-            mapper = ::listMapper
-        )
+        return if (isNewestFirst(sortOrder)) {
+            queries.allNewestFirst(
+                read = read,
+                starred = starred,
+                limit = limit,
+                offset = offset,
+                lastReadAt = mapLastRead(read, since),
+                lastStarredAt = mapLastStarred(starred, since),
+                publishedSince = mapTodayStartDate(),
+                query = query,
+                mapper = ::listMapper
+            )
+        } else {
+            queries.allOldestFirst(
+                read = read,
+                starred = starred,
+                limit = limit,
+                offset = offset,
+                lastReadAt = mapLastRead(read, since),
+                lastStarredAt = mapLastStarred(starred, since),
+                publishedSince = mapTodayStartDate(),
+                query = query,
+                mapper = ::listMapper
+            )
+        }
     }
 
     fun unreadArticleIDs(

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/21_AddPerformanceIndexes.sqm
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/21_AddPerformanceIndexes.sqm
@@ -1,0 +1,5 @@
+-- Covering index for the common join + filter pattern on article_statuses
+CREATE INDEX article_statuses_covering_index ON article_statuses(article_id, read, starred);
+
+-- Index for NOT IN subqueries in updateStaleUnreads/updateStaleStars
+CREATE INDEX excluded_statuses_type_article_id_index ON excluded_statuses(type, article_id);

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articles.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articles.sq
@@ -19,7 +19,7 @@ LIMIT 1;
 countAll:
 SELECT
  articles.feed_id,
- COUNT(DISTINCT articles.id)
+ COUNT(*)
 FROM articles
 JOIN article_statuses ON articles.id = article_statuses.article_id
 WHERE (article_statuses.read = :read OR :read IS NULL)
@@ -29,7 +29,7 @@ GROUP BY articles.feed_id;
 countAllBySavedSearch:
 SELECT
  saved_search_articles.saved_search_id,
- COUNT(DISTINCT articles.id)
+ COUNT(*)
 FROM articles
 JOIN article_statuses ON articles.id = article_statuses.article_id
 JOIN saved_search_articles ON articles.id = saved_search_articles.article_id

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByFeed.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByFeed.sq
@@ -1,4 +1,4 @@
-all:
+allNewestFirst:
 SELECT
   articles.id,
   articles.feed_id,
@@ -24,8 +24,36 @@ AND ((article_statuses.starred = :starred AND article_statuses.last_starred_at I
 AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
 AND (articles.title LIKE '%' || :query || '%' OR articles.summary  LIKE '%' || :query || '%' OR :query IS NULL)
 AND (feeds.priority IN :priorities OR feeds.priority IS NULL)
-GROUP BY articles.id
-ORDER BY CASE WHEN :newestFirst THEN articles.published_at ELSE (-1 * articles.published_at) END DESC
+ORDER BY articles.published_at DESC
+LIMIT :limit OFFSET :offset;
+
+allOldestFirst:
+SELECT
+  articles.id,
+  articles.feed_id,
+  articles.title,
+  articles.author,
+  articles.url,
+  articles.summary,
+  articles.image_url,
+  articles.published_at,
+  articles.enclosure_type,
+  feeds.title AS feed_title,
+  feeds.favicon_url,
+  feeds.open_articles_in_browser,
+  article_statuses.updated_at,
+  article_statuses.starred,
+  article_statuses.read
+FROM articles
+JOIN feeds ON articles.feed_id = feeds.id
+JOIN article_statuses ON articles.id = article_statuses.article_id
+WHERE articles.feed_id IN :feedIDs
+AND ((article_statuses.read = :read AND article_statuses.last_read_at IS NULL OR article_statuses.last_read_at >= :lastReadAt) OR :read IS NULL)
+AND ((article_statuses.starred = :starred AND article_statuses.last_starred_at IS NULL OR article_statuses.last_starred_at >= :lastStarredAt) OR :starred IS NULL)
+AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
+AND (articles.title LIKE '%' || :query || '%' OR articles.summary  LIKE '%' || :query || '%' OR :query IS NULL)
+AND (feeds.priority IN :priorities OR feeds.priority IS NULL)
+ORDER BY articles.published_at ASC
 LIMIT :limit OFFSET :offset;
 
 countAll:
@@ -64,5 +92,4 @@ AND (
         THEN articles.published_at <= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
         ELSE articles.published_at >= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
     END
-)
-GROUP BY articles.id;
+);

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articlesBySavedSearch.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articlesBySavedSearch.sq
@@ -1,4 +1,4 @@
-all:
+allNewestFirst:
 SELECT
   articles.id,
   articles.feed_id,
@@ -24,8 +24,36 @@ AND ((article_statuses.read = :read AND article_statuses.last_read_at IS NULL OR
 AND ((article_statuses.starred = :starred AND article_statuses.last_starred_at IS NULL OR article_statuses.last_starred_at >= :lastStarredAt) OR :starred IS NULL)
 AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
 AND (articles.title LIKE '%' || :query || '%' OR articles.summary  LIKE '%' || :query || '%' OR :query IS NULL)
-GROUP BY articles.id
-ORDER BY CASE WHEN :newestFirst THEN articles.published_at ELSE (-1 * articles.published_at) END DESC
+ORDER BY articles.published_at DESC
+LIMIT :limit OFFSET :offset;
+
+allOldestFirst:
+SELECT
+  articles.id,
+  articles.feed_id,
+  articles.title,
+  articles.author,
+  articles.url,
+  articles.summary,
+  articles.image_url,
+  articles.published_at,
+  articles.enclosure_type,
+  feeds.title AS feed_title,
+  feeds.favicon_url,
+  feeds.open_articles_in_browser,
+  article_statuses.updated_at,
+  article_statuses.starred,
+  article_statuses.read
+FROM articles
+JOIN feeds ON articles.feed_id = feeds.id
+JOIN article_statuses ON articles.id = article_statuses.article_id
+JOIN saved_search_articles ON articles.id = saved_search_articles.article_id
+WHERE saved_search_id = :savedSearchID
+AND ((article_statuses.read = :read AND article_statuses.last_read_at IS NULL OR article_statuses.last_read_at >= :lastReadAt) OR :read IS NULL)
+AND ((article_statuses.starred = :starred AND article_statuses.last_starred_at IS NULL OR article_statuses.last_starred_at >= :lastStarredAt) OR :starred IS NULL)
+AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
+AND (articles.title LIKE '%' || :query || '%' OR articles.summary  LIKE '%' || :query || '%' OR :query IS NULL)
+ORDER BY articles.published_at ASC
 LIMIT :limit OFFSET :offset;
 
 countAll:
@@ -63,5 +91,4 @@ AND (
         THEN articles.published_at <= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
         ELSE articles.published_at >= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
     END
-)
-GROUP BY articles.id;
+);

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByStatus.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByStatus.sq
@@ -1,4 +1,4 @@
-all:
+allNewestFirst:
 SELECT
   articles.id,
   articles.feed_id,
@@ -23,8 +23,35 @@ AND (feeds.priority IS NULL OR feeds.priority IN ('main', 'important'))
 AND ((article_statuses.starred = :starred AND article_statuses.last_starred_at IS NULL OR article_statuses.last_starred_at >= :lastStarredAt) OR :starred IS NULL)
 AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
 AND (articles.title LIKE '%' || :query || '%' OR articles.summary  LIKE '%' || :query || '%' OR :query IS NULL)
-GROUP BY articles.id
-ORDER BY CASE WHEN :newestFirst THEN articles.published_at ELSE (-1 * articles.published_at) END DESC
+ORDER BY articles.published_at DESC
+LIMIT :limit OFFSET :offset;
+
+allOldestFirst:
+SELECT
+  articles.id,
+  articles.feed_id,
+  articles.title,
+  articles.author,
+  articles.url,
+  articles.summary,
+  articles.image_url,
+  articles.published_at,
+  articles.enclosure_type,
+  feeds.title AS feed_title,
+  feeds.favicon_url,
+  feeds.open_articles_in_browser,
+  article_statuses.updated_at,
+  article_statuses.starred,
+  article_statuses.read
+FROM articles
+JOIN feeds ON articles.feed_id = feeds.id
+JOIN article_statuses ON articles.id = article_statuses.article_id
+WHERE ((article_statuses.read = :read AND article_statuses.last_read_at IS NULL OR article_statuses.last_read_at >= :lastReadAt) OR :read IS NULL)
+AND (feeds.priority IS NULL OR feeds.priority IN ('main', 'important'))
+AND ((article_statuses.starred = :starred AND article_statuses.last_starred_at IS NULL OR article_statuses.last_starred_at >= :lastStarredAt) OR :starred IS NULL)
+AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
+AND (articles.title LIKE '%' || :query || '%' OR articles.summary  LIKE '%' || :query || '%' OR :query IS NULL)
+ORDER BY articles.published_at ASC
 LIMIT :limit OFFSET :offset;
 
 countAll:
@@ -61,5 +88,4 @@ AND (
         THEN articles.published_at <= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
         ELSE articles.published_at >= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
     END
-)
-GROUP BY articles.id;
+);


### PR DESCRIPTION
- Remove unnecessary GROUP BY articles.id from all list queries (joins are already 1:1)
- Replace COUNT(DISTINCT articles.id) with COUNT(*) in countAll queries
- Split ORDER BY CASE into allNewestFirst/allOldestFirst variants so the published_at index can be used
- Add covering index on article_statuses(article_id, read, starred)
- Add index on excluded_statuses(type, article_id) for updateStaleUnreads/updateStaleStars