### PR TITLE
Increase list paging size to 100

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/AccountBuildArticlePagerExt.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/AccountBuildArticlePagerExt.kt
@@ -16,7 +16,7 @@ fun Account.buildArticlePager(
 ): Pager<Int, Article> {
     return Pager(
         config = PagingConfig(
-            pageSize = 50,
+            pageSize = 100,
             prefetchDistance = 10,
         ),
         pagingSourceFactory = {

--- a/bench/src/main/kotlin/com/jocmp/bench/Commands.kt
+++ b/bench/src/main/kotlin/com/jocmp/bench/Commands.kt
@@ -85,7 +85,7 @@ suspend fun commandArticles(account: Account) {
 
 suspend fun commandSelectProfile(account: Account) {
     val records = ArticleRecords(account.database)
-    val pageSize = 50L
+    val pageSize = 100L
 
     val total = account.countAllByStatus(ArticleStatus.ALL).first()
 


### PR DESCRIPTION
Double page size to decrease the overall paging size in benchmarking from ~2s to ~1.1s across 13k articles.