### PR TITLE
Don't proxy iframe media

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/components/WebRequestProxyPolicy.kt
+++ b/app/src/main/java/com/capyreader/app/ui/components/WebRequestProxyPolicy.kt
@@ -24,8 +24,12 @@ object WebRequestProxyPolicy {
                 url.startsWith("http")
 
         // Sub-resource requests that need a Referer header for CDNs
+        // Only proxy article sub-resources (null origin from loadDataWithBaseURL),
+        // not iframe sub-resources which have their own origin
+        // Issue #1878, Issue #1901
         val isMediaRequest = pageUrl != null &&
                 !request.isForMainFrame &&
+                origin == "null" &&
                 accept?.startsWith("text/html") != true &&
                 url.startsWith("http")
 

--- a/app/src/test/java/com/capyreader/app/ui/components/WebRequestProxyPolicyTest.kt
+++ b/app/src/test/java/com/capyreader/app/ui/components/WebRequestProxyPolicyTest.kt
@@ -36,7 +36,7 @@ class WebRequestProxyPolicyTest {
         assertTrue(
             shouldProxy(
                 "https://cdn.example.com/image.jpg",
-                FakeWebResourceRequest(accept = "image/webp,image/apng,*/*;q=0.8"),
+                FakeWebResourceRequest(accept = "image/webp,image/apng,*/*;q=0.8", origin = "null"),
                 pageUrl = "https://example.com/article",
             )
         )
@@ -49,6 +49,20 @@ class WebRequestProxyPolicyTest {
                 "https://example.com/",
                 FakeWebResourceRequest(forMainFrame = true),
                 pageUrl = null,
+            )
+        )
+    }
+
+    @Test
+    fun shouldProxy_iframeSubResourceIsSkipped() {
+        assertFalse(
+            shouldProxy(
+                "https://cdn.iframe-origin.com/script.js",
+                FakeWebResourceRequest(
+                    accept = "application/javascript",
+                    origin = "https://iframe-origin.com",
+                ),
+                pageUrl = "https://example.com/article",
             )
         )
     }


### PR DESCRIPTION
Skips iframe media in the proxy to ensure media like Bilibili works

- https://github.com/jocmp/capyreader/issues/1901
- https://github.com/jocmp/capyreader/discussions/1894