### PR TITLE
fix(freshrss): Remove concurrency for memory

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegate.kt
@@ -406,21 +406,17 @@ internal class ReaderAccountDelegate(
             return
         }
 
-        coroutineScope {
-            ids.chunked(MAX_PAGINATED_ITEM_LIMIT).map { chunkedIDs ->
-                launch {
-                    val response = withPostToken {
-                        googleReader.streamItemsContents(
-                            postToken = postToken.get(),
-                            ids = chunkedIDs.map { it }
-                        )
-                    }
-
-                    val result = response.body() ?: return@launch
-
-                    saveArticles(result.items)
-                }
+        ids.chunked(MAX_PAGINATED_ITEM_LIMIT).forEach { chunkedIDs ->
+            val response = withPostToken {
+                googleReader.streamItemsContents(
+                    postToken = postToken.get(),
+                    ids = chunkedIDs.map { it }
+                )
             }
+
+            val result = response.body() ?: return@forEach
+
+            saveArticles(result.items)
         }
     }
 


### PR DESCRIPTION
Removes "launch" to avoid saturating memory on low-end devices.

A Kotlin semaphore may be a good option at some point, but figuring out deltas with the "ot" tag may be a better approach in the long run.

Ref

- https://github.com/jocmp/capyreader/issues/1858