### PR TITLE
Fall back to iTunes channel image artwork

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/Account.kt
+++ b/capy/src/main/java/com/jocmp/capy/Account.kt
@@ -251,7 +251,7 @@ data class Account(
             return null
         }
 
-        val enclosures = enclosureRecords.byArticle(articleID)
+        val enclosures = enclosureRecords.findByArticle(articleID)
         return articleRecords.find(articleID = articleID)?.copy(enclosures = enclosures)
     }
 

--- a/capy/src/main/java/com/jocmp/capy/Feed.kt
+++ b/capy/src/main/java/com/jocmp/capy/Feed.kt
@@ -11,6 +11,7 @@ data class Feed(
     val siteURL: String = "",
     val folderName: String = "",
     val faviconURL: String? = null,
+    val itunesImageURL: String? = null,
     /** Unread count */
     override val count: Long = 0,
     val enableStickyFullContent: Boolean = false,

--- a/capy/src/main/java/com/jocmp/capy/accounts/feedbin/FeedbinAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/feedbin/FeedbinAccountDelegate.kt
@@ -299,7 +299,8 @@ internal class FeedbinAccountDelegate(
             feed_url = subscription.feed_url,
             site_url = subscription.site_url,
             favicon_url = icon?.url,
-            priority = null
+            priority = null,
+            itunes_image_url = null,
         )
     }
 

