### PR TITLE
Fix Unread filter on boot

### DIFF
--- a/app/src/main/java/com/capyreader/app/notifications/NotificationHelper.kt
+++ b/app/src/main/java/com/capyreader/app/notifications/NotificationHelper.kt
@@ -18,7 +18,6 @@ import com.capyreader.app.preferences.AppPreferences
 import com.jocmp.capy.Account
 import com.jocmp.capy.ArticleFilter
 import com.jocmp.capy.ArticleNotification
-import com.jocmp.capy.ArticleStatus
 import com.jocmp.capy.logging.CapyLog
 import com.jocmp.capy.preferences.getAndSet
 import java.time.ZonedDateTime
@@ -164,7 +163,7 @@ class NotificationHelper(
                 intent.replaceExtras(Bundle())
 
                 appPreferences.filter.set(
-                    ArticleFilter.Articles(articleStatus = ArticleStatus.UNREAD)
+                    ArticleFilter.Unread()
                 )
 
                 return null

--- a/app/src/main/java/com/capyreader/app/preferences/HomePage.kt
+++ b/app/src/main/java/com/capyreader/app/preferences/HomePage.kt
@@ -21,7 +21,7 @@ sealed class HomePage {
     fun toArticleFilter(readLaterFeedID: String? = null): ArticleFilter {
         return when (this) {
             is Today -> ArticleFilter.Today(todayStatus = ArticleStatus.ALL)
-            is Unread -> ArticleFilter.Articles(articleStatus = ArticleStatus.UNREAD)
+            is Unread -> ArticleFilter.Unread()
             is Starred -> ArticleFilter.Starred()
             is ReadLater -> if (readLaterFeedID != null) {
                 ArticleFilter.Feeds(
@@ -30,7 +30,7 @@ sealed class HomePage {
                     feedStatus = ArticleStatus.ALL,
                 )
             } else {
-                ArticleFilter.Articles(articleStatus = ArticleStatus.UNREAD)
+                ArticleFilter.Unread()
             }
         }
     }

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
@@ -49,12 +49,9 @@ fun ArticleList(
     refreshingAll: Boolean,
     enableMarkReadOnScroll: Boolean = false,
     dimReadArticles: Boolean = true,
-    showIcons: Boolean = true,
 ) {
-    val options = rememberArticleOptions()
-    val articleOptions = options.copy(
+    val articleOptions = rememberArticleOptions().copy(
         dim = dimReadArticles,
-        showIcon = options.showIcon && showIcons,
     )
     val currentTime = rememberCurrentTime()
     val localDensity = LocalDensity.current

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleListBackHandler.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleListBackHandler.kt
@@ -35,7 +35,7 @@ fun ArticleListBackHandler(
         closeDrawer()
     }
 
-    BackHandler(backAction == BackAction.NAVIGATE_TO_PARENT && filter !is ArticleFilter.Articles) {
+    BackHandler(backAction == BackAction.NAVIGATE_TO_PARENT && filter !is ArticleFilter.Unread) {
         when(filter) {
             is ArticleFilter.Feeds -> {
                 val folderTitle = filter.folderTitle

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticlePagerFactory.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticlePagerFactory.kt
@@ -21,7 +21,7 @@ class ArticlePagerFactory(private val database: Database) {
         since: OffsetDateTime
     ): PagingSource<Int, Article> {
         return when (filter) {
-            is ArticleFilter.Articles -> articleSource(filter, query, sortOrder, since)
+            is ArticleFilter.Unread -> articleSource(filter, query, sortOrder, since)
             is ArticleFilter.Feeds -> feedSource(filter, query, sortOrder, since)
             is ArticleFilter.Folders -> folderSource(filter, query, sortOrder, since)
             is ArticleFilter.SavedSearches -> savedSearchSource(filter, query, sortOrder, since)
@@ -31,7 +31,7 @@ class ArticlePagerFactory(private val database: Database) {
     }
 
     private fun articleSource(
-        filter: ArticleFilter.Articles,
+        filter: ArticleFilter.Unread,
         query: String?,
         sortOrder: SortOrder,
         since: OffsetDateTime

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -445,7 +445,7 @@ fun ArticleScreen(
         }
 
         val selectFilter = {
-            if (!filter.hasArticlesSelected()) {
+            if (!filter.hasUnreadSelected()) {
                 openNextList { viewModel.selectArticleFilter() }
             } else {
                 closeDrawer()
@@ -897,7 +897,7 @@ fun canOpenNextFeed(
     filter: ArticleFilter,
     range: MarkRead,
 ): Boolean {
-    return range is MarkRead.All && filter !is ArticleFilter.Articles
+    return range is MarkRead.All && filter !is ArticleFilter.Unread
 }
 
 fun isFeedActive(

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
@@ -219,7 +219,7 @@ class ArticleScreenViewModel(
     }
 
     fun selectArticleFilter() {
-        updateFilter(ArticleFilter.Articles(articleStatus = UNREAD))
+        updateFilter(ArticleFilter.Unread())
     }
 
     fun selectToday() {
@@ -534,7 +534,7 @@ class ArticleScreenViewModel(
     }
 
     private fun resetToDefaultFilter() {
-        updateFilter(ArticleFilter.default().copy(currentStatus))
+        updateFilter(ArticleFilter.default())
     }
 
     private fun toggleCurrentStarred(articleID: String) {

--- a/app/src/main/java/com/capyreader/app/ui/articles/FilterActionMenu.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/FilterActionMenu.kt
@@ -41,7 +41,7 @@ fun FilterActionMenu(
             }
         }
 
-        if (filter !is ArticleFilter.Articles) {
+        if (filter !is ArticleFilter.Unread && filter !is ArticleFilter.Starred) {
             val tooltip = if (hideReadArticles) {
                 stringResource(R.string.article_list_show_read)
             } else {

--- a/app/src/main/java/com/capyreader/app/ui/articles/FilterAppBarTitle.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/FilterAppBarTitle.kt
@@ -30,7 +30,7 @@ fun FilterAppBarTitle(
     onRequestJumpToTop: () -> Unit
 ) {
     val text = when (filter) {
-        is ArticleFilter.Articles -> stringResource(R.string.filter_unread)
+        is ArticleFilter.Unread -> stringResource(R.string.filter_unread)
         is ArticleFilter.Feeds -> {
             allFeeds.find { it.id == filter.feedID }?.displayTitle()
         }

--- a/app/src/main/java/com/capyreader/app/ui/articles/feeds/FeedList.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/feeds/FeedList.kt
@@ -146,7 +146,7 @@ fun FeedList(
                     )
                 },
                 badge = { CountBadge(count = statusCount) },
-                selected = filter.hasArticlesSelected(),
+                selected = filter.hasUnreadSelected(),
                 onClick = {
                     onFilterSelect()
                 }

--- a/capy/src/main/java/com/jocmp/capy/ArticleFilter.kt
+++ b/capy/src/main/java/com/jocmp/capy/ArticleFilter.kt
@@ -16,8 +16,8 @@ sealed class ArticleFilter(open val status: ArticleStatus) {
         return this is SavedSearches && this.savedSearchID == savedSearch.id
     }
 
-    fun hasArticlesSelected(): Boolean {
-        return this is Articles
+    fun hasUnreadSelected(): Boolean {
+        return this is Unread
     }
 
     fun hasTodaySelected(): Boolean {
@@ -28,13 +28,9 @@ sealed class ArticleFilter(open val status: ArticleStatus) {
         return this is Starred
     }
 
-    fun isReadLaterFeed(feed: Feed?): Boolean {
-        return feed != null && isFeedSelected(feed)
-    }
-
     fun withStatus(status: ArticleStatus): ArticleFilter {
         return when (this) {
-            is Articles -> copy(articleStatus = status)
+            is Unread -> copy(unreadStatus = status)
             is Feeds -> copy(feedStatus = status)
             is Folders -> copy(folderStatus = status)
             is SavedSearches -> copy(savedSearchStatus = status)
@@ -44,9 +40,9 @@ sealed class ArticleFilter(open val status: ArticleStatus) {
     }
 
     @Serializable
-    data class Articles(val articleStatus: ArticleStatus) : ArticleFilter(articleStatus) {
+    data class Unread(val unreadStatus: ArticleStatus = ArticleStatus.UNREAD) : ArticleFilter(unreadStatus) {
         override val status: ArticleStatus
-            get() = articleStatus
+            get() = unreadStatus
     }
 
     @Serializable
@@ -85,6 +81,6 @@ sealed class ArticleFilter(open val status: ArticleStatus) {
     }
 
     companion object {
-        fun default() = Articles(articleStatus = ArticleStatus.ALL)
+        fun default() = Unread()
     }
 }

--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegate.kt
@@ -61,7 +61,7 @@ internal class ReaderAccountDelegate(
 
     override suspend fun refresh(filter: ArticleFilter, cutoffDate: ZonedDateTime?): Result<Unit> {
         return withErrorHandling {
-            if (filter.hasArticlesSelected()) {
+            if (filter.hasUnreadSelected()) {
                 refreshTopLevelArticles()
             } else {
                 refreshArticles(filter.toStream(source))
@@ -664,7 +664,7 @@ private val SubscriptionQuickAddResult.toSubscription: Subscription?
 
 private fun ArticleFilter.toStream(source: Source): Stream {
     return when (this) {
-        is ArticleFilter.Articles, is ArticleFilter.Today, is ArticleFilter.Starred -> Read()
+        is ArticleFilter.Unread, is ArticleFilter.Today, is ArticleFilter.Starred -> Read()
         is ArticleFilter.Feeds -> Stream.Feed(feedID)
         is ArticleFilter.Folders -> folderStream(this, source)
         is ArticleFilter.SavedSearches -> UserLabel(savedSearchID)

--- a/capy/src/main/java/com/jocmp/capy/articles/SidebarItem.kt
+++ b/capy/src/main/java/com/jocmp/capy/articles/SidebarItem.kt
@@ -54,8 +54,8 @@ class SidebarItem(
         )
 
         private fun articlesItem() = SidebarItem(
-            toFilter = { ArticleFilter.Articles(it) },
-            isSelected = { it is ArticleFilter.Articles },
+            toFilter = { ArticleFilter.Unread(it) },
+            isSelected = { it is ArticleFilter.Unread },
         )
 
         private fun starredItem() = SidebarItem(

--- a/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
@@ -260,8 +260,8 @@ class ArticleRecords(
         val since = null
 
         val count = when (filter) {
-            is ArticleFilter.Articles -> byStatus.count(
-                status = filter.articleStatus,
+            is ArticleFilter.Unread -> byStatus.count(
+                status = filter.status,
                 query = query,
                 since = null
             )
@@ -332,8 +332,8 @@ class ArticleRecords(
         query: String?,
     ): List<String> {
         val ids = when (filter) {
-            is ArticleFilter.Articles -> byStatus.unreadArticleIDs(
-                filter.articleStatus,
+            is ArticleFilter.Unread -> byStatus.unreadArticleIDs(
+                filter.status,
                 range = range,
                 sortOrder = sortOrder,
                 query = query,

--- a/capy/src/test/java/com/jocmp/capy/AccountTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/AccountTest.kt
@@ -78,7 +78,7 @@ class AccountTest {
             .map { it.id }
 
         val ids = account.unreadArticleIDs(
-            filter = ArticleFilter.Articles(ArticleStatus.ALL),
+            filter = ArticleFilter.Unread(ArticleStatus.ALL),
             range = MarkRead.All,
             sortOrder = SortOrder.NEWEST_FIRST,
             query = null,
@@ -109,7 +109,7 @@ class AccountTest {
             .map { it.id }
 
         val ids = account.unreadArticleIDs(
-            filter = ArticleFilter.Articles(ArticleStatus.UNREAD),
+            filter = ArticleFilter.Unread(),
             range = MarkRead.Before(unreadArticleIDs[1]),
             sortOrder = SortOrder.NEWEST_FIRST,
             query = null,
@@ -142,7 +142,7 @@ class AccountTest {
             .map { it.id }
 
         val ids = account.unreadArticleIDs(
-            filter = ArticleFilter.Articles(ArticleStatus.UNREAD),
+            filter = ArticleFilter.Unread(),
             range = MarkRead.After(unreadArticleIDs[1]),
             sortOrder = SortOrder.NEWEST_FIRST,
             query = null,
@@ -175,7 +175,7 @@ class AccountTest {
             .map { it.id }
 
         val ids = account.unreadArticleIDs(
-            filter = ArticleFilter.Articles(ArticleStatus.UNREAD),
+            filter = ArticleFilter.Unread(),
             range = MarkRead.Before(unreadArticleIDs[1]),
             sortOrder = SortOrder.OLDEST_FIRST,
             query = null,

--- a/capy/src/test/java/com/jocmp/capy/ArticleFilterTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/ArticleFilterTest.kt
@@ -7,11 +7,15 @@ import kotlin.test.assertNotEquals
 class ArticleFilterTest {
     @Test
     fun withStatus_copiesExistingFilter() {
-        val articles = ArticleFilter.default()
+        val filter = ArticleFilter.Feeds(
+            feedID = "1",
+            folderTitle = null,
+            feedStatus = ArticleStatus.ALL
+        )
 
-        val nextFilter = articles.withStatus(status = ArticleStatus.UNREAD)
+        val nextFilter = filter.withStatus(status = ArticleStatus.UNREAD)
 
-        assertNotEquals(articles.status, nextFilter.status)
+        assertNotEquals(filter.status, nextFilter.status)
         assertEquals(expected = ArticleStatus.UNREAD, actual = nextFilter.status)
     }
 }

--- a/capy/src/test/java/com/jocmp/capy/articles/SidebarItemTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/articles/SidebarItemTest.kt
@@ -78,7 +78,7 @@ class SidebarItemTest {
 
     @Test
     fun `next from article filter with a folder`() {
-        val filter = ArticleFilter.Articles(articleStatus = ArticleStatus.UNREAD)
+        val filter = ArticleFilter.Unread()
         val folder = Folder(title = "This Is My Next Folder")
 
         val next = findNext(
@@ -92,7 +92,7 @@ class SidebarItemTest {
 
     @Test
     fun `next from article filter with a feed`() {
-        val filter = ArticleFilter.Articles(articleStatus = ArticleStatus.UNREAD)
+        val filter = ArticleFilter.Unread()
         val feed = feedFixture.create()
 
         val next = findNext(
@@ -106,7 +106,7 @@ class SidebarItemTest {
 
     @Test
     fun `next from article filter that is empty`() {
-        val filter = ArticleFilter.Articles(articleStatus = ArticleStatus.UNREAD)
+        val filter = ArticleFilter.Unread()
 
         val next = findNext(filter)
 
@@ -362,7 +362,7 @@ class SidebarItemTest {
 
         val filters = items.map { it.toFilter(ArticleStatus.ALL) }
         assertIs<ArticleFilter.Today>(filters[0])
-        assertIs<ArticleFilter.Articles>(filters[1])
+        assertIs<ArticleFilter.Unread>(filters[1])
         assertIs<ArticleFilter.Starred>(filters[2])
         assertIs<ArticleFilter.SavedSearches>(filters[3])
         assertIs<ArticleFilter.Folders>(filters[4])
@@ -382,7 +382,7 @@ class SidebarItemTest {
         val today = items[0]
         assertTrue(today.isSelected(ArticleFilter.Today(ArticleStatus.ALL)))
         assertNotNull(today.next)
-        assertTrue(today.next!!.isSelected(ArticleFilter.Articles(ArticleStatus.ALL)))
+        assertTrue(today.next!!.isSelected(ArticleFilter.Unread()))
         assertNotNull(today.next?.next)
         assertTrue(today.next!!.next!!.isSelected(ArticleFilter.Starred()))
         assertNotNull(today.next?.next?.next)

--- a/capy/src/test/java/com/jocmp/capy/persistence/ArticleRecordsTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/persistence/ArticleRecordsTest.kt
@@ -547,7 +547,7 @@ class ArticleRecordsTest {
             articleRecords.markUnread(article.id)
         }
 
-        val filter = ArticleFilter.Articles(ArticleStatus.UNREAD)
+        val filter = ArticleFilter.Unread()
 
         val count = articleRecords.countUnread(
             filter = filter,
@@ -601,7 +601,7 @@ class ArticleRecordsTest {
             )
         }
 
-        val filter = ArticleFilter.Articles(ArticleStatus.UNREAD)
+        val filter = ArticleFilter.Unread()
 
         val count = articleRecords.countUnread(
             filter = filter,


### PR DESCRIPTION
- Replace Articles filter with dedicated Unread type that defaults to UNREAD status, matching the Starred filter pattern.
- Hide the read/unread toggle on Unread and Starred feeds.

Ref

- #2011 