### PR TITLE
feat(freshrss): Use "ot" variable for incremental sync

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/AccountSettingsPanel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/AccountSettingsPanel.kt
@@ -21,6 +21,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -51,6 +53,7 @@ fun AccountSettingsPanel(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
+    val lastRefreshedAt by viewModel.lastRefreshedAt.collectAsState()
 
     val importer = rememberLauncherForActivityResult(
         GetOPMLContent()
@@ -81,6 +84,7 @@ fun AccountSettingsPanel(
         accountSource = viewModel.accountSource,
         accountURL = viewModel.accountURL,
         accountName = viewModel.accountName,
+        lastRefreshedAt = lastRefreshedAt,
     )
 }
 
@@ -92,6 +96,7 @@ fun AccountSettingsPanelView(
     accountSource: Source,
     accountURL: String,
     accountName: String,
+    lastRefreshedAt: LastRefreshed,
     importProgress: ImportProgress?,
 ) {
     val strings = AccountSettingsStrings.build(accountSource)
@@ -130,6 +135,17 @@ fun AccountSettingsPanelView(
                         )
                     }
                 }
+            }
+        }
+
+        FormSection(
+            title = stringResource(R.string.settings_section_refresh),
+        ) {
+            RowItem {
+                Text(
+                    text = lastRefreshed(lastRefreshedAt),
+                    color = colorScheme.onSurfaceVariant,
+                )
             }
         }
 
@@ -215,6 +231,15 @@ fun showImportButton(source: Source): Boolean {
     return source == Source.LOCAL
 }
 
+@Composable
+private fun lastRefreshed(lastRefreshed: LastRefreshed): String {
+    return when (lastRefreshed) {
+        is LastRefreshed.Never -> stringResource(R.string.settings_account_never_refreshed)
+        is LastRefreshed.Today -> stringResource(R.string.settings_account_refresh_value_today, lastRefreshed.time)
+        is LastRefreshed.Past -> stringResource(R.string.settings_account_refresh_value, lastRefreshed.date, lastRefreshed.time)
+    }
+}
+
 @Preview
 @Composable
 private fun AccountSettingsPanelViewPreview() {
@@ -226,6 +251,7 @@ private fun AccountSettingsPanelViewPreview() {
             accountSource = Source.FEEDBIN,
             accountURL = "",
             accountName = "test@example.com",
+            lastRefreshedAt = LastRefreshed.from(1700000000L),
             importProgress = null
         )
     }
