### PR TITLE
Rework mark read on scroll

### DIFF
--- a/app/src/main/java/com/capyreader/app/common/AndroidLogging.kt
+++ b/app/src/main/java/com/capyreader/app/common/AndroidLogging.kt
@@ -1,10 +1,13 @@
 package com.capyreader.app.common
 
 import android.util.Log
+import com.capyreader.app.BuildConfig
 import com.jocmp.capy.logging.Logging
 
 class AndroidLogging : Logging {
     override fun debug(event: String, data: Map<String, Any?>) {
+        if (!BuildConfig.DEBUG) return
+
         Log.d(TAG, serializeData(event, data))
     }
 
@@ -25,7 +28,7 @@ class AndroidLogging : Logging {
     }
 
     private fun serializeData(event: String, data: Map<String, Any?>): String {
-        return "event=${event.padEnd(15, ' ')}" + data.map { (key, value) -> "$key=$value" }.joinToString(" ")
+        return "event=${event.padEnd(15, ' ')} " + data.map { (key, value) -> "$key=$value" }.joinToString(" ")
     }
 
     companion object {

--- a/app/src/main/java/com/capyreader/app/preferences/AppPreferences.kt
+++ b/app/src/main/java/com/capyreader/app/preferences/AppPreferences.kt
@@ -191,5 +191,8 @@ class AppPreferences(context: Context) {
                 AfterReadAllBehavior.default
             )
 
+        val markReadOnScroll: Preference<Boolean>
+            get() = preferenceStore.getBoolean("article_list_mark_read_on_scroll", false)
+
     }
 }

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
@@ -28,6 +29,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -41,6 +43,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.capyreader.app.R
 import com.capyreader.app.common.Media
@@ -92,12 +95,16 @@ import com.jocmp.capy.MarkRead
 import com.jocmp.capy.SavedSearch
 import com.jocmp.capy.common.launchIO
 import com.jocmp.capy.common.launchUI
