### PR TITLE
Add refresh bandwidth checks

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/accounts/local/LocalAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/local/LocalAccountDelegate.kt
@@ -220,18 +220,44 @@ internal class LocalAccountDelegate(
 
     private suspend fun refreshFeed(feed: Feed, cutoffDate: ZonedDateTime?) {
         try {
-            feedFinder.fetch(feed.feedURL).onSuccess { channel ->
-                val itunesImageURL = channel.itunesChannelData?.image
+            val conditionalGet = feedRecords.findConditionalGet(feed.id)
 
-                if (itunesImageURL != null) {
-                    database.feedsQueries.updateItunesImage(
-                        itunesImageURL = itunesImageURL,
-                        feedID = feed.id,
-                    )
-                }
+            val result = feedFinder.fetch(
+                url = feed.feedURL,
+                conditionalGet = conditionalGet,
+            ).getOrElse { throw it }
 
-                saveArticles(channel.items, cutoffDate = cutoffDate, feed = feed)
+            val refreshedAt = nowUTC().toEpochSecond()
+            val channel = result.channel
+
+            if (channel == null) {
+                feedRecords.updateConditionalGet(
+                    feedID = feed.id,
+                    conditionalGet = conditionalGet,
+                    refreshedAt = refreshedAt,
+                )
+                CapyLog.debug("refresh_feed_skip", mapOf("id" to feed.id))
+                return
             }
+
+            val itunesImageURL = channel.itunesChannelData?.image
+
+            if (itunesImageURL != null) {
+                database.feedsQueries.updateItunesImage(
+                    itunesImageURL = itunesImageURL,
+                    feedID = feed.id,
+                )
+            }
+
+            saveArticles(channel.items, cutoffDate = cutoffDate, feed = feed)
+
+            feedRecords.updateConditionalGet(
+                feedID = feed.id,
+                conditionalGet = result.conditionalGet,
+                refreshedAt = refreshedAt,
+            )
+
+            CapyLog.debug("refresh_feed_complete", mapOf("id" to feed.id))
         } catch (e: Throwable) {
             CapyLog.error("refresh", e)
         }
@@ -260,7 +286,7 @@ internal class LocalAccountDelegate(
                     val enclosureType = parsedItem.enclosures.firstOrNull()?.type
 
                     database.articlesQueries.create(
-                        id =parsedItem.id,
+                        id = parsedItem.id,
                         feed_id = feed.id,
                         title = parsedItem.title,
                         author = item.author,

--- a/capy/src/main/java/com/jocmp/capy/persistence/FeedRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/FeedRecords.kt
@@ -7,6 +7,7 @@ import com.jocmp.capy.FeedPriority
 import com.jocmp.capy.Folder
 import com.jocmp.capy.common.withIOContext
 import com.jocmp.capy.db.Database
+import com.jocmp.rssparser.model.ConditionalGetInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
@@ -18,6 +19,37 @@ internal class FeedRecords(private val database: Database) {
 
     suspend fun findByFeedURL(feedURL: String): Feed? = withIOContext {
         database.feedsQueries.findByFeedURL(feedURL, mapper = ::feedMapper).executeAsOneOrNull()
+    }
+
+    suspend fun findConditionalGet(feedID: String): ConditionalGetInfo = withIOContext {
+        val feed = database.feedsQueries.findConditionalGet(feedID).executeAsOneOrNull()
+
+        ConditionalGetInfo(
+            etag = feed?.etag,
+            lastModified = feed?.last_modified,
+        )
+    }
+
+    /**
+     * Persists conditional-GET state after a successful refresh (200 or 304)
+     *
+     * - [ConditionalGetInfo.lastModified] is the server's HTTP `Last-Modified` header,
+     *   an opaque value for use in the next request as `If-Modified-Since`
+     * - [refreshedAt] reflects when the feed was last fetched from the client regardless
+     *   of whether the feed had changed. Used locally to compare
+     *   staleness of the stored etag/last-modified pair.
+     */
+    suspend fun updateConditionalGet(
+        feedID: String,
+        conditionalGet: ConditionalGetInfo,
+        refreshedAt: Long,
+    ) = withIOContext {
+        database.feedsQueries.updateConditionalGet(
+            etag = conditionalGet.etag,
+            last_modified = conditionalGet.lastModified,
+            refreshed_at = refreshedAt,
+            feedID = feedID,
+        )
     }
 
     suspend fun upsert(
@@ -151,6 +183,9 @@ internal class FeedRecords(private val database: Database) {
         showUnreadBadge: Boolean = true,
         itunesImageURL: String? = null,
         readLater: Boolean = false,
+        etag: String? = null,
+        lastModified: String? = null,
+        conditionalGetRefreshedAt: Long? = null,
         folderName: String? = "",
         expanded: Boolean? = false,
     ) = Feed(

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/25_AddFeedConditionalGet.sqm
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/25_AddFeedConditionalGet.sqm
@@ -1,0 +1,3 @@
+ALTER TABLE feeds ADD COLUMN etag TEXT;
+ALTER TABLE feeds ADD COLUMN last_modified TEXT;
+ALTER TABLE feeds ADD COLUMN conditional_get_refreshed_at INTEGER;

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/feeds.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/feeds.sq
@@ -84,6 +84,17 @@ updateItunesImage:
 UPDATE feeds SET
 itunes_image_url = :itunesImageURL WHERE feeds.id = :feedID;
 
+findConditionalGet:
+SELECT etag, last_modified, conditional_get_refreshed_at
+FROM feeds WHERE id = :feedID LIMIT 1;
+
+updateConditionalGet:
+UPDATE feeds SET
+etag = :etag,
+last_modified = :last_modified,
+conditional_get_refreshed_at = :refreshed_at
+WHERE id = :feedID;
+
 isFullContentEnabled:
 SELECT enable_sticky_full_content FROM feeds WHERE feeds.id = :feedID LIMIT 1;
 

--- a/capy/src/test/java/com/jocmp/capy/MacroProcessorTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/MacroProcessorTest.kt
@@ -7,7 +7,6 @@ import kotlin.time.measureTime
 class MacroProcessorTest {
     @Test
     fun `benchmark MacroProcessor vs String format`() {
-        // Template with %s placeholders (like ReadYou uses)
         val formatTemplate = """
             <!DOCTYPE html>
             <html dir="auto">
@@ -167,7 +166,7 @@ class MacroProcessorTest {
             }
         }
 
-        // Benchmark String.format (ReadYou approach)
+        // Benchmark String.format
         val stringFormatTime = measureTime {
             repeat(iterations) {
                 String.format(formatTemplate, *formatArgs)

--- a/capy/src/test/java/com/jocmp/capy/MockFeedFinder.kt
+++ b/capy/src/test/java/com/jocmp/capy/MockFeedFinder.kt
@@ -2,7 +2,8 @@ package com.jocmp.capy
 
 import com.jocmp.feedfinder.FeedFinder
 import com.jocmp.feedfinder.parser.Feed
-import com.jocmp.rssparser.model.RssChannel
+import com.jocmp.rssparser.model.ConditionalGetInfo
+import com.jocmp.rssparser.model.RssChannelResult
 
 class MockFeedFinder(private val sites: Map<String, Feed> = emptyMap()) : FeedFinder {
     override suspend fun find(url: String): Result<List<Feed>> {
@@ -11,7 +12,7 @@ class MockFeedFinder(private val sites: Map<String, Feed> = emptyMap()) : FeedFi
         return Result.success(listOf(feed))
     }
 
-    override suspend fun fetch(url: String): Result<RssChannel> {
+    override suspend fun fetch(url: String, conditionalGet: ConditionalGetInfo): Result<RssChannelResult> {
         TODO("Not yet implemented")
     }
 }

--- a/capy/src/test/java/com/jocmp/capy/accounts/local/LocalAccountDelegateTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/local/LocalAccountDelegateTest.kt
@@ -11,15 +11,20 @@ import com.jocmp.capy.db.Database
 import com.jocmp.capy.fixtures.FeedFixture
 import com.jocmp.capy.logging.CapyLog
 import com.jocmp.capy.persistence.ArticleRecords
+import com.jocmp.capy.persistence.FeedRecords
 import com.jocmp.capy.rssItemFixture
 import com.jocmp.feedfinder.FeedFinder
 import com.jocmp.feedfinder.parser.Feed
+import com.jocmp.rssparser.model.ConditionalGetInfo
 import com.jocmp.rssparser.model.RssChannel
+import com.jocmp.rssparser.model.RssChannelResult
 import com.jocmp.rssparser.model.RssItem
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import org.junit.Before
@@ -105,7 +110,7 @@ class LocalAccountDelegateTest {
 
     @Test
     fun refreshAll_updatesEntries() = runTest {
-        coEvery { feedFinder.fetch(url = any()) }.returns(Result.success(channel))
+        coEvery { feedFinder.fetch(url = any()) }.returns(Result.success(RssChannelResult(channel = channel, conditionalGet = ConditionalGetInfo.EMPTY)))
 
         FeedFixture(database).create(feedID = channel.link!!)
 
@@ -129,7 +134,7 @@ class LocalAccountDelegateTest {
     @Test
     fun refreshAll_updatesEntries_filteredByFilters() = runTest {
         accountPreferences.filterKeywords.set(setOf("Apple Intelligence"))
-        coEvery { feedFinder.fetch(url = any()) }.returns(Result.success(channel))
+        coEvery { feedFinder.fetch(url = any()) }.returns(Result.success(RssChannelResult(channel = channel, conditionalGet = ConditionalGetInfo.EMPTY)))
 
         FeedFixture(database).create(feedID = channel.link!!)
 
@@ -154,7 +159,7 @@ class LocalAccountDelegateTest {
     fun refreshAll_doesNotChangeUpdatedAtTimestamp() = runTest {
         val mockNow = ZonedDateTime.parse("2024-12-25T09:00:00-00:00")
         mockkObject(TimeHelpers)
-        coEvery { feedFinder.fetch(url = any()) }.returns(Result.success(channel))
+        coEvery { feedFinder.fetch(url = any()) }.returns(Result.success(RssChannelResult(channel = channel, conditionalGet = ConditionalGetInfo.EMPTY)))
         every { TimeHelpers.nowUTC() }.returns(mockNow)
 
         FeedFixture(database).create(feedID = channel.link!!)
@@ -177,7 +182,7 @@ class LocalAccountDelegateTest {
 
     @Test
     fun refreshAll_updatesEntriesWithCutoff() = runTest {
-        coEvery { feedFinder.fetch(url = any()) }.returns(Result.success(channel))
+        coEvery { feedFinder.fetch(url = any()) }.returns(Result.success(RssChannelResult(channel = channel, conditionalGet = ConditionalGetInfo.EMPTY)))
 
         FeedFixture(database).create(feedID = channel.link!!)
 
@@ -202,6 +207,102 @@ class LocalAccountDelegateTest {
         assertNotNull(ArticleRecords(database).find(articleID = item.link!!))
     }
 
+
+    @Test
+    fun refreshAll_whenNotModified_skipsArticleSaveAndPersistsRefreshedAt() = runTest {
+        val feedID = channel.link!!
+        FeedFixture(database).create(feedID = feedID, feedURL = feedID)
+
+        val feedRecords = FeedRecords(database)
+        feedRecords.updateConditionalGet(
+            feedID = feedID,
+            conditionalGet = ConditionalGetInfo(etag = "abc", lastModified = "Mon, 01 Jan 2024 00:00:00 GMT"),
+            refreshedAt = 1_000L,
+        )
+
+        val mockNow = ZonedDateTime.parse("2024-12-25T09:00:00-00:00")
+        mockkObject(TimeHelpers)
+        every { TimeHelpers.nowUTC() }.returns(mockNow)
+
+        coEvery {
+            feedFinder.fetch(url = any(), conditionalGet = any())
+        }.returns(
+            Result.success(
+                RssChannelResult(channel = null, conditionalGet = ConditionalGetInfo.EMPTY)
+            )
+        )
+
+        delegate.refresh(ArticleFilter.default())
+
+        val articleCounts = database
+            .articlesQueries
+            .countAll(read = false, starred = false)
+            .executeAsList()
+        assertTrue(articleCounts.isEmpty())
+
+        val stored = feedRecords.findConditionalGet(feedID)
+        assertEquals(expected = "abc", actual = stored.etag)
+        assertEquals(expected = "Mon, 01 Jan 2024 00:00:00 GMT", actual = stored.lastModified)
+
+        val refreshedAt = database
+            .feedsQueries
+            .findConditionalGet(feedID)
+            .executeAsOne()
+            .conditional_get_refreshed_at
+        assertEquals(expected = mockNow.toEpochSecond(), actual = refreshedAt)
+    }
+
+    @Test
+    fun refreshAll_sendsStoredConditionalGetOnFetch() = runTest {
+        val feedID = channel.link!!
+        FeedFixture(database).create(feedID = feedID, feedURL = feedID)
+
+        val stored = ConditionalGetInfo(etag = "xyz", lastModified = "Wed, 03 Jan 2024 12:00:00 GMT")
+        FeedRecords(database).updateConditionalGet(
+            feedID = feedID,
+            conditionalGet = stored,
+            refreshedAt = 1_000L,
+        )
+
+        val captured = slot<ConditionalGetInfo>()
+        coEvery {
+            feedFinder.fetch(url = any(), conditionalGet = capture(captured))
+        }.returns(
+            Result.success(
+                RssChannelResult(channel = null, conditionalGet = ConditionalGetInfo.EMPTY)
+            )
+        )
+
+        delegate.refresh(ArticleFilter.default())
+
+        coVerify { feedFinder.fetch(url = feedID, conditionalGet = any()) }
+        assertEquals(expected = stored, actual = captured.captured)
+    }
+
+    @Test
+    fun refreshAll_onSuccess_persistsResponseConditionalGet() = runTest {
+        val feedID = channel.link!!
+        FeedFixture(database).create(feedID = feedID, feedURL = feedID)
+
+        val responseConditionalGet = ConditionalGetInfo(
+            etag = "new-etag",
+            lastModified = "Thu, 04 Jan 2024 08:00:00 GMT",
+        )
+
+        coEvery {
+            feedFinder.fetch(url = any(), conditionalGet = any())
+        }.returns(
+            Result.success(
+                RssChannelResult(channel = channel, conditionalGet = responseConditionalGet)
+            )
+        )
+
+        delegate.refresh(ArticleFilter.default())
+
+        val stored = FeedRecords(database).findConditionalGet(feedID)
+        assertEquals(expected = "new-etag", actual = stored.etag)
+        assertEquals(expected = "Thu, 04 Jan 2024 08:00:00 GMT", actual = stored.lastModified)
+    }
 
     @Test
     fun markRead() = runTest {

--- a/feedfinder/src/main/java/com/jocmp/feedfinder/DefaultFeedFinder.kt
+++ b/feedfinder/src/main/java/com/jocmp/feedfinder/DefaultFeedFinder.kt
@@ -9,7 +9,8 @@ import com.jocmp.feedfinder.sources.Source
 import com.jocmp.feedfinder.sources.XML
 import com.jocmp.rssparser.RssParser
 import com.jocmp.rssparser.RssParserBuilder
-import com.jocmp.rssparser.model.RssChannel
+import com.jocmp.rssparser.model.ConditionalGetInfo
+import com.jocmp.rssparser.model.RssChannelResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -51,9 +52,12 @@ class DefaultFeedFinder internal constructor(
     }
 
 
-    override suspend fun fetch(url: String): Result<RssChannel> {
+    override suspend fun fetch(
+        url: String,
+        conditionalGet: ConditionalGetInfo,
+    ): Result<RssChannelResult> {
         return try {
-            Result.success(rssParser.getRssChannel(url))
+            Result.success(rssParser.getRssChannel(url, conditionalGet))
         } catch (e: Throwable) {
             Result.failure(e)
         }

--- a/feedfinder/src/main/java/com/jocmp/feedfinder/FeedFinder.kt
+++ b/feedfinder/src/main/java/com/jocmp/feedfinder/FeedFinder.kt
@@ -1,10 +1,14 @@
 package com.jocmp.feedfinder
 
 import com.jocmp.feedfinder.parser.Feed
-import com.jocmp.rssparser.model.RssChannel
+import com.jocmp.rssparser.model.ConditionalGetInfo
+import com.jocmp.rssparser.model.RssChannelResult
 
 interface FeedFinder {
     suspend fun find(url: String): Result<List<Feed>>
 
-    suspend fun fetch(url: String): Result<RssChannel>
+    suspend fun fetch(
+        url: String,
+        conditionalGet: ConditionalGetInfo = ConditionalGetInfo.EMPTY,
+    ): Result<RssChannelResult>
 }

--- a/rssparser/src/main/kotlin/com/jocmp/rssparser/RssParser.kt
+++ b/rssparser/src/main/kotlin/com/jocmp/rssparser/RssParser.kt
@@ -3,7 +3,9 @@ package com.jocmp.rssparser
 import com.jocmp.rssparser.internal.Fetcher
 import com.jocmp.rssparser.internal.Parser
 import com.jocmp.rssparser.internal.ParserInput
+import com.jocmp.rssparser.model.ConditionalGetInfo
 import com.jocmp.rssparser.model.RssChannel
+import com.jocmp.rssparser.model.RssChannelResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.withContext
@@ -27,6 +29,26 @@ class RssParser internal constructor(
     suspend fun getRssChannel(url: String): RssChannel = withContext(coroutineContext) {
         val parserInput = fetcher.fetch(url)
         return@withContext parser.parse(parserInput)
+    }
+
+    /**
+     * Downloads and parses an RSS feed from [url], sending If-None-Match / If-Modified-Since
+     * headers from [conditionalGet] when present. Returns a result that may indicate the feed
+     * is unchanged (304) along with any ETag / Last-Modified values from the response.
+     */
+    suspend fun getRssChannel(
+        url: String,
+        conditionalGet: ConditionalGetInfo,
+    ): RssChannelResult = withContext(coroutineContext) {
+        val response = fetcher.fetch(url, conditionalGet)
+        if (response.notModified) {
+            return@withContext RssChannelResult(channel = null, conditionalGet = conditionalGet)
+        }
+        val channel = parser.parse(requireNotNull(response.parserInput))
+        return@withContext RssChannelResult(
+            channel = channel,
+            conditionalGet = response.conditionalGet,
+        )
     }
 
     /**

--- a/rssparser/src/main/kotlin/com/jocmp/rssparser/exception/NonFeedResponseException.kt
+++ b/rssparser/src/main/kotlin/com/jocmp/rssparser/exception/NonFeedResponseException.kt
@@ -1,0 +1,6 @@
+package com.jocmp.rssparser.exception
+
+data class NonFeedResponseException(
+    val url: String,
+    val detectedType: String,
+) : Exception("Response at $url is not a feed. Detected $detectedType")

--- a/rssparser/src/main/kotlin/com/jocmp/rssparser/internal/BufferedSourceExt.kt
+++ b/rssparser/src/main/kotlin/com/jocmp/rssparser/internal/BufferedSourceExt.kt
@@ -1,0 +1,34 @@
+package com.jocmp.rssparser.internal
+
+import okio.BufferedSource
+import okio.ByteString.Companion.decodeHex
+import java.io.IOException
+
+private val NOT_FEED_SIGNATURES = listOf(
+    "89504e47".decodeHex(),     // PNG
+    "ffd8ff".decodeHex(),       // JPEG
+    "474946383761".decodeHex(), // GIF87a
+    "474946383961".decodeHex(), // GIF89a
+    "25504446".decodeHex(),     // PDF
+    "504b0304".decodeHex(),     // ZIP
+    "1f8b08".decodeHex(),       // GZIP
+    "49443303".decodeHex(),     // MP3 (ID3v2.3)
+)
+
+private const val PREFIX_BYTES = 8L
+
+/**
+ * Ported from
+ * https://github.com/Ranchero-Software/NetNewsWire/blob/d7c20f5fab7f44e5fd4ab5021df1687ecc31c4b2/Modules/Account/Sources/Account/LocalAccount/LocalAccountRefresher.swift#L291-L294
+ */
+internal fun BufferedSource.isDefinitelyNotFeed(): Boolean {
+    val peek = peek()
+    val available = try {
+        if (peek.request(PREFIX_BYTES)) PREFIX_BYTES else peek.buffer.size
+    } catch (_: IOException) {
+        return false
+    }
+    if (available <= 0) return false
+    val prefix = peek.readByteString(available)
+    return NOT_FEED_SIGNATURES.any { prefix.startsWith(it) }
+}

--- a/rssparser/src/main/kotlin/com/jocmp/rssparser/internal/DefaultFetcher.kt
+++ b/rssparser/src/main/kotlin/com/jocmp/rssparser/internal/DefaultFetcher.kt
@@ -1,6 +1,8 @@
 package com.jocmp.rssparser.internal
 
 import com.jocmp.rssparser.exception.HttpException
+import com.jocmp.rssparser.exception.NonFeedResponseException
+import com.jocmp.rssparser.model.ConditionalGetInfo
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
 import okhttp3.Callback
@@ -14,17 +16,23 @@ import kotlin.coroutines.resumeWithException
 internal class DefaultFetcher(
     private val callFactory: Call.Factory,
 ) : Fetcher {
-    override suspend fun fetch(url: String): ParserInput {
-        val request = createRequest(url)
-        return callFactory.newCall(request).awaitForInputStream()
+    override suspend fun fetch(url: String, conditionalGet: ConditionalGetInfo): FetchResponse {
+        val request = createRequest(url, conditionalGet)
+        return callFactory.newCall(request).awaitForResponse()
     }
 
-    private fun createRequest(url: String): Request =
-        Request.Builder()
-            .url(url)
-            .build()
+    private fun createRequest(url: String, conditionalGet: ConditionalGetInfo): Request {
+        val builder = Request.Builder().url(url)
+        conditionalGet.etag?.takeIf { it.isNotBlank() }?.let {
+            builder.header("If-None-Match", it)
+        }
+        conditionalGet.lastModified?.takeIf { it.isNotBlank() }?.let {
+            builder.header("If-Modified-Since", it)
+        }
+        return builder.build()
+    }
 
-    private suspend fun Call.awaitForInputStream(): ParserInput =
+    private suspend fun Call.awaitForResponse(): FetchResponse =
         suspendCancellableCoroutine { continuation ->
             continuation.invokeOnCancellation {
                 cancel()
@@ -32,19 +40,41 @@ internal class DefaultFetcher(
 
             enqueue(object : Callback {
                 override fun onResponse(call: Call, response: Response) {
-                    if (response.isSuccessful) {
-                        val body = requireNotNull(response.body)
-                        val charset = response.header("content-type")?.toMediaTypeOrNull()?.charset()
+                    if (response.code == 304) {
+                        response.close()
                         continuation.resume(
-                            ParserInput(body.bytes(), charset = charset)
+                            FetchResponse(parserInput = null, conditionalGet = ConditionalGetInfo.EMPTY)
                         )
-                    } else {
-                        val exception = HttpException(
-                            code = response.code,
-                            message = response.message,
-                        )
-                        continuation.resumeWithException(exception)
+                        return
                     }
+
+                    if (!response.isSuccessful) {
+                        continuation.resumeWithException(
+                            HttpException(code = response.code, message = response.message)
+                        )
+                        return
+                    }
+
+                    val body = requireNotNull(response.body)
+                    val source = body.source()
+
+                    if (source.isDefinitelyNotFeed()) {
+                        response.close()
+                        continuation.resumeWithException(
+                            NonFeedResponseException(call.request().url.toString(), "image")
+                        )
+                        return
+                    }
+
+                    val charset = response.header("content-type")?.toMediaTypeOrNull()?.charset()
+                    val parserInput = ParserInput(body.bytes(), charset = charset)
+                    val responseConditionalGet = ConditionalGetInfo(
+                        etag = response.header("ETag"),
+                        lastModified = response.header("Last-Modified"),
+                    )
+                    continuation.resume(
+                        FetchResponse(parserInput = parserInput, conditionalGet = responseConditionalGet)
+                    )
                 }
 
                 override fun onFailure(call: Call, e: IOException) {
@@ -53,3 +83,4 @@ internal class DefaultFetcher(
             })
         }
 }
+

--- a/rssparser/src/main/kotlin/com/jocmp/rssparser/internal/FetchResponse.kt
+++ b/rssparser/src/main/kotlin/com/jocmp/rssparser/internal/FetchResponse.kt
@@ -1,0 +1,11 @@
+package com.jocmp.rssparser.internal
+
+import com.jocmp.rssparser.model.ConditionalGetInfo
+
+internal data class FetchResponse(
+    val parserInput: ParserInput?,
+    val conditionalGet: ConditionalGetInfo,
+) {
+    val notModified: Boolean
+        get() = parserInput == null
+}

--- a/rssparser/src/main/kotlin/com/jocmp/rssparser/internal/Fetcher.kt
+++ b/rssparser/src/main/kotlin/com/jocmp/rssparser/internal/Fetcher.kt
@@ -1,5 +1,10 @@
 package com.jocmp.rssparser.internal
 
+import com.jocmp.rssparser.model.ConditionalGetInfo
+
 internal interface Fetcher {
-    suspend fun fetch(url: String): ParserInput
+    suspend fun fetch(url: String): ParserInput = fetch(url, ConditionalGetInfo.EMPTY).parserInput
+        ?: error("Conditional GET not expected here")
+
+    suspend fun fetch(url: String, conditionalGet: ConditionalGetInfo): FetchResponse
 }

--- a/rssparser/src/main/kotlin/com/jocmp/rssparser/model/ConditionalGetInfo.kt
+++ b/rssparser/src/main/kotlin/com/jocmp/rssparser/model/ConditionalGetInfo.kt
@@ -1,0 +1,18 @@
+package com.jocmp.rssparser.model
+
+data class ConditionalGetInfo(
+    val etag: String? = null,
+    val lastModified: String? = null,
+) {
+    val isEmpty: Boolean
+        get() = etag.isNullOrBlank() && lastModified.isNullOrBlank()
+
+    companion object {
+        val EMPTY = ConditionalGetInfo()
+    }
+}
+
+data class RssChannelResult(
+    val channel: RssChannel?,
+    val conditionalGet: ConditionalGetInfo,
+)

--- a/rssparser/src/test/kotlin/com/jocmp/rssparser/MalformedFeedParserTest.kt
+++ b/rssparser/src/test/kotlin/com/jocmp/rssparser/MalformedFeedParserTest.kt
@@ -1,7 +1,8 @@
 package com.jocmp.rssparser
 
+import com.jocmp.rssparser.internal.FetchResponse
 import com.jocmp.rssparser.internal.Fetcher
-import com.jocmp.rssparser.internal.ParserInput
+import com.jocmp.rssparser.model.ConditionalGetInfo
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -11,8 +12,11 @@ class MalformedFeedParserTest {
     fun whenReceivingAMalformedXmlTheParserWillHandleIt() = runTest {
         val rssParser = RssParser(
             fetcher = object : Fetcher {
-                override suspend fun fetch(url: String): ParserInput =
-                    readFileFromResources("feed-test-malformed.xml")
+                override suspend fun fetch(url: String, conditionalGet: ConditionalGetInfo): FetchResponse =
+                    FetchResponse(
+                        parserInput = readFileFromResources("feed-test-malformed.xml"),
+                        conditionalGet = ConditionalGetInfo.EMPTY,
+                    )
             },
             parser = ParserFactory.build()
         )

--- a/rssparser/src/test/kotlin/com/jocmp/rssparser/internal/BufferedSourceExtTest.kt
+++ b/rssparser/src/test/kotlin/com/jocmp/rssparser/internal/BufferedSourceExtTest.kt
@@ -1,0 +1,74 @@
+package com.jocmp.rssparser.internal
+
+import okio.Buffer
+import okio.ByteString.Companion.decodeHex
+import okio.ByteString.Companion.encodeUtf8
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BufferedSourceExtTest {
+    @Test
+    fun `detects PNG`() {
+        assertTrue(source("89504e470d0a1a0a".decodeHex()).isDefinitelyNotFeed())
+    }
+
+    @Test
+    fun `detects JPEG`() {
+        assertTrue(source("ffd8ffe000104a464946".decodeHex()).isDefinitelyNotFeed())
+    }
+
+    @Test
+    fun `detects GIF`() {
+        assertTrue(source("474946383961".decodeHex()).isDefinitelyNotFeed())
+    }
+
+    @Test
+    fun `detects PDF`() {
+        assertTrue(source("255044462d312e34".decodeHex()).isDefinitelyNotFeed())
+    }
+
+    @Test
+    fun `detects ZIP`() {
+        assertTrue(source("504b03040a000000".decodeHex()).isDefinitelyNotFeed())
+    }
+
+    @Test
+    fun `detects GZIP`() {
+        assertTrue(source("1f8b0808000000".decodeHex()).isDefinitelyNotFeed())
+    }
+
+    @Test
+    fun `detects MP3 with ID3 header`() {
+        assertTrue(source("4944330300000000".decodeHex()).isDefinitelyNotFeed())
+    }
+
+    @Test
+    fun `passes XML`() {
+        assertFalse(source("<?xml version=\"1.0\"?>".encodeUtf8()).isDefinitelyNotFeed())
+    }
+
+    @Test
+    fun `passes HTML`() {
+        assertFalse(source("<!DOCTYPE html><html>".encodeUtf8()).isDefinitelyNotFeed())
+    }
+
+    @Test
+    fun `passes JSON feed`() {
+        assertFalse(source("{\"version\":\"https:".encodeUtf8()).isDefinitelyNotFeed())
+    }
+
+    @Test
+    fun `passes empty body`() {
+        assertFalse(source("".encodeUtf8()).isDefinitelyNotFeed())
+    }
+
+    @Test
+    fun `does not consume bytes`() {
+        val buffer = Buffer().write("<?xml version=\"1.0\"?>".encodeUtf8())
+        buffer.isDefinitelyNotFeed()
+        assertTrue(buffer.readUtf8().startsWith("<?xml"))
+    }
+
+    private fun source(bytes: okio.ByteString): Buffer = Buffer().write(bytes)
+}


### PR DESCRIPTION
- Persist ETag/Last-Modified per feed and send them on refresh and skip parsing on 304. New migration adds etag, last_modified, conditional_get_refreshed_at columns on feeds.
- Inspect first bytes of a feed response and skip if it looks like a binary instead of feed content.

Ref

- https://github.com/jocmp/capyreader/discussions/2054