### PR TITLE
Follow system 24-hour time format

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/LocalTimeFormats.kt
+++ b/app/src/main/java/com/capyreader/app/ui/LocalTimeFormats.kt
@@ -1,0 +1,31 @@
+package com.capyreader.app.ui
+
+import android.text.format.DateFormat
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import com.jocmp.capy.common.DisplayTimeFormats
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+val LocalTimeFormats = compositionLocalOf { DisplayTimeFormats.localized() }
+
+@Composable
+fun rememberDisplayTimeFormats(): DisplayTimeFormats {
+    val context = LocalContext.current
+    val configuration = LocalConfiguration.current
+    return remember(configuration) {
+        val time = if (DateFormat.is24HourFormat(context)) {
+            DateTimeFormatter.ofPattern("HH:mm")
+        } else {
+            DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
+        }
+        DisplayTimeFormats(
+            time = time,
+            shortDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM),
+            longDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG),
+        )
+    }
+}

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleRow.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleRow.kt
@@ -59,6 +59,7 @@ import com.capyreader.app.preferences.AppTheme
 import com.capyreader.app.preferences.ThemeMode
 import com.capyreader.app.ui.articles.list.ArticleActionMenu
 import com.capyreader.app.ui.articles.list.ArticleListItem
+import com.capyreader.app.ui.LocalTimeFormats
 import com.capyreader.app.ui.articles.list.ArticleRowSwipeBox
 import com.capyreader.app.ui.fixtures.ArticleSample
 import com.capyreader.app.ui.fixtures.PreviewKoinApplication
