### PR TITLE
Only render webview when it's wider than 0 pixels

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -635,7 +635,7 @@ fun ArticleScreen(
                     ) {
                         CapyPlaceholder()
                     }
-                } else if (article != null && !paneExpansion.isDetailHidden) {
+                } else if (article != null) {
                     val isAudioPlaying by audioController.isPlaying.collectAsState()
                     val currentAudio by audioController.currentAudio.collectAsState()
 

--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleView.kt
@@ -1,6 +1,7 @@
 package com.capyreader.app.ui.articles.detail
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
@@ -135,9 +136,10 @@ fun ArticleView(
     CompositionLocalProvider(
         LocalSnackbarHost provides snackbarHostState,
     ) {
-        Box(Modifier
+        BoxWithConstraints(Modifier
             .fillMaxSize()
             .nestedScroll(scrollState.connection)) {
+          if (maxWidth > 0.dp) {
             Box(
                 modifier = Modifier
                     .padding(contentPadding)
@@ -204,6 +206,7 @@ fun ArticleView(
                     .align(Alignment.BottomCenter)
                     .padding(bottom = 80.dp)
             )
+          }
         }
     }
 


### PR DESCRIPTION
Second attempt, this time is actually works.

Prevents the webview pane from rendering offscreen when the list-detail pane is hidden. This avoids measurement issues when the webview is rendered for the first time.