@@ -242,6 +268,7 @@ private fun AccountSettingsPanelViewLocalPreview() {
             accountURL = "",
             accountSource = Source.LOCAL,
             accountName = "test@example.com",
+            lastRefreshedAt = LastRefreshed.Never,
             importProgress = ImportProgress(currentCount = 3, total = 9001)
         )
     }

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/AccountSettingsViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/AccountSettingsViewModel.kt
@@ -18,6 +18,9 @@ import com.jocmp.capy.Account
 import com.jocmp.capy.AccountManager
 import com.jocmp.capy.accounts.Source
 import com.jocmp.capy.opml.ImportProgress
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class AccountSettingsViewModel(
@@ -34,6 +37,11 @@ class AccountSettingsViewModel(
     val accountURL = account.preferences.url.get()
 
     val accountName = account.preferences.username.get()
+
+    val lastRefreshedAt = account.preferences.lastRefreshedAt
+        .changes()
+        .map { LastRefreshed.from(it) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), LastRefreshed.Never)
 
     fun removeAccount() {
         appPreferences.clearAll()

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/LastRefreshed.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/LastRefreshed.kt
@@ -1,0 +1,36 @@
+package com.capyreader.app.ui.settings.panels
+
+import com.jocmp.capy.common.toDateTimeFromSeconds
+import com.jocmp.capy.common.toDeviceDateTime
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+sealed interface LastRefreshed {
+    data object Never : LastRefreshed
+
+    data class Today(val time: String) : LastRefreshed
+
+    data class Past(val date: String, val time: String) : LastRefreshed
+
+    companion object {
+        fun from(
+            epochSeconds: Long,
+            today: LocalDate = LocalDate.now(),
+        ): LastRefreshed {
+            if (epochSeconds == 0L) {
+                return Never
+            }
+
+            val deviceDateTime = epochSeconds.toDateTimeFromSeconds.toDeviceDateTime()
+            val time = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).format(deviceDateTime)
+
+            return if (deviceDateTime.toLocalDate() == today) {
+                Today(time = time)
+            } else {
+                val date = DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).format(deviceDateTime)
+                Past(date = date, time = time)
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,9 @@
     <string name="transfers_export_subscriptions">Export Subscriptions</string>
     <string name="settings_section_account">Account</string>
     <string name="settings_section_account_server">Server</string>
+    <string name="settings_account_refresh_value">%1$s at %2$s</string>
+    <string name="settings_account_refresh_value_today">Today at %1$s</string>
+    <string name="settings_account_never_refreshed">Never</string>
     <string name="settings_section_import">Import</string>
     <string name="settings_section_export">Export</string>
     <string name="opml_import_notification_title">Importing subscriptions…</string>
@@ -128,7 +131,7 @@
     <string name="notifications_channel_title_feed_update">Feed Updates</string>
     <string name="notification_mark_as_read_action">Mark as read</string>
     <string name="settings_section_privacy">Privacy</string>
-    <string name="settings_section_refresh">Refresh</string>
+    <string name="settings_section_refresh">Last Updated</string>
     <string name="opml_import_button_text">Import from File</string>
     <string name="opml_export_button_text">Export to OPML</string>
     <string name="opml_import_progress_content_text_start">Starting import</string>

--- a/app/src/test/java/com/capyreader/app/ui/settings/panels/LastRefreshedTest.kt
+++ b/app/src/test/java/com/capyreader/app/ui/settings/panels/LastRefreshedTest.kt
@@ -1,0 +1,72 @@
+package com.capyreader.app.ui.settings.panels
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class LastRefreshedTest {
+    @Test
+    fun zeroEpoch_returnsNever() {
+        val result = LastRefreshed.from(epochSeconds = 0L)
+
+        assertTrue(result is LastRefreshed.Never)
+    }
+
+    @Test
+    fun todayTimestamp_returnsToday() {
+        val now = ZonedDateTime.now(ZoneId.systemDefault())
+        val epochSeconds = now.toEpochSecond()
+
+        val result = LastRefreshed.from(
+            epochSeconds = epochSeconds,
+            today = now.toLocalDate(),
+        )
+
+        assertTrue(result is LastRefreshed.Today)
+    }
+
+    @Test
+    fun pastTimestamp_returnsPastDate() {
+        val today = LocalDate.of(2026, 3, 1)
+        val pastDate = ZonedDateTime.of(2026, 2, 15, 10, 30, 0, 0, ZoneId.systemDefault())
+        val epochSeconds = pastDate.toEpochSecond()
+
+        val result = LastRefreshed.from(
+            epochSeconds = epochSeconds,
+            today = today,
+        )
+
+        assertTrue(result is LastRefreshed.Past)
+    }
+
+    @Test
+    fun todayResult_includesFormattedTime() {
+        val dateTime = ZonedDateTime.of(2026, 3, 1, 14, 30, 0, 0, ZoneId.systemDefault())
+        val epochSeconds = dateTime.toEpochSecond()
+
+        val result = LastRefreshed.from(
+            epochSeconds = epochSeconds,
+            today = dateTime.toLocalDate(),
+        )
+
+        val time = (result as LastRefreshed.Today).time
+        assertTrue(time.isNotBlank())
+    }
+
+    @Test
+    fun pastDateResult_includesFormattedDateAndTime() {
+        val today = LocalDate.of(2026, 3, 1)
+        val pastDate = ZonedDateTime.of(2026, 2, 15, 10, 30, 0, 0, ZoneId.systemDefault())
+        val epochSeconds = pastDate.toEpochSecond()
+
+        val result = LastRefreshed.from(
+            epochSeconds = epochSeconds,
+            today = today,
+        ) as LastRefreshed.Past
+
+        assertTrue(result.date.isNotBlank())
+        assertTrue(result.time.isNotBlank())
+    }
+}

--- a/capy/src/main/java/com/jocmp/capy/Account.kt
+++ b/capy/src/main/java/com/jocmp/capy/Account.kt
@@ -73,7 +73,8 @@ data class Account(
             feedbin = Feedbin.forAccount(
                 path = cacheDirectory,
                 preferences = preferences
-            )
+            ),
+            preferences = preferences,
         )
 
         Source.MINIFLUX,

--- a/capy/src/main/java/com/jocmp/capy/AccountPreferences.kt
+++ b/capy/src/main/java/com/jocmp/capy/AccountPreferences.kt
@@ -2,9 +2,12 @@ package com.jocmp.capy
 
 import com.jocmp.capy.accounts.AutoDelete
 import com.jocmp.capy.accounts.Source
+import com.jocmp.capy.common.TimeHelpers
+import com.jocmp.capy.common.toDateTimeFromSeconds
 import com.jocmp.capy.preferences.Preference
 import com.jocmp.capy.preferences.PreferenceStore
 import com.jocmp.capy.preferences.getEnum
+import java.time.ZonedDateTime
 
 class AccountPreferences(
     private val store: PreferenceStore,
@@ -32,4 +35,21 @@ class AccountPreferences(
 
     val canSaveArticleExternally: Preference<Boolean>
         get() = store.getBoolean("can_save_article_externally", false)
+
+    val lastRefreshedAt: Preference<Long>
+        get() = store.getLong("last_refreshed_at", 0L)
+
+    fun touchLastRefreshedAt() {
+        lastRefreshedAt.set(TimeHelpers.nowUTC().toEpochSecond())
+    }
+
+    fun lastRefreshedAt(): ZonedDateTime {
+        val epoch = lastRefreshedAt.get()
+
+        return if (epoch > 0L) {
+            epoch.toDateTimeFromSeconds
+        } else {
+            TimeHelpers.nowUTC().minusMonths(3)
+        }
+    }
 }

--- a/capy/src/main/java/com/jocmp/capy/accounts/feedbin/FeedbinAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/feedbin/FeedbinAccountDelegate.kt
@@ -1,6 +1,7 @@
 package com.jocmp.capy.accounts.feedbin
 
 import com.jocmp.capy.AccountDelegate
+import com.jocmp.capy.AccountPreferences
 import com.jocmp.capy.ArticleFilter
 import com.jocmp.capy.Feed
 import com.jocmp.capy.accounts.AddFeedResult
@@ -42,7 +43,8 @@ import java.time.ZonedDateTime
 
 internal class FeedbinAccountDelegate(
     private val database: Database,
-    private val feedbin: Feedbin
+    private val feedbin: Feedbin,
+    private val preferences: AccountPreferences,
 ) : AccountDelegate {
     private val articleRecords = ArticleRecords(database)
     private val enclosureRecords = EnclosureRecords(database)
@@ -55,7 +57,8 @@ internal class FeedbinAccountDelegate(
             refreshFeeds()
             refreshTaggings()
             refreshSavedSearches()
-            refreshArticles(since = maxArrivedAt())
+            refreshArticles(since = preferences.lastRefreshedAt().toString())
+            preferences.touchLastRefreshedAt()
 
             Result.success(Unit)
         } catch (exception: IOException) {
@@ -69,10 +72,9 @@ internal class FeedbinAccountDelegate(
         val entryIDs = articleIDs.map { it.toLong() }
 
         return withErrorHandling {
-            entryIDs.chunked(MAX_CREATE_UNREAD_LIMIT).map { batchIDs ->
+            entryIDs.chunked(MAX_CREATE_UNREAD_LIMIT).forEach { batchIDs ->
                 feedbin.deleteUnreadEntries(UnreadEntriesRequest(unread_entries = batchIDs))
             }
-            Unit
         }
     }
 
@@ -250,7 +252,7 @@ internal class FeedbinAccountDelegate(
         }
     }
 
-    private suspend fun refreshArticles(since: String = maxArrivedAt()) {
+    private suspend fun refreshArticles(since: String = preferences.lastRefreshedAt().toString()) {
         refreshStarredEntries()
         refreshUnreadEntries()
         refreshAllArticles(since = since)
@@ -497,8 +499,6 @@ internal class FeedbinAccountDelegate(
             query = savedSearch.query
         )
     }
-
-    private fun maxArrivedAt() = articleRecords.maxArrivedAt().toString()
 
     private suspend fun fetchIcons(): List<Icon> {
         val response = feedbin.icons()

--- a/capy/src/main/java/com/jocmp/capy/accounts/local/LocalAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/local/LocalAccountDelegate.kt
@@ -44,6 +44,7 @@ internal class LocalAccountDelegate(
             is ArticleFilter.Folders -> refreshFolderFilter(filter, cutoffDate = cutoffDate)
             else -> refreshArticleFilter(cutoffDate)
         }
+        preferences.touchLastRefreshedAt()
 
         return Result.success(Unit)
     }

--- a/capy/src/main/java/com/jocmp/capy/accounts/miniflux/MinifluxAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/miniflux/MinifluxAccountDelegate.kt
@@ -51,6 +51,7 @@ internal class MinifluxAccountDelegate(
             refreshIntegrationStatus()
             refreshFeeds()
             refreshArticles()
+            preferences.touchLastRefreshedAt()
 
             Result.success(Unit)
         } catch (exception: IOException) {

--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/BuildReaderDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/BuildReaderDelegate.kt
@@ -23,6 +23,7 @@ internal fun buildReaderDelegate(
         googleReader = GoogleReader.create(
             client = httpClient,
             baseURL = preferences.url.get()
-        )
+        ),
+        preferences = preferences,
     )
 }

--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegate.kt
@@ -1,6 +1,7 @@
 package com.jocmp.capy.accounts.reader
 
 import com.jocmp.capy.AccountDelegate
+import com.jocmp.capy.AccountPreferences
 import com.jocmp.capy.ArticleFilter
 import com.jocmp.capy.Feed
 import com.jocmp.capy.accounts.AddFeedResult
@@ -46,6 +47,7 @@ internal class ReaderAccountDelegate(
     private val source: Source,
     private val database: Database,
     private val googleReader: GoogleReader,
+    private val preferences: AccountPreferences,
 ) : AccountDelegate {
     private var postToken = AtomicReference<String?>(null)
     private val articleRecords = ArticleRecords(database)
@@ -56,11 +58,19 @@ internal class ReaderAccountDelegate(
 
     override suspend fun refresh(filter: ArticleFilter, cutoffDate: ZonedDateTime?): Result<Unit> {
         return withErrorHandling {
-            if (filter.hasArticlesSelected()) {
-                refreshTopLevelArticles()
+            if (source == Source.FRESHRSS) {
+                refreshFeeds()
+                refreshAllSavedSearches()
+                refreshAllArticles(since = preferences.lastRefreshedAt().toEpochSecond())
+                fetchMissingArticles()
             } else {
-                refreshArticles(filter.toStream(source))
+                if (filter.hasArticlesSelected()) {
+                    refreshTopLevelArticles()
+                } else {
+                    refreshArticles(filter.toStream(source))
+                }
             }
+            preferences.touchLastRefreshedAt()
         }
     }
 
@@ -87,7 +97,10 @@ internal class ReaderAccountDelegate(
     override suspend fun addSavedSearch(articleID: String, savedSearchID: String): Result<Unit> {
         savedSearchRecords.upsertArticle(articleID = articleID, savedSearchID = savedSearchID)
 
-        return editTag(ids = listOf(articleID), addTag = Stream.UserLabel(savedSearchID)).onFailure {
+        return editTag(
+            ids = listOf(articleID),
+            addTag = Stream.UserLabel(savedSearchID)
+        ).onFailure {
             savedSearchRecords.removeArticle(articleID = articleID, savedSearchID = savedSearchID)
         }
     }
@@ -95,7 +108,10 @@ internal class ReaderAccountDelegate(
     override suspend fun removeSavedSearch(articleID: String, savedSearchID: String): Result<Unit> {
         savedSearchRecords.removeArticle(articleID = articleID, savedSearchID = savedSearchID)
 
-        return editTag(ids = listOf(articleID), removeTag = Stream.UserLabel(savedSearchID)).onFailure {
+        return editTag(
+            ids = listOf(articleID),
+            removeTag = Stream.UserLabel(savedSearchID)
+        ).onFailure {
             savedSearchRecords.upsertArticle(articleID = articleID, savedSearchID = savedSearchID)
         }
     }
@@ -260,6 +276,10 @@ internal class ReaderAccountDelegate(
         }
     }
 
+    private suspend fun refreshAllArticles(since: Long?) {
+        fetchPaginatedArticles(since = since, stream = Stream.ReadingList())
+    }
+
     private suspend fun refreshFeeds() {
         withResult(googleReader.subscriptionList()) { result ->
             val subscriptions = result.subscriptions
@@ -376,7 +396,7 @@ internal class ReaderAccountDelegate(
             refreshFeeds()
         }
 
-        if (stream is Stream.UserLabel) {
+        if (stream is UserLabel) {
             fetchPaginatedArticles(stream = stream)
         } else {
             refreshArticleState()

--- a/capy/src/test/java/com/jocmp/capy/accounts/feedbin/FeedbinAccountDelegateTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/feedbin/FeedbinAccountDelegateTest.kt
@@ -1,8 +1,10 @@
 package com.jocmp.capy.accounts.feedbin
 
 import com.jocmp.capy.AccountDelegate
+import com.jocmp.capy.AccountPreferences
 import com.jocmp.capy.ArticleFilter
 import com.jocmp.capy.ArticleStatus
+import com.jocmp.capy.InMemoryDataStore
 import com.jocmp.capy.InMemoryDatabaseProvider
 import com.jocmp.capy.accounts.AddFeedResult
 import com.jocmp.capy.accounts.SubscriptionChoice
@@ -46,6 +48,7 @@ class FeedbinAccountDelegateTest {
     private lateinit var feedbin: Feedbin
     private lateinit var feedFixture: FeedFixture
     private lateinit var delegate: AccountDelegate
+    private lateinit var preferences: AccountPreferences
 
     private val subscriptions = listOf(
         Subscription(
@@ -127,7 +130,8 @@ class FeedbinAccountDelegateTest {
         database = InMemoryDatabaseProvider.build(accountID)
         feedFixture = FeedFixture(database)
         feedbin = mockk()
-        delegate = FeedbinAccountDelegate(database, feedbin)
+        preferences = AccountPreferences(InMemoryDataStore())
+        delegate = FeedbinAccountDelegate(database, feedbin, preferences)
 
         coEvery { feedbin.icons() }.returns(Response.success(listOf()))
     }
@@ -447,8 +451,42 @@ class FeedbinAccountDelegateTest {
     }
 
     @Test
+    fun refresh_setsLastRefreshedAt() = runTest {
+        coEvery { feedbin.subscriptions() }.returns(Response.success(subscriptions))
+        coEvery { feedbin.unreadEntries() }.returns(Response.success(emptyList()))
+        coEvery { feedbin.starredEntries() }.returns(Response.success(emptyList()))
+        coEvery { feedbin.taggings() }.returns(Response.success(taggings))
+        coEvery { feedbin.savedSearches() }.returns(Response.success(emptyList()))
+        coEvery {
+            feedbin.entries(
+                since = any(),
+                perPage = any(),
+                page = any(),
+                ids = any(),
+            )
+        }.returns(Response.success(emptyList()))
+
+        assertEquals(expected = 0L, actual = preferences.lastRefreshedAt.get())
+
+        delegate.refresh(ArticleFilter.default())
+
+        assertTrue(preferences.lastRefreshedAt.get() > 0L)
+    }
+
+    @Test
+    fun refresh_failure_doesNotUpdateLastRefreshedAt() = runTest {
+        coEvery { feedbin.subscriptions() }.throws(SocketTimeoutException("timeout"))
+
+        assertEquals(expected = 0L, actual = preferences.lastRefreshedAt.get())
+
+        delegate.refresh(ArticleFilter.default())
+
+        assertEquals(expected = 0L, actual = preferences.lastRefreshedAt.get())
+    }
+
+    @Test
     fun updateFeed_modifyTitle() = runTest {
-        val delegate = FeedbinAccountDelegate(database, feedbin)
+        val delegate = FeedbinAccountDelegate(database, feedbin, preferences)
         val feed = feedFixture.create()
 
         val subscription = Subscription(

--- a/capy/src/test/java/com/jocmp/capy/accounts/local/LocalAccountDelegateTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/local/LocalAccountDelegateTest.kt
@@ -3,6 +3,7 @@ package com.jocmp.capy.accounts.local
 import com.jocmp.capy.AccountDelegate
 import com.jocmp.capy.AccountPreferences
 import com.jocmp.capy.ArticleFilter
+import com.jocmp.capy.InMemoryDataStore
 import com.jocmp.capy.InMemoryDatabaseProvider
 import com.jocmp.capy.accounts.AddFeedResult
 import com.jocmp.capy.common.TimeHelpers
@@ -10,7 +11,6 @@ import com.jocmp.capy.db.Database
 import com.jocmp.capy.fixtures.FeedFixture
 import com.jocmp.capy.logging.CapyLog
 import com.jocmp.capy.persistence.ArticleRecords
-import com.jocmp.capy.preferences.Preference
 import com.jocmp.capy.rssItemFixture
 import com.jocmp.feedfinder.FeedFinder
 import com.jocmp.feedfinder.parser.Feed
@@ -87,10 +87,7 @@ class LocalAccountDelegateTest {
     fun setup() {
         mockkObject(CapyLog)
 
-        accountPreferences = mockk()
-        val blocklist = mockk<Preference<Set<String>>>()
-        every { blocklist.get() }.returns(emptySet())
-        every { accountPreferences.keywordBlocklist }.returns(blocklist)
+        accountPreferences = AccountPreferences(InMemoryDataStore())
         every { CapyLog.warn(any(), any()) }.returns(Unit)
         every { CapyLog.error(any(), any()) }.returns(Unit)
         every { CapyLog.info(any(), any()) }.returns(Unit)
@@ -131,9 +128,7 @@ class LocalAccountDelegateTest {
 
     @Test
     fun refreshAll_updatesEntries_filteredByBlocklist() = runTest {
-        val blocklist = mockk<Preference<Set<String>>>()
-        every { blocklist.get() }.returns(setOf("Apple Intelligence"))
-        every { accountPreferences.keywordBlocklist }.returns(blocklist)
+        accountPreferences.keywordBlocklist.set(setOf("Apple Intelligence"))
         coEvery { feedFinder.fetch(url = any()) }.returns(Result.success(channel))
 
         FeedFixture(database).create(feedID = channel.link!!)

--- a/capy/src/test/java/com/jocmp/capy/accounts/miniflux/MinifluxAccountDelegateTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/miniflux/MinifluxAccountDelegateTest.kt
@@ -23,9 +23,12 @@ import com.jocmp.minifluxclient.IconData
 import com.jocmp.minifluxclient.Miniflux
 import com.jocmp.minifluxclient.UpdateEntriesRequest
 import com.jocmp.minifluxclient.UpdateFeedRequest
+import com.jocmp.capy.logging.CapyLog
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import retrofit2.Response
@@ -162,6 +165,10 @@ class MinifluxAccountDelegateTest {
 
     @BeforeTest
     fun setup() {
+        mockkObject(CapyLog)
+        every { CapyLog.warn(any(), any()) }.returns(Unit)
+        every { CapyLog.info(any(), any()) }.returns(Unit)
+
         database = InMemoryDatabaseProvider.build(accountID)
         feedFixture = FeedFixture(database)
         miniflux = mockk()

--- a/capy/src/test/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegateTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegateTest.kt
@@ -1,8 +1,10 @@
 package com.jocmp.capy.accounts.reader
 
 import com.jocmp.capy.AccountDelegate
+import com.jocmp.capy.AccountPreferences
 import com.jocmp.capy.ArticleFilter
 import com.jocmp.capy.ArticleStatus
+import com.jocmp.capy.InMemoryDataStore
 import com.jocmp.capy.InMemoryDatabaseProvider
 import com.jocmp.capy.accounts.AddFeedResult
 import com.jocmp.capy.accounts.Source
@@ -55,6 +57,7 @@ class ReaderAccountDelegateTest {
     private lateinit var feedFixture: FeedFixture
     private lateinit var folderFixture: FolderFixture
     private lateinit var delegate: AccountDelegate
+    private lateinit var preferences: AccountPreferences
 
     private val arsTechnica = Subscription(
         id = "feed/2",
@@ -174,8 +177,9 @@ class ReaderAccountDelegateTest {
         feedFixture = FeedFixture(database)
         folderFixture = FolderFixture(database)
         googleReader = mockk()
+        preferences = AccountPreferences(InMemoryDataStore())
 
-        delegate = ReaderAccountDelegate(source = Source.FRESHRSS, database, googleReader)
+        delegate = ReaderAccountDelegate(source = Source.FRESHRSS, database, googleReader, preferences)
     }
 
     @Test
@@ -184,11 +188,8 @@ class ReaderAccountDelegateTest {
 
         stubSubscriptions()
         stubTags()
-        stubUnread(itemRefs)
-        stubStarred()
         stubStreamItemsIDs(itemRefs)
         stubStreamItemsIDs(stream = Stream.UserLabel(chicagoTag.id), itemRefs = emptyList())
-        stubStreamItemsIDs(stream = Stream.Read(), itemRefs = emptyList())
 
         delegate.refresh(ArticleFilter.default())
 
@@ -220,6 +221,8 @@ class ReaderAccountDelegateTest {
 
     @Test
     fun refresh_feedOnly() = runTest {
+        delegate = ReaderAccountDelegate(source = Source.READER, database, googleReader, preferences)
+
         val id = "feed/2"
         val itemRefs = listOf(ItemRef("16"))
 
@@ -245,6 +248,8 @@ class ReaderAccountDelegateTest {
 
     @Test
     fun refresh_folderOnly() = runTest {
+        delegate = ReaderAccountDelegate(source = Source.READER, database, googleReader, preferences)
+
         val folderTitle = "Tech"
         val feed = feedFixture.create(feedID = "feed/2")
         folderFixture.create(name = folderTitle, feed = feed)
@@ -254,7 +259,7 @@ class ReaderAccountDelegateTest {
         stubStarred()
         stubUnread()
         stubSubscriptions()
-        stubStreamItemsIDs(itemRefs, stream = Stream.Label(folderTitle))
+        stubStreamItemsIDs(itemRefs, stream = Stream.ReadingList())
 
         delegate.refresh(
             ArticleFilter.Folders(
@@ -273,7 +278,7 @@ class ReaderAccountDelegateTest {
 
     @Test
     fun `refresh Miniflux folder`() = runTest {
-        delegate = ReaderAccountDelegate(source = Source.READER, database, googleReader)
+        delegate = ReaderAccountDelegate(source = Source.READER, database, googleReader, preferences)
 
         val folderTitle = "Tech"
         val feed = feedFixture.create(feedID = "feed/2")
@@ -303,6 +308,8 @@ class ReaderAccountDelegateTest {
 
     @Test
     fun refresh_findsMissingArticles() = runTest {
+        delegate = ReaderAccountDelegate(source = Source.READER, database, googleReader, preferences)
+
         val readingListItems = listOf(unreadStarredItem, unreadItem)
         val readingListItemRefs = listOf("1", "16").map { ItemRef(it) }
 
@@ -346,6 +353,48 @@ class ReaderAccountDelegateTest {
         assertTrue(readArticle.read)
     }
 
+
+    @Test
+    fun refresh_freshrss_setsLastRefreshedAt() = runTest {
+        stubSubscriptions()
+        stubTags()
+        stubStreamItemsIDs(emptyList())
+        stubStreamItemsIDs(stream = Stream.UserLabel(chicagoTag.id), itemRefs = emptyList())
+
+        assertEquals(expected = 0L, actual = preferences.lastRefreshedAt.get())
+
+        delegate.refresh(ArticleFilter.default())
+
+        assertTrue(preferences.lastRefreshedAt.get() > 0L)
+    }
+
+    @Test
+    fun refresh_freshrss_usesOtParameter() = runTest {
+        val knownEpoch = 1700000000L
+        preferences.lastRefreshedAt.set(knownEpoch)
+
+        stubSubscriptions()
+        stubTags()
+        stubStreamItemsIDs(stream = Stream.UserLabel(chicagoTag.id), itemRefs = emptyList())
+
+        coEvery {
+            googleReader.streamItemsIDs(
+                streamID = Stream.ReadingList().id,
+                since = knownEpoch,
+                count = 10_000,
+            )
+        }.returns(Response.success(StreamItemIDsResult(itemRefs = emptyList(), continuation = null)))
+
+        delegate.refresh(ArticleFilter.default())
+
+        coVerify {
+            googleReader.streamItemsIDs(
+                streamID = Stream.ReadingList().id,
+                since = knownEpoch,
+                count = 10_000,
+            )
+        }
+    }
 
     @Test
     fun refresh_IOException() = runTest {


### PR DESCRIPTION
Tracks a "last refreshed at" timestamp and uses it in tandem with the FreshRSS `ot` variable to sync based on timestamps instead of a static 10k article ceiling. 

Ref

- #1858 
- https://github.com/FreshRSS/FreshRSS/pull/8131