--- a/capy/src/main/java/com/jocmp/capy/accounts/local/LocalAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/local/LocalAccountDelegate.kt
@@ -215,6 +215,15 @@ internal class LocalAccountDelegate(
     private suspend fun refreshFeed(feed: Feed, cutoffDate: ZonedDateTime?) {
         try {
             feedFinder.fetch(feed.feedURL).onSuccess { channel ->
+                val itunesImageURL = channel.itunesChannelData?.image
+
+                if (itunesImageURL != null) {
+                    database.feedsQueries.updateItunesImage(
+                        itunesImageURL = itunesImageURL,
+                        feedID = feed.id,
+                    )
+                }
+
                 saveArticles(channel.items, cutoffDate = cutoffDate, feed = feed)
             }
         } catch (e: Throwable) {
@@ -305,7 +314,8 @@ internal class LocalAccountDelegate(
             feed_url = feedURL,
             site_url = feed.siteURL?.toString(),
             favicon_url = feed.faviconURL?.toString(),
-            priority = null
+            priority = null,
+            itunes_image_url = feed.itunesImageURL,
         )
     }
 

--- a/capy/src/main/java/com/jocmp/capy/accounts/miniflux/MinifluxAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/miniflux/MinifluxAccountDelegate.kt
@@ -412,7 +412,8 @@ internal class MinifluxAccountDelegate(
             feed_url = feed.feed_url,
             site_url = feed.site_url,
             favicon_url = icon,
-            priority = null
+            priority = null,
+            itunes_image_url = null,
         )
 
         feed.category?.let { category ->

--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegate.kt
@@ -314,7 +314,8 @@ internal class ReaderAccountDelegate(
                 CapyLog.warn(tag("blank_icon"), mapOf("feed_url" to subscription.url))
                 null
             },
-            priority = subscription.frssPriority
+            priority = subscription.frssPriority,
+            itunes_image_url = null,
         )
 
         upsertTaggings(subscription)

--- a/capy/src/main/java/com/jocmp/capy/persistence/EnclosureRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/EnclosureRecords.kt
@@ -27,7 +27,7 @@ internal class EnclosureRecords internal constructor(
         )
     }
 
-    suspend fun byArticle(id: String): List<Enclosure> = withIOContext {
+    suspend fun findByArticle(id: String): List<Enclosure> = withIOContext {
         database
             .enclosuresQueries
             .findByArticleID(id, ::mapper)

--- a/capy/src/main/java/com/jocmp/capy/persistence/FeedRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/FeedRecords.kt
@@ -28,6 +28,7 @@ internal class FeedRecords(private val database: Database) {
         siteURL: String?,
         faviconURL: String?,
         priority: String? = null,
+        itunesImageURL: String? = null,
     ): Feed? = withIOContext {
         database.feedsQueries.upsert(
             id = feedID,
@@ -37,6 +38,7 @@ internal class FeedRecords(private val database: Database) {
             site_url = siteURL,
             favicon_url = faviconURL,
             priority = priority,
+            itunes_image_url = itunesImageURL,
         )
 
         find(feedID)
@@ -145,6 +147,7 @@ internal class FeedRecords(private val database: Database) {
         openArticlesInBrowser: Boolean = false,
         priority: String? = null,
         showUnreadBadge: Boolean = true,
+        itunesImageURL: String? = null,
         folderName: String? = "",
         expanded: Boolean? = false,
     ) = Feed(
@@ -154,6 +157,7 @@ internal class FeedRecords(private val database: Database) {
         feedURL = feedURL,
         siteURL = siteURL.orEmpty(),
         faviconURL = faviconURL,
+        itunesImageURL = itunesImageURL,
         folderName = folderName.orEmpty(),
         count = 0,
         enableStickyFullContent = enableStickyFullContent,

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/23_AddItunesImageToFeeds.sqm
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/23_AddItunesImageToFeeds.sqm
@@ -1,0 +1,1 @@
+ALTER TABLE feeds ADD COLUMN itunes_image_url TEXT;

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/enclosures.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/enclosures.sq
@@ -3,9 +3,14 @@ SELECT
     enclosures.url,
     enclosures.type,
     enclosures.itunes_duration_seconds,
-    enclosures.itunes_image
+    CASE
+        WHEN enclosures.type LIKE 'audio/%'
+        THEN COALESCE(enclosures.itunes_image, feeds.itunes_image_url)
+        ELSE enclosures.itunes_image
+    END AS itunes_image
 FROM enclosures
 JOIN articles ON articles.id = enclosures.article_id
+JOIN feeds ON feeds.id = articles.feed_id
 WHERE articles.id = :articleID;
 
 create:

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/feeds.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/feeds.sq
@@ -45,7 +45,8 @@ INSERT INTO feeds(
     feed_url,
     site_url,
     favicon_url,
-    priority
+    priority,
+    itunes_image_url
 )
 VALUES (
   :id,
@@ -54,7 +55,8 @@ VALUES (
   :feed_url,
   :site_url,
   :favicon_url,
-  :priority
+  :priority,
+  :itunes_image_url
 )
 ON CONFLICT(id) DO UPDATE
 SET id = id,
@@ -64,7 +66,8 @@ feed_url = excluded.feed_url,
 site_url = excluded.site_url,
 favicon_url = COALESCE(excluded.favicon_url, favicon_url),
 enable_sticky_full_content = enable_sticky_full_content,
-priority = excluded.priority;
+priority = excluded.priority,
+itunes_image_url = COALESCE(excluded.itunes_image_url, itunes_image_url);
 
 update:
 UPDATE feeds SET
@@ -73,6 +76,10 @@ title = :title WHERE feeds.id = :feedID;
 updateFavicon:
 UPDATE feeds SET
 favicon_url = :faviconURL WHERE feeds.id = :feedID;
+
+updateItunesImage:
+UPDATE feeds SET
+itunes_image_url = :itunesImageURL WHERE feeds.id = :feedID;
 
 isFullContentEnabled:
 SELECT enable_sticky_full_content FROM feeds WHERE feeds.id = :feedID LIMIT 1;

--- a/capy/src/test/java/com/jocmp/capy/accounts/feedbin/FeedbinAccountDelegateTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/feedbin/FeedbinAccountDelegateTest.kt
@@ -193,7 +193,7 @@ class FeedbinAccountDelegateTest {
 
         assertEquals(expected = 2, actual = articles.size)
 
-        val enclosures = EnclosureRecords(database).byArticle(vergeArticle.id.toString())
+        val enclosures = EnclosureRecords(database).findByArticle(vergeArticle.id.toString())
         assertEquals(expected = 1, actual = enclosures.size)
     }
 

--- a/capy/src/test/java/com/jocmp/capy/accounts/miniflux/MinifluxAccountDelegateTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/miniflux/MinifluxAccountDelegateTest.kt
@@ -235,7 +235,7 @@ class MinifluxAccountDelegateTest {
         assertEquals(expected = listOf(null, "Tech"), actual = taggedNames.sortedWith(nullsFirst(naturalOrder())))
         assertEquals(expected = 1, actual = articles.size)
 
-        val enclosures = EnclosureRecords(database).byArticle(vergeArticle.id.toString())
+        val enclosures = EnclosureRecords(database).findByArticle(vergeArticle.id.toString())
         assertEquals(expected = 1, actual = enclosures.size)
     }
 

--- a/capy/src/test/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegateTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegateTest.kt
@@ -216,7 +216,7 @@ class ReaderAccountDelegateTest {
 
         assertEquals(expected = 1, actual = articles.size)
 
-        val enclosures = EnclosureRecords(database).byArticle("0000000000000010")
+        val enclosures = EnclosureRecords(database).findByArticle("0000000000000010")
         assertEquals(expected = 1, actual = enclosures.size)
     }
 

--- a/capy/src/test/java/com/jocmp/capy/persistence/EnclosureRecordsTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/persistence/EnclosureRecordsTest.kt
@@ -31,7 +31,7 @@ class EnclosureRecordsTest {
             itunesDurationSeconds = "3000",
         )
 
-        val result = enclosures.byArticle(id = article.id).first()
+        val result = enclosures.findByArticle(id = article.id).first()
 
         assertEquals(expected = "https://example.com/test.jpg", actual = result.url.toString())
         assertEquals(expected = "image/jpeg", actual = result.type)

--- a/feedfinder/src/main/java/com/jocmp/feedfinder/parser/Feed.kt
+++ b/feedfinder/src/main/java/com/jocmp/feedfinder/parser/Feed.kt
@@ -14,5 +14,8 @@ interface Feed {
 
     val faviconURL: URL?
 
+    val itunesImageURL: String?
+        get() = null
+
     val items: List<RssItem>
 }

--- a/feedfinder/src/main/java/com/jocmp/feedfinder/parser/XMLFeed.kt
+++ b/feedfinder/src/main/java/com/jocmp/feedfinder/parser/XMLFeed.kt
@@ -25,6 +25,9 @@ internal class XMLFeed(
     override val faviconURL: URL?
         get() = channel?.image?.url?.let { optionalURL(it) }
 
+    override val itunesImageURL: String?
+        get() = channel?.itunesChannelData?.image
+
     override val items: List<RssItem>
         get() = channel?.items.orEmpty()
 


### PR DESCRIPTION
Saves the channel-level 'itunes:image' on feeds. This is then used as a fallback for audio enclosures that don't have an episode-specific image to use.

Ref 

- https://github.com/jocmp/capyreader/issues/1885

<table>
<tr>
<th>Feed</th>
<th>Article</th>
</th>
<tr>
<td valign="top">
<img width="1080" height="2400" alt="Screenshot_20260314_215652" src="https://github.com/user-attachments/assets/1132a813-889a-46d9-a7dd-acd24c0bf848" />
</td>
<td  valign="top">
<img width="1080" height="2400" alt="Screenshot_20260314_215702" src="https://github.com/user-attachments/assets/6f1dc7ef-957e-41ff-86df-34ee12b16f88" />
</td>
</table>