@@ -184,6 +185,7 @@ fun ArticleRow(
                                 text = relativeTime(
                                     time = article.publishedAt,
                                     currentTime = currentTime,
+                                    formats = LocalTimeFormats.current,
                                 ),
                                 color = feedNameColor,
                                 maxLines = 1,

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -56,7 +56,9 @@ import com.capyreader.app.ui.LocalBadgeStyle
 import com.capyreader.app.ui.LocalConnectivity
 import com.capyreader.app.ui.LocalLinkOpener
 import com.capyreader.app.ui.LocalMarkAllReadButtonPosition
+import com.capyreader.app.ui.LocalTimeFormats
 import com.capyreader.app.ui.LocalUnreadCount
+import com.capyreader.app.ui.rememberDisplayTimeFormats
 import com.capyreader.app.ui.articles.audio.AudioPlayerController
 import com.capyreader.app.ui.articles.audio.FloatingAudioPlayer
 import com.capyreader.app.ui.articles.detail.ArticleView
@@ -197,6 +199,7 @@ fun ArticleScreen(
         LocalBadgeStyle provides badgeStyle,
         LocalUnreadCount provides unreadCount,
         LocalSnackbarHost provides snackbarHostState,
+        LocalTimeFormats provides rememberDisplayTimeFormats(),
     ) {
         val openNextFeedOnReadAll = afterReadAll == AfterReadAllBehavior.OPEN_NEXT_FEED
 

--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleBylineExt.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleBylineExt.kt
@@ -3,14 +3,16 @@ package com.capyreader.app.ui.articles.detail
 import android.content.Context
 import com.capyreader.app.R
 import com.jocmp.capy.Article
+import com.jocmp.capy.common.DisplayTimeFormats
 import com.jocmp.capy.common.toDeviceDateTime
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
 
-fun Article.byline(context: Context): String {
+fun Article.byline(
+    context: Context,
+    formats: DisplayTimeFormats,
+): String {
     val deviceDateTime = publishedAt.toDeviceDateTime()
-    val date = DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).format(deviceDateTime)
-    val time = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).format(deviceDateTime)
+    val date = formats.longDate.format(deviceDateTime)
+    val time = formats.time.format(deviceDateTime)
 
     return if (!author.isNullOrBlank()) {
         context.getString(R.string.article_byline, date, time, author)

--- a/app/src/main/java/com/capyreader/app/ui/components/WebView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/components/WebView.kt
@@ -22,11 +22,13 @@ import com.capyreader.app.common.AudioEnclosure
 import com.capyreader.app.common.Media
 import com.capyreader.app.common.WebViewInterface
 import com.capyreader.app.common.rememberTalkbackPreference
+import com.capyreader.app.ui.LocalTimeFormats
 import com.capyreader.app.ui.articles.detail.articleTemplateColors
 import com.capyreader.app.ui.articles.detail.byline
 import com.capyreader.app.ui.articles.displayFeedName
 import com.jocmp.capy.Article
 import com.jocmp.capy.articles.ArticleRenderer
+import com.jocmp.capy.common.DisplayTimeFormats
 import com.jocmp.capy.logging.CapyLog
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -41,12 +43,13 @@ fun WebView(
     article: Article? = null,
     showImages: Boolean = true,
 ) {
+    val timeFormats = LocalTimeFormats.current
     AndroidView(
         modifier = modifier,
         factory = { state.webView },
         update = {
             article?.let {
-                state.loadHtml(article, showImages)
+                state.loadHtml(article, showImages, timeFormats)
             }
         }
     )
@@ -162,7 +165,7 @@ class WebViewState(
         loadEmpty()
     }
 
-    fun loadHtml(article: Article, showImages: Boolean) {
+    fun loadHtml(article: Article, showImages: Boolean, timeFormats: DisplayTimeFormats) {
         val id = article.id
         val hash = article.content.hashCode()
 
@@ -180,7 +183,7 @@ class WebViewState(
         val html = renderer.render(
             article,
             hideImages = !showImages,
-            byline = article.byline(context = webView.context),
+            byline = article.byline(context = webView.context, formats = timeFormats),
             colors = colors,
             feedName = article.displayFeedName(webView.context),
         )

--- a/app/src/main/java/com/capyreader/app/ui/widget/ArticleHeadline.kt
+++ b/app/src/main/java/com/capyreader/app/ui/widget/ArticleHeadline.kt
@@ -34,6 +34,10 @@ import com.capyreader.app.notifications.NotificationHelper.Companion.ARTICLE_ID_
 import com.capyreader.app.notifications.NotificationHelper.Companion.FEED_ID_KEY
 import com.jocmp.capy.Article
 import com.jocmp.capy.articles.relativeTime
+import com.jocmp.capy.common.DisplayTimeFormats
+import android.text.format.DateFormat
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import java.net.URL
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -76,6 +80,7 @@ fun ArticleHeadline(article: Article, currentTime: LocalDateTime) {
                 relativeTime(
                     time = article.publishedAt,
                     currentTime = currentTime,
+                    formats = widgetTimeFormats(context),
                 ),
                 style = TextStyle(
                     fontSize = 12.sp,
@@ -84,6 +89,19 @@ fun ArticleHeadline(article: Article, currentTime: LocalDateTime) {
             )
         }
     }
+}
+
+private fun widgetTimeFormats(context: Context): DisplayTimeFormats {
+    val time = if (DateFormat.is24HourFormat(context)) {
+        DateTimeFormatter.ofPattern("HH:mm")
+    } else {
+        DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
+    }
+    return DisplayTimeFormats(
+        time = time,
+        shortDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM),
+        longDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG),
+    )
 }
 
 private fun Context.openArticle(article: Article): Action {

--- a/capy/src/main/java/com/jocmp/capy/articles/RelativeTime.kt
+++ b/capy/src/main/java/com/jocmp/capy/articles/RelativeTime.kt
@@ -1,22 +1,21 @@
 package com.jocmp.capy.articles
 
+import com.jocmp.capy.common.DisplayTimeFormats
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
 import java.util.TimeZone
 
 fun relativeTime(
     time: ZonedDateTime,
     currentTime: LocalDateTime,
+    formats: DisplayTimeFormats,
 ): String {
     val local = time.withZoneSameInstant(TimeZone.getDefault().toZoneId()).toLocalDateTime()
-    val timeFormat = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
-    val dateFormat = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
     val currentDay = currentTime.toLocalDate().atStartOfDay()
 
-    return when {
-        local.isAfter(currentDay) -> timeFormat.format(local)
-        else -> dateFormat.format(local)
+    return if (local.isAfter(currentDay)) {
+        formats.time.format(local)
+    } else {
+        formats.shortDate.format(local)
     }
 }

--- a/capy/src/main/java/com/jocmp/capy/common/DisplayTimeFormats.kt
+++ b/capy/src/main/java/com/jocmp/capy/common/DisplayTimeFormats.kt
@@ -1,0 +1,20 @@
+package com.jocmp.capy.common
+
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+data class DisplayTimeFormats(
+    val time: DateTimeFormatter,
+    val shortDate: DateTimeFormatter,
+    val longDate: DateTimeFormatter,
+) {
+    companion object {
+        fun localized(): DisplayTimeFormats {
+            return DisplayTimeFormats(
+                time = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT),
+                shortDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM),
+                longDate = DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG),
+            )
+        }
+    }
+}

--- a/capy/src/test/java/com/jocmp/capy/articles/RelativeTimeTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/articles/RelativeTimeTest.kt
@@ -1,6 +1,8 @@
 package com.jocmp.capy.articles
 
+import com.jocmp.capy.common.DisplayTimeFormats
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 import java.util.TimeZone
 import kotlin.test.AfterTest
@@ -11,6 +13,12 @@ import kotlin.test.assertEquals
 class RelativeTimeTest {
     private val defaultZone = TimeZone.getDefault()
     private val defaultLocale = Locale.getDefault()
+
+    private val formats = DisplayTimeFormats(
+        time = DateTimeFormatter.ofPattern("h:mm a", Locale.US),
+        shortDate = DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.US),
+        longDate = DateTimeFormatter.ofPattern("MMMM d, yyyy", Locale.US),
+    )
 
     @BeforeTest
     fun setup() {
@@ -28,9 +36,9 @@ class RelativeTimeTest {
         val time = ZonedDateTime.parse("2023-12-25T09:00:00-00:00")
         val currentTime = time.toLocalDateTime()
 
-        val result = relativeTime(time = time, currentTime = currentTime)
+        val result = relativeTime(time = time, currentTime = currentTime, formats = formats)
 
-        assertEquals(expected = "9:00 AM", actual = result)
+        assertEquals(expected = "9:00 AM", actual = result)
     }
 
     @Test
@@ -38,18 +46,18 @@ class RelativeTimeTest {
         val time = ZonedDateTime.parse("2023-12-25T09:00:00-00:00")
         val currentTime = time.toLocalDateTime()
 
-        val result = relativeTime(time = time, currentTime = currentTime)
+        val result = relativeTime(time = time, currentTime = currentTime, formats = formats)
 
-        assertEquals(expected = "9:00 AM", actual = result)
+        assertEquals(expected = "9:00 AM", actual = result)
     }
 
     @Test
-    fun `same day with a different locale`() {
-        Locale.setDefault(Locale("fr", "FR"))
+    fun `honors a 24-hour time formatter`() {
         val time = ZonedDateTime.parse("2023-12-25T09:00:00-00:00")
         val currentTime = time.toLocalDateTime()
+        val twentyFourHour = formats.copy(time = DateTimeFormatter.ofPattern("HH:mm"))
 
-        val result = relativeTime(time = time, currentTime = currentTime)
+        val result = relativeTime(time = time, currentTime = currentTime, formats = twentyFourHour)
 
         assertEquals(expected = "09:00", actual = result)
     }
@@ -59,7 +67,7 @@ class RelativeTimeTest {
         val time = ZonedDateTime.parse("2023-12-24T23:59:00-00:00")
         val currentTime = ZonedDateTime.parse("2023-12-25T09:00:00-00:00").toLocalDateTime()
 
-        val result = relativeTime(time = time, currentTime = currentTime)
+        val result = relativeTime(time = time, currentTime = currentTime, formats = formats)
 
         assertEquals(expected = "Dec 24, 2023", actual = result)
     }

--- a/capy/src/test/java/com/jocmp/capy/common/DisplayTimeFormatsTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/common/DisplayTimeFormatsTest.kt
@@ -1,0 +1,55 @@
+package com.jocmp.capy.common
+
+import java.time.LocalDateTime
+import java.util.Locale
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DisplayTimeFormatsTest {
+    private val defaultLocale = Locale.getDefault()
+    private val instant = LocalDateTime.of(2023, 12, 25, 9, 5)
+
+    @AfterTest
+    fun teardown() {
+        Locale.setDefault(defaultLocale)
+    }
+
+    @Test
+    fun `localized reflects the default locale`() {
+        val cases = listOf(
+            Case(Locale.US, time = "9:05\u202FAM", shortDate = "Dec 25, 2023", longDate = "December 25, 2023"),
+            Case(Locale.UK, time = "09:05", shortDate = "25 Dec 2023", longDate = "25 December 2023"),
+            Case(Locale.FRANCE, time = "09:05", shortDate = "25 déc. 2023", longDate = "25 décembre 2023"),
+            Case(Locale.GERMANY, time = "09:05", shortDate = "25.12.2023", longDate = "25. Dezember 2023"),
+        )
+
+        cases.forEach { case ->
+            Locale.setDefault(case.locale)
+            val formats = DisplayTimeFormats.localized()
+
+            assertEquals(expected = case.time, actual = formats.time.format(instant), message = "time (${case.locale})")
+            assertEquals(expected = case.shortDate, actual = formats.shortDate.format(instant), message = "shortDate (${case.locale})")
+            assertEquals(expected = case.longDate, actual = formats.longDate.format(instant), message = "longDate (${case.locale})")
+        }
+    }
+
+    @Test
+    fun `localized rebuilds when the default locale changes`() {
+        Locale.setDefault(Locale.FRANCE)
+        val french = DisplayTimeFormats.localized()
+
+        Locale.setDefault(Locale.GERMANY)
+        val german = DisplayTimeFormats.localized()
+
+        assertEquals(expected = "25 déc. 2023", actual = french.shortDate.format(instant))
+        assertEquals(expected = "25.12.2023", actual = german.shortDate.format(instant))
+    }
+
+    private data class Case(
+        val locale: Locale,
+        val time: String,
+        val shortDate: String,
+        val longDate: String,
+    )
+}


### PR DESCRIPTION
The app's article list and article-detail byline formatted times using only the JVM locale, so users who had the 24-hour system toggle enabled on a 12-hour locale still saw AM/PM.

The fix is to route time formatting through a single shared formatter resolved at the UI layer, where the Android system preference can be used.

Discussed in #2059