+import com.jocmp.capy.logging.CapyLog
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
-@OptIn(ExperimentalMaterial3AdaptiveApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3AdaptiveApi::class, ExperimentalMaterial3Api::class, FlowPreview::class)
 @Composable
 fun ArticleScreen(
     viewModel: ArticleScreenViewModel = koinViewModel(),
@@ -204,7 +211,7 @@ fun ArticleScreen(
         val scaffoldNavigator = rememberListDetailPaneScaffoldNavigator()
         val showMultipleColumns = scaffoldNavigator.scaffoldDirective.maxHorizontalPartitions > 1
         val paneExpansion = rememberArticlePaneExpansion()
-        var isPullToRefreshing by remember { mutableStateOf(false) }
+        val isPullToRefreshing = viewModel.isPullToRefreshing
         val addFeedSuccessMessage = stringResource(R.string.add_feed_success)
         val scrollBehavior = pinnedScrollBehavior()
         var media by rememberSaveable(saver = Media.Saver) { mutableStateOf(null) }
@@ -262,6 +269,14 @@ fun ArticleScreen(
             }
         }
 
+        MarkReadOnScroll(
+            listState = listState,
+            articles = articles,
+            scrollHighWaterMark = viewModel.scrollHighWaterMark,
+            updateScrollHighWaterMark = viewModel::updateScrollHighWaterMark,
+            markReadOnScroll = viewModel::markReadOnScroll,
+        )
+
         suspend fun openNextStatus(action: suspend () -> Unit) {
             scope.launchIO { action() }
             scaffoldNavigator.navigateTo(ListDetailPaneScaffoldRole.List)
@@ -306,24 +321,19 @@ fun ArticleScreen(
             }
         }
 
-        val refreshPagination = {
-            coroutineScope.launch {
-                resetScrollBehaviorOffset()
-            }
-        }
-
         fun refreshAll() {
             viewModel.refreshAll {
-                refreshPagination()
+                if (viewModel.markReadOnScrollEnabled) {
+                    scrollToTop()
+                }
             }
         }
 
         fun refreshFeeds() {
-            isPullToRefreshing = true
-
             viewModel.refresh(filter) {
-                isPullToRefreshing = false
-                refreshPagination()
+                if (viewModel.markReadOnScrollEnabled) {
+                    scrollToTop()
+                }
             }
         }
 
@@ -859,4 +869,53 @@ fun isFeedActive(
     return media == null &&
             article == null &&
             !search.isActive
+}
+
+@OptIn(FlowPreview::class)
+@Composable
+private fun MarkReadOnScroll(
+    listState: LazyListState,
+    articles: LazyPagingItems<Article>,
+    scrollHighWaterMark: Int,
+    updateScrollHighWaterMark: (Int) -> Unit,
+    markReadOnScroll: (String) -> Unit,
+) {
+    val appPreferences = koinInject<AppPreferences>()
+
+    val enabled by appPreferences
+        .articleListOptions
+        .markReadOnScroll
+        .collectChangesWithCurrent()
+
+    if (enabled) {
+        LaunchedEffect(listState) {
+            snapshotFlow {
+                listState.firstVisibleItemIndex - 1
+            }
+                .distinctUntilChanged()
+                .debounce(500)
+                .collect { scrolledPastIndex ->
+                    CapyLog.debug(
+                        "mark_read_on_scroll:collect", mapOf(
+                            "scrolledPastIndex" to scrolledPastIndex,
+                            "highWaterMark" to scrollHighWaterMark,
+                            "itemCount" to articles.itemCount,
+                        )
+                    )
+                    if (scrolledPastIndex > scrollHighWaterMark && scrolledPastIndex < articles.itemCount) {
+                        updateScrollHighWaterMark(scrolledPastIndex)
+                        val boundaryArticle = articles[scrolledPastIndex]
+                        if (boundaryArticle != null) {
+                            CapyLog.debug(
+                                "mark_read_on_scroll:boundary", mapOf(
+                                    "articleID" to boundaryArticle.id,
+                                    "index" to scrolledPastIndex,
+                                )
+                            )
+                            markReadOnScroll(boundaryArticle.id)
+                        }
+                    }
+                }
+        }
+    }
 }

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreenViewModel.kt
@@ -3,6 +3,7 @@ package com.capyreader.app.ui.articles
 import android.app.Application
 import android.content.Context
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
@@ -30,6 +31,7 @@ import com.jocmp.capy.MarkRead
 import com.jocmp.capy.SavedSearch
 import com.jocmp.capy.articles.ArticleContent
 import com.jocmp.capy.articles.SidebarItem
+import com.jocmp.capy.articles.SortOrder
 import com.jocmp.capy.common.UnauthorizedError
 import com.jocmp.capy.common.launchIO
 import kotlinx.coroutines.CoroutineDispatcher
@@ -80,8 +82,19 @@ class ArticleScreenViewModel(
     var refreshingAll by mutableStateOf(false)
         private set
 
+    var isPullToRefreshing by mutableStateOf(false)
+        private set
+
     var refreshInitialized by mutableStateOf(false)
         private set
+
+    private var _scrollHighWaterMark by mutableIntStateOf(-1)
+
+    val scrollHighWaterMark: Int
+        get() = _scrollHighWaterMark
+
+    val markReadOnScrollEnabled: Boolean
+        get() = appPreferences.articleListOptions.markReadOnScroll.get()
 
     val articlesSince = MutableStateFlow<OffsetDateTime>(OffsetDateTime.now())
 
@@ -383,11 +396,14 @@ class ArticleScreenViewModel(
         }
     }
 
-    fun refresh(filter: ArticleFilter, onComplete: () -> Unit) {
+    fun refresh(filter: ArticleFilter, onComplete: () -> Unit = {}) {
+        isPullToRefreshing = true
         updateArticlesSince()
 
         refreshFilter(filter) {
             updateArticlesSince()
+            isPullToRefreshing = false
+            resetScrollHighWaterMark()
             onComplete()
         }
     }
@@ -403,10 +419,75 @@ class ArticleScreenViewModel(
         refresh(ArticleFilter.default()) {
             _refreshAllState.value = AngleRefreshState.SETTLING
             refreshInitialized = true
+            resetScrollHighWaterMark()
             onComplete()
 
             refreshJob?.invokeOnCompletion {
                 refreshingAll = false
+            }
+        }
+    }
+
+    fun updateScrollHighWaterMark(index: Int) {
+        if (index > _scrollHighWaterMark) {
+            CapyLog.debug(
+                "scroll_high_water_mark:update",
+                mapOf("previous" to _scrollHighWaterMark, "new" to index)
+            )
+            _scrollHighWaterMark = index
+        }
+    }
+
+    fun resetScrollHighWaterMark() {
+        CapyLog.debug(
+            "scroll_high_water_mark:reset",
+            mapOf("previous" to _scrollHighWaterMark)
+        )
+        _scrollHighWaterMark = -1
+    }
+
+    fun markReadOnScroll(articleID: String) {
+        if (isPullToRefreshing) {
+            CapyLog.debug("mark_read_on_scroll:skip", mapOf("reason" to "pull_to_refresh"))
+            return
+        }
+
+        if (_refreshAllState.value == AngleRefreshState.RUNNING) {
+            CapyLog.debug("mark_read_on_scroll:skip", mapOf("reason" to "refresh_all_running"))
+            return
+        }
+
+        val range = MarkRead.After(articleID)
+
+        CapyLog.debug(
+            "mark_read_on_scroll",
+            mapOf(
+                "articleID" to articleID,
+                "range" to range.toString(),
+                "sortOrder" to sortOrder.value.toString(),
+                "highWaterMark" to _scrollHighWaterMark,
+            )
+        )
+
+        viewModelScope.launchIO {
+            val articleIDs = account.unreadArticleIDs(
+                filter = latestFilter,
+                range = range,
+                sortOrder = sortOrder.value,
+                query = _searchQuery.value,
+            )
+
+            CapyLog.debug(
+                "mark_read_on_scroll:marking",
+                mapOf("count" to articleIDs.size)
+            )
+
+            account.markAllRead(articleIDs).onFailure {
+                Sync.markReadAsync(articleIDs, context)
+            }
+
+            launchIO {
+                notificationHelper.dismissNotifications(articleIDs)
             }
         }
     }
@@ -482,11 +563,13 @@ class ArticleScreenViewModel(
         }
         _searchQuery.value = ""
         _searchState.value = SearchState.INACTIVE
+        resetScrollHighWaterMark()
     }
 
     fun updateSearch(query: String) {
         clearArticle()
         _searchQuery.value = query
+        resetScrollHighWaterMark()
     }
 
     fun addStarAsync(articleID: String) {
@@ -574,6 +657,7 @@ class ArticleScreenViewModel(
         appPreferences.filter.set(filter)
 
         clearArticle()
+        resetScrollHighWaterMark()
 
         updateArticlesSince()
     }

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/GeneralSettingsPanel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/GeneralSettingsPanel.kt
@@ -95,6 +95,8 @@ fun GeneralSettingsPanel(
             updateAfterReadAll = viewModel::updateAfterReadAll,
             updateStickyFullContent = viewModel::updateStickyFullContent,
             enableStickyFullContent = viewModel.enableStickyFullContent,
+            markReadOnScroll = viewModel.markReadOnScroll,
+            updateMarkReadOnScroll = viewModel::updateMarkReadOnScroll,
         )
     }
 }
