### PR TITLE
Remove mark read on scroll

### DIFF
--- a/app/src/main/java/com/capyreader/app/preferences/AppPreferences.kt
+++ b/app/src/main/java/com/capyreader/app/preferences/AppPreferences.kt
@@ -199,9 +199,6 @@ class AppPreferences(context: Context) {
         val confirmMarkAllRead: Preference<Boolean>
             get() = preferenceStore.getBoolean("article_list_confirm_mark_all_read", true)
 
-        val markReadOnScroll: Preference<Boolean>
-            get() = preferenceStore.getBoolean("article_list_mark_read_on_scroll", false)
-
         val afterReadAllBehavior: Preference<AfterReadAllBehavior>
             get() = preferenceStore.getEnum(
                 "after_read_all_behavior",

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleList.kt
@@ -3,12 +3,9 @@ package com.capyreader.app.ui.articles
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -18,24 +15,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemKey
-import com.capyreader.app.R
 import com.capyreader.app.preferences.AppPreferences
 import com.jocmp.capy.Article
 import com.jocmp.capy.MarkRead
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.debounce
 import org.koin.compose.koinInject
 import java.time.LocalDateTime
 
@@ -47,25 +34,18 @@ fun ArticleList(
     listState: LazyListState,
     onMarkAllRead: (range: MarkRead) -> Unit = {},
     refreshingAll: Boolean,
-    enableMarkReadOnScroll: Boolean = false,
     dimReadArticles: Boolean = true,
 ) {
     val articleOptions = rememberArticleOptions().copy(
         dim = dimReadArticles,
     )
     val currentTime = rememberCurrentTime()
-    val localDensity = LocalDensity.current
-    var listHeight by remember { mutableStateOf(0.dp) }
 
     key(listState) {
         LazyScrollbar(state = listState) {
             LazyColumn(
                 state = listState,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .onGloballyPositioned { coordinates ->
-                        listHeight = with(localDensity) { coordinates.size.height.toDp() }
-                    }
+                modifier = Modifier.fillMaxSize()
             ) {
                 items(count = articles.itemCount, key = articles.itemKey { it.id }) { index ->
                     val item = articles[index]
@@ -89,74 +69,13 @@ fun ArticleList(
                     }
                 }
 
-                if (enableMarkReadOnScroll && articles.itemCount > 0) {
-                    item {
-                        FeedOverScrollBox(height = listHeight)
-                    }
-                } else {
-                    item {
-                        Spacer(Modifier.height(120.dp))
-                    }
+                item {
+                    Spacer(Modifier.height(120.dp))
                 }
             }
         }
     }
 
-    MarkReadOnScroll(
-        enabled = enableMarkReadOnScroll && !refreshingAll,
-        articles = articles,
-        listState
-    ) { range ->
-        onMarkAllRead(range)
-    }
-}
-
-@Composable
-fun FeedOverScrollBox(height: Dp) {
-    Box(
-        Modifier
-            .fillMaxWidth()
-            .height(height)
-    ) {
-        Text(
-            stringResource(R.string.end_of_feed_text),
-            fontStyle = FontStyle.Italic,
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .padding(bottom = 32.dp)
-        )
-    }
-}
-
-@OptIn(FlowPreview::class)
-@Composable
-fun MarkReadOnScroll(
-    enabled: Boolean,
-    articles: LazyPagingItems<Article>,
-    listState: LazyListState,
-    onRead: (range: MarkRead) -> Unit
-) {
-    if (!enabled) {
-        return
-    }
-
-    LaunchedEffect(listState) {
-        snapshotFlow { listState.firstVisibleItemIndex }
-            .debounce(500)
-            .collect { firstVisibleIndex ->
-                val offscreenIndex = firstVisibleIndex - 1
-
-                val markAsRead =
-                    (articles.itemCount == 1 && firstVisibleIndex > 0) ||
-                            (offscreenIndex > 0 && articles.itemCount > 0)
-
-                if (!markAsRead) {
-                    return@collect
-                }
-
-                articles.getOrNull(offscreenIndex)?.let { onRead(MarkRead.After(it.id)) }
-            }
-    }
 }
 
 @Composable
@@ -197,8 +116,4 @@ fun rememberArticleOptions(appPreferences: AppPreferences = koinInject()): Artic
         shortenTitles = shortenTitles,
         accentColors = accentColors,
     )
-}
-
-private fun <T : Any> LazyPagingItems<T>.getOrNull(index: Int): T? {
-    return if (index in 0..<itemCount) get(index) else null
 }

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -94,8 +93,6 @@ import com.jocmp.capy.SavedSearch
 import com.jocmp.capy.common.launchIO
 import com.jocmp.capy.common.launchUI
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
@@ -225,8 +222,6 @@ fun ArticleScreen(
             viewModel.dismissUnauthorizedMessage()
             setUpdatePasswordDialogOpen(true)
         }
-        val enableMarkReadOnScroll by appPreferences.articleListOptions.markReadOnScroll.collectChangesWithDefault()
-
         suspend fun navigateToDetail() {
             scaffoldNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail)
             if (showMultipleColumns) {
@@ -259,16 +254,6 @@ fun ArticleScreen(
                 listState.scrollToItem(0)
                 resetScrollBehaviorOffset()
             }
-        }
-
-        LaunchedEffect(listState) {
-            snapshotFlow { listState.layoutInfo.totalItemsCount }
-                .drop(if (enableMarkReadOnScroll) 0 else 1)
-                .distinctUntilChanged()
-                .collect {
-                    listState.scrollToItem(0)
-                    resetScrollBehaviorOffset()
-                }
         }
 
         val (scrolledFilter, setScrolledFilter) = rememberSaveable(
@@ -335,10 +320,6 @@ fun ArticleScreen(
         }
 
         fun refreshAll() {
-            if (enableMarkReadOnScroll) {
-                scrollToTop()
-            }
-
             if (refreshAllState == AngleRefreshState.RUNNING) {
                 return
             }
@@ -623,7 +604,6 @@ fun ArticleScreen(
                                             articles = articles,
                                             selectedArticleKey = article?.id,
                                             listState = listState,
-                                            enableMarkReadOnScroll = enableMarkReadOnScroll,
                                             refreshingAll = viewModel.refreshingAll,
                                             dimReadArticles = filter !is ArticleFilter.Starred,
                                             onMarkAllRead = { range ->

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/GeneralSettingsPanel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/GeneralSettingsPanel.kt
@@ -92,9 +92,7 @@ fun GeneralSettingsPanel(
             updateSortOrder = viewModel::updateSortOrder,
             sortOrder = viewModel.sortOrder,
             updateConfirmMarkAllRead = viewModel::updateConfirmMarkAllRead,
-            updateMarkReadOnScroll = viewModel::updateMarkReadOnScroll,
             confirmMarkAllRead = viewModel.confirmMarkAllRead,
-            markReadOnScroll = viewModel.markReadOnScroll,
             afterReadAll = viewModel.afterReadAll,
             updateAfterReadAll = viewModel::updateAfterReadAll,
             updateStickyFullContent = viewModel::updateStickyFullContent,
@@ -122,11 +120,9 @@ fun GeneralSettingsPanelView(
     updateStickyFullContent: (enable: Boolean) -> Unit,
     enableStickyFullContent: Boolean,
     updateConfirmMarkAllRead: (enable: Boolean) -> Unit,
-    updateMarkReadOnScroll: (enable: Boolean) -> Unit,
     afterReadAll: AfterReadAllBehavior,
     updateAfterReadAll: (behavior: AfterReadAllBehavior) -> Unit,
     confirmMarkAllRead: Boolean,
-    markReadOnScroll: Boolean,
     homePage: HomePage = HomePage.default,
     updateHomePage: (HomePage) -> Unit = {},
     hasReadLaterFeed: Boolean = false,
@@ -211,11 +207,6 @@ fun GeneralSettingsPanelView(
                         onCheckedChange = updateConfirmMarkAllRead,
                         checked = confirmMarkAllRead,
                         title = stringResource(R.string.settings_confirm_mark_all_read),
-                    )
-                    TextSwitch(
-                        onCheckedChange = updateMarkReadOnScroll,
-                        checked = markReadOnScroll,
-                        title = stringResource(R.string.settings_mark_read_on_scroll),
                     )
                 }
                 PreferenceSelect(
@@ -363,9 +354,7 @@ private fun GeneralSettingsPanelPreview() {
                 sortOrder = SortOrder.NEWEST_FIRST,
                 updateSortOrder = {},
                 onNavigateToNotifications = {},
-                markReadOnScroll = true,
                 updateConfirmMarkAllRead = {},
-                updateMarkReadOnScroll = {},
                 confirmMarkAllRead = true,
                 updateStickyFullContent = {},
                 enableStickyFullContent = true,

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/GeneralSettingsViewModel.kt
@@ -40,9 +40,6 @@ class GeneralSettingsViewModel(
     var confirmMarkAllRead by mutableStateOf(appPreferences.articleListOptions.confirmMarkAllRead.get())
         private set
 
-    var markReadOnScroll by mutableStateOf(appPreferences.articleListOptions.markReadOnScroll.get())
-        private set
-
     var afterReadAll by mutableStateOf(appPreferences.articleListOptions.afterReadAllBehavior.get())
         private set
 
@@ -105,12 +102,6 @@ class GeneralSettingsViewModel(
                 account.clearStickyFullContent()
             }
         }
-    }
-
-    fun updateMarkReadOnScroll(enable: Boolean) {
-        appPreferences.articleListOptions.markReadOnScroll.set(enable)
-
-        markReadOnScroll = enable
     }
 
     fun clearAllArticles() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -278,7 +278,6 @@
     <string name="article_list_row_swipe_open_externally">Open article in browser</string>
     <string name="article_view_open_externally">Open externally</string>
     <string name="settings_confirm_mark_all_read">Confirm marking all as read</string>
-    <string name="settings_mark_read_on_scroll">Mark as read on scroll</string>
     <string name="settings_gestures_reader_tap_to_page_title">E Ink tap to scroll</string>
     <string name="settings_gestures_enable_horizontal_pagination_title">Enable horizontal scroll</string>
     <string name="settings_gestures_enable_horizontal_pagination_subtitle">Swipe left or right to navigate articles</string>
@@ -291,7 +290,6 @@
     <string name="reader_image_visibility_always_hide">Block images</string>
     <string name="reader_image_visibility_always_show">Always show images</string>
     <string name="reader_image_visibility_label">Images</string>
-    <string name="end_of_feed_text">All caught up!</string>
     <string name="after_read_all_behavior_label">After Read All</string>
     <string name="after_read_all_behavior_default">Default</string>
     <string name="after_read_all_behavior_open_drawer">Open Navigation Drawer</string>


### PR DESCRIPTION
- Lots of bugs originate from this feature (https://github.com/jocmp/capyreader/issues/1419, https://github.com/jocmp/capyreader/issues/1461, https://github.com/jocmp/capyreader/issues/1557, https://github.com/jocmp/capyreader/discussions/1724)
- Incompatible with key pagination-based offset (https://github.com/jocmp/capyreader/pull/1972) since the total count only represents the current page set (not total like offset pagination)