@@ -118,6 +120,8 @@ fun GeneralSettingsPanelView(
     afterReadAll: AfterReadAllBehavior,
     updateAfterReadAll: (behavior: AfterReadAllBehavior) -> Unit,
     confirmMarkAllRead: Boolean,
+    markReadOnScroll: Boolean,
+    updateMarkReadOnScroll: (enable: Boolean) -> Unit,
 ) {
     val (isClearArticlesDialogOpen, setClearArticlesDialogOpen) = remember { mutableStateOf(false) }
 
@@ -188,6 +192,13 @@ fun GeneralSettingsPanelView(
             title = stringResource(R.string.settings_section_mark_all_as_read),
         ) {
             Column {
+                RowItem {
+                    TextSwitch(
+                        onCheckedChange = updateMarkReadOnScroll,
+                        checked = markReadOnScroll,
+                        title = stringResource(R.string.settings_mark_read_on_scroll),
+                    )
+                }
                 RowItem {
                     TextSwitch(
                         onCheckedChange = updateConfirmMarkAllRead,
@@ -346,6 +357,8 @@ private fun GeneralSettingsPanelPreview() {
                 enableStickyFullContent = true,
                 afterReadAll = AfterReadAllBehavior.NOTHING,
                 updateAfterReadAll = {},
+                markReadOnScroll = false,
+                updateMarkReadOnScroll = {},
             )
         }
     }

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/GeneralSettingsViewModel.kt
@@ -45,6 +45,9 @@ class GeneralSettingsViewModel(
     var enableStickyFullContent by mutableStateOf(appPreferences.enableStickyFullContent.get())
         private set
 
+    var markReadOnScroll by mutableStateOf(appPreferences.articleListOptions.markReadOnScroll.get())
+        private set
+
     val filterKeywords = account
         .preferences
         .filterKeywords
@@ -84,6 +87,12 @@ class GeneralSettingsViewModel(
         appPreferences.articleListOptions.afterReadAllBehavior.set(behavior)
 
         afterReadAll = behavior
+    }
+
+    fun updateMarkReadOnScroll(enabled: Boolean) {
+        appPreferences.articleListOptions.markReadOnScroll.set(enabled)
+
+        markReadOnScroll = enabled
     }
 
     fun updateStickyFullContent(enable: Boolean) {

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByFeed.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByFeed.sq
@@ -24,7 +24,7 @@ AND ((article_statuses.starred = :starred AND article_statuses.last_unstarred_at
 AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
 AND (:query IS NULL OR articles.title LIKE '%' || :query || '%' OR articles.summary LIKE '%' || :query || '%')
 AND (feeds.priority IN :priorities OR feeds.priority IS NULL)
-ORDER BY articles.published_at DESC
+ORDER BY articles.published_at DESC, articles.id DESC
 LIMIT :limit OFFSET :offset;
 
 allOldestFirst:
@@ -53,7 +53,7 @@ AND ((article_statuses.starred = :starred AND article_statuses.last_unstarred_at
 AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
 AND (:query IS NULL OR articles.title LIKE '%' || :query || '%' OR articles.summary LIKE '%' || :query || '%')
 AND (feeds.priority IN :priorities OR feeds.priority IS NULL)
-ORDER BY articles.published_at ASC
+ORDER BY articles.published_at ASC, articles.id ASC
 LIMIT :limit OFFSET :offset;
 
 countAll:
@@ -73,6 +73,8 @@ SELECT articles.id
 FROM articles
 JOIN feeds ON articles.feed_id = feeds.id
 JOIN article_statuses ON articles.id = article_statuses.article_id
+LEFT JOIN articles AS after_articles ON after_articles.id = :afterArticleID
+LEFT JOIN articles AS before_articles ON before_articles.id = :beforeArticleID
 WHERE article_statuses.read = 0
 AND (article_statuses.starred = :starred OR :starred IS NULL)
 AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
@@ -82,14 +84,18 @@ AND (feeds.priority IN :priorities OR feeds.priority IS NULL)
 AND (
     :afterArticleID IS NULL
     OR CASE WHEN :newestFirst
-        THEN articles.published_at >= (SELECT published_at FROM articles WHERE id = :afterArticleID)
-        ELSE articles.published_at <= (SELECT published_at FROM articles WHERE id = :afterArticleID)
+        THEN articles.published_at > after_articles.published_at
+             OR (articles.published_at = after_articles.published_at AND articles.id >= :afterArticleID)
+        ELSE articles.published_at < after_articles.published_at
+             OR (articles.published_at = after_articles.published_at AND articles.id <= :afterArticleID)
     END
 )
 AND (
     :beforeArticleID IS NULL
     OR CASE WHEN :newestFirst
-        THEN articles.published_at <= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
-        ELSE articles.published_at >= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+        THEN articles.published_at < before_articles.published_at
+             OR (articles.published_at = before_articles.published_at AND articles.id <= :beforeArticleID)
+        ELSE articles.published_at > before_articles.published_at
+             OR (articles.published_at = before_articles.published_at AND articles.id >= :beforeArticleID)
     END
 );

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articlesBySavedSearch.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articlesBySavedSearch.sq
@@ -24,7 +24,7 @@ AND ((article_statuses.read = :read AND article_statuses.last_read_at IS NULL OR
 AND ((article_statuses.starred = :starred AND article_statuses.last_unstarred_at IS NULL OR article_statuses.last_unstarred_at >= :lastUnstarredAt) OR :starred IS NULL)
 AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
 AND (:query IS NULL OR articles.title LIKE '%' || :query || '%' OR articles.summary LIKE '%' || :query || '%')
-ORDER BY articles.published_at DESC
+ORDER BY articles.published_at DESC, articles.id DESC
 LIMIT :limit OFFSET :offset;
 
 allOldestFirst:
@@ -53,7 +53,7 @@ AND ((article_statuses.read = :read AND article_statuses.last_read_at IS NULL OR
 AND ((article_statuses.starred = :starred AND article_statuses.last_unstarred_at IS NULL OR article_statuses.last_unstarred_at >= :lastUnstarredAt) OR :starred IS NULL)
 AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
 AND (:query IS NULL OR articles.title LIKE '%' || :query || '%' OR articles.summary LIKE '%' || :query || '%')
-ORDER BY articles.published_at ASC
+ORDER BY articles.published_at ASC, articles.id ASC
 LIMIT :limit OFFSET :offset;
 
 countAll:
@@ -73,6 +73,8 @@ FROM articles
 JOIN feeds ON articles.feed_id = feeds.id
 JOIN article_statuses ON articles.id = article_statuses.article_id
 JOIN saved_search_articles ON articles.id = saved_search_articles.article_id
+LEFT JOIN articles AS after_articles ON after_articles.id = :afterArticleID
+LEFT JOIN articles AS before_articles ON before_articles.id = :beforeArticleID
 WHERE article_statuses.read = 0
 AND (article_statuses.starred = :starred OR :starred IS NULL)
 AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
@@ -81,14 +83,18 @@ AND saved_search_id = :savedSearchID
 AND (
     :afterArticleID IS NULL
     OR CASE WHEN :newestFirst
-        THEN articles.published_at >= (SELECT published_at FROM articles WHERE id = :afterArticleID)
-        ELSE articles.published_at <= (SELECT published_at FROM articles WHERE id = :afterArticleID)
+        THEN articles.published_at > after_articles.published_at
+             OR (articles.published_at = after_articles.published_at AND articles.id >= :afterArticleID)
+        ELSE articles.published_at < after_articles.published_at
+             OR (articles.published_at = after_articles.published_at AND articles.id <= :afterArticleID)
     END
 )
 AND (
     :beforeArticleID IS NULL
     OR CASE WHEN :newestFirst
-        THEN articles.published_at <= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
-        ELSE articles.published_at >= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+        THEN articles.published_at < before_articles.published_at
+             OR (articles.published_at = before_articles.published_at AND articles.id <= :beforeArticleID)
+        ELSE articles.published_at > before_articles.published_at
+             OR (articles.published_at = before_articles.published_at AND articles.id >= :beforeArticleID)
     END
 );

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByStatus.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articlesByStatus.sq
@@ -23,7 +23,7 @@ AND (feeds.priority IS NULL OR feeds.priority IN ('main', 'important'))
 AND ((article_statuses.starred = :starred AND article_statuses.last_unstarred_at IS NULL OR article_statuses.last_unstarred_at >= :lastUnstarredAt) OR :starred IS NULL)
 AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
 AND (:query IS NULL OR articles.title LIKE '%' || :query || '%' OR articles.summary LIKE '%' || :query || '%')
-ORDER BY articles.published_at DESC
+ORDER BY articles.published_at DESC, articles.id DESC
 LIMIT :limit OFFSET :offset;
 
 allOldestFirst:
@@ -51,7 +51,7 @@ AND (feeds.priority IS NULL OR feeds.priority IN ('main', 'important'))
 AND ((article_statuses.starred = :starred AND article_statuses.last_unstarred_at IS NULL OR article_statuses.last_unstarred_at >= :lastUnstarredAt) OR :starred IS NULL)
 AND (articles.published_at >= :publishedSince OR :publishedSince IS NULL)
 AND (:query IS NULL OR articles.title LIKE '%' || :query || '%' OR articles.summary LIKE '%' || :query || '%')
-ORDER BY articles.published_at ASC
+ORDER BY articles.published_at ASC, articles.id ASC
 LIMIT :limit OFFSET :offset;
 
 countAll:
@@ -70,6 +70,8 @@ SELECT articles.id
 FROM articles
 JOIN feeds ON articles.feed_id = feeds.id
 JOIN article_statuses ON articles.id = article_statuses.article_id
+LEFT JOIN articles AS after_articles ON after_articles.id = :afterArticleID
+LEFT JOIN articles AS before_articles ON before_articles.id = :beforeArticleID
 WHERE article_statuses.read = 0
 AND (article_statuses.starred = :starred OR :starred IS NULL)
 AND (feeds.priority IS NULL OR feeds.priority IN ('main', 'important'))
@@ -78,14 +80,18 @@ AND (:query IS NULL OR articles.title LIKE '%' || :query || '%' OR articles.summ
 AND (
     :afterArticleID IS NULL
     OR CASE WHEN :newestFirst
-        THEN articles.published_at >= (SELECT published_at FROM articles WHERE id = :afterArticleID)
-        ELSE articles.published_at <= (SELECT published_at FROM articles WHERE id = :afterArticleID)
+        THEN articles.published_at > after_articles.published_at
+             OR (articles.published_at = after_articles.published_at AND articles.id >= :afterArticleID)
+        ELSE articles.published_at < after_articles.published_at
+             OR (articles.published_at = after_articles.published_at AND articles.id <= :afterArticleID)
     END
 )
 AND (
     :beforeArticleID IS NULL
     OR CASE WHEN :newestFirst
-        THEN articles.published_at <= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
-        ELSE articles.published_at >= (SELECT published_at FROM articles WHERE id = :beforeArticleID)
+        THEN articles.published_at < before_articles.published_at
+             OR (articles.published_at = before_articles.published_at AND articles.id <= :beforeArticleID)
+        ELSE articles.published_at > before_articles.published_at
+             OR (articles.published_at = before_articles.published_at AND articles.id >= :beforeArticleID)
     END
 );

--- a/capy/src/test/java/com/jocmp/capy/AccountTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/AccountTest.kt
@@ -186,6 +186,37 @@ class AccountTest {
         assertEquals(result, ids)
     }
 
+    /**
+     * Newest-first display order:
+     *   "hij" published_at t-1
+     *   "lmn" published_at t-2
+     *   "efg" published_at t-3
+     *   "abc" published_at t-3
+     *
+     * Scroll boundary is "efg". Only hij, lmn, efg should be
+     * marked — not abc, even though it shares the same timestamp.
+     */
+    @Test
+    fun `unreadArticleIDs_afterID excludes timestamp sibling below boundary`() = runTest {
+        val articleFixture = ArticleFixture(account.database)
+        val time = nowUTC().minusMonths(1)
+        val sharedTime = time.minusDays(3).toEpochSecond()
+
+        val hij = articleFixture.create(id = "hij", read = false, publishedAt = time.minusDays(1).toEpochSecond())
+        val lmn = articleFixture.create(id = "lmn", read = false, publishedAt = time.minusDays(2).toEpochSecond())
+        val efg = articleFixture.create(id = "efg", read = false, publishedAt = sharedTime)
+        val abc = articleFixture.create(id = "abc", read = false, publishedAt = sharedTime)
+
+        val ids = account.unreadArticleIDs(
+            filter = ArticleFilter.Articles(ArticleStatus.UNREAD),
+            range = MarkRead.After("efg"),
+            sortOrder = SortOrder.NEWEST_FIRST,
+            query = null,
+        )
+
+        assertEquals(listOf("hij", "lmn", "efg"), ids)
+    }
+
     @Test
     fun markAllRead() = runTest {
         coEvery { account.delegate.markRead(any()) }.returns(Result.success(Unit))


### PR DESCRIPTION
Implements a "high watermark" approach that resets between refreshes. This should avoid marking all as read without continuously scrolling to 0 (https://github.com/jocmp/capyreader/issues/1419).

Additionally sorts by id as a secondary sort to avoid marking simultaneously published articles as read if they haven't been scrolled (https://github.com/jocmp/capyreader/issues/1557)