### PR TITLE
Add BazQux Reader as a Source

### DIFF
--- a/app/src/main/java/com/capyreader/app/common/AccountSourceTitleExt.kt
+++ b/app/src/main/java/com/capyreader/app/common/AccountSourceTitleExt.kt
@@ -10,4 +10,5 @@ val Source.titleKey: Int
         Source.LOCAL -> R.string.account_source_local
         Source.MINIFLUX, Source.MINIFLUX_TOKEN -> R.string.account_source_miniflux
         Source.READER -> R.string.account_source_reader
+        Source.BAZQUX -> R.string.account_source_bazqux
     }

--- a/app/src/main/java/com/capyreader/app/ui/accounts/AccountRow.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/AccountRow.kt
@@ -82,6 +82,13 @@ private fun buildItem(source: Source): SourceModel {
                 iconID = R.drawable.rss_logo,
                 subtitle = stringResource(R.string.add_account_reader_subtitle),
             )
+
+        Source.BAZQUX ->
+            SourceModel(
+                title = stringResource(source.titleKey),
+                iconID = R.drawable.rss_logo,
+                subtitle = stringResource(R.string.add_account_bazqux_subtitle),
+            )
     }
 }
 

--- a/app/src/main/java/com/capyreader/app/ui/accounts/AddAccountView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/AddAccountView.kt
@@ -78,6 +78,10 @@ fun AddAccountView(
                     onSelectService,
                     source = Source.READER
                 )
+                SyncServiceRow(
+                    onSelectService,
+                    source = Source.BAZQUX
+                )
             }
             if (CrashReporting.isAvailable) {
                 Box(

--- a/app/src/main/java/com/capyreader/app/ui/accounts/LoginViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/LoginViewModel.kt
@@ -39,6 +39,15 @@ class LoginViewModel(
     private var _useApiToken by mutableStateOf(false)
     private val routeSource = handle.toRoute<Route.Login>().source
 
+    init {
+        // BazQux is a hosted service at a fixed URL — prefill it so users don't
+        // have to type the host. Mirrors NetNewsWire's
+        // ReaderAPIVariant.bazQux.host (NNW: Modules/Account/Sources/Account/ReaderAPI/ReaderAPIVariant.swift).
+        if (routeSource == Source.BAZQUX) {
+            _url = BAZQUX_DEFAULT_URL
+        }
+    }
+
     val source: Source
         get() = if (routeSource == Source.MINIFLUX && _useApiToken) {
             Source.MINIFLUX_TOKEN
@@ -165,4 +174,8 @@ class LoginViewModel(
     }
 
     private fun loginError() = Error("Error logging in")
+
+    companion object {
+        const val BAZQUX_DEFAULT_URL = "https://bazqux.com/"
+    }
 }

--- a/app/src/main/java/com/capyreader/app/ui/accounts/ServiceSignup.kt
+++ b/app/src/main/java/com/capyreader/app/ui/accounts/ServiceSignup.kt
@@ -55,6 +55,12 @@ private fun buildPrompt(source: Source): SignupPrompt? {
             link = "https://miniflux.app/"
         )
 
+        Source.BAZQUX -> SignupPrompt(
+            text = stringResource(R.string.add_account_bazqux_signup_prompt),
+            linkText = stringResource(R.string.add_account_bazqux_signup_link_text),
+            link = "https://bazqux.com/"
+        )
+
         else -> null
     }
 }

--- a/app/src/main/java/com/capyreader/app/ui/settings/AccountSettingsStrings.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/AccountSettingsStrings.kt
@@ -24,7 +24,8 @@ data class AccountSettingsStrings(
                 Source.FRESHRSS,
                 Source.MINIFLUX,
                 Source.MINIFLUX_TOKEN,
-                Source.READER -> AccountSettingsStrings(
+                Source.READER,
+                Source.BAZQUX -> AccountSettingsStrings(
                     dialogTitle = R.string.settings_remove_account_title_service,
                     dialogMessage = R.string.settings_remove_account_message_service,
                     dialogConfirmText = R.string.settings_remove_account_confirm_service,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,7 @@
     <string name="account_source_freshrss" translatable="false">FreshRSS</string>
     <string name="account_source_miniflux" translatable="false">Miniflux</string>
     <string name="account_source_reader">Reader</string>
+    <string name="account_source_bazqux" translatable="false">BazQux</string>
     <string name="account_source_local">Local</string>
     <string name="add_account_title">Add Account</string>
     <string name="add_account_local_subtitle">On your device</string>
@@ -120,6 +121,9 @@
     <string name="add_account_freshrss_subtitle" translatable="false">freshrss.org</string>
     <string name="add_account_miniflux_subtitle" translatable="false">miniflux.app</string>
     <string name="add_account_reader_subtitle">Self-hosted Google Reader API</string>
+    <string name="add_account_bazqux_subtitle" translatable="false">bazqux.com</string>
+    <string name="add_account_bazqux_signup_prompt">Don\'t have a BazQux Reader account?</string>
+    <string name="add_account_bazqux_signup_link_text">Sign up here.</string>
     <string name="add_account_feedbin_signup_prompt">Don\'t have a Feedbin account?</string>
     <string name="add_account_feedbin_signup_link_text">Create one here.</string>
     <string name="add_account_freshrss_signup_prompt">Don\'t have a FreshRSS instance?</string>

--- a/bench/BAZQUX-TESTING.md
+++ b/bench/BAZQUX-TESTING.md
@@ -1,0 +1,88 @@
+# BazQux live verification
+
+These steps exercise a real BazQux Reader account against the bench CLI.
+The bench module wires the same `ReaderAccountDelegate` the Android app
+uses, so a green run here implies the Android client is also wired up.
+
+## 1. Drop credentials
+
+```sh
+cp bench/bench.properties.bazqux.example bench/bench.properties
+$EDITOR bench/bench.properties   # fill in username + password
+```
+
+`bench/bench.properties` is gitignored. Confirm with `git check-ignore -v
+bench/bench.properties` if you want to be paranoid.
+
+## 2. Verify credentials
+
+```sh
+./gradlew :bench:run --args="login"
+```
+
+Expect: `Logged in as <username>` and exit 0. Bad credentials return exit
+1 with a single-line error (no stack trace). On first run this also
+creates the local on-disk account under `bench/data/`.
+
+## 3. First sync
+
+```sh
+./gradlew :bench:run --args="refresh"
+```
+
+Expect a feed count and an article count. Re-running should be cheaper
+and idempotent.
+
+## 4. Inspect
+
+```sh
+./gradlew :bench:run --args="folders"
+./gradlew :bench:run --args="feeds"
+./gradlew :bench:run --args="articles"
+./gradlew :bench:run --args="articles unread"
+./gradlew :bench:run --args="articles starred"
+```
+
+`articles <status>` prints the first 50 articles with a `[rs]` flag
+column (read, starred).
+
+## 5. Round-trip read state
+
+Pick an article ID from `articles unread` output, then:
+
+```sh
+./gradlew :bench:run --args="mark-read <article-id>"
+./gradlew :bench:run --args="refresh"
+./gradlew :bench:run --args="articles unread"
+```
+
+The article should no longer appear in the unread list. Re-run
+`mark-read <article-id>` to flip it back to unread and verify it
+returns.
+
+## 6. Round-trip starred state
+
+```sh
+./gradlew :bench:run --args="mark-starred <article-id>"
+./gradlew :bench:run --args="refresh"
+./gradlew :bench:run --args="articles starred"
+```
+
+Same idea — the article should appear in starred. Re-run to unstar.
+
+## 7. Reset
+
+```sh
+./gradlew :bench:run --args="reset"
+```
+
+Wipes `bench/data/` so the next run logs in afresh.
+
+## Reporting results
+
+Comment on the BazQux PR with:
+
+- Output of `login`, `refresh`, `articles`, `folders`.
+- Whether the read/starred round-trips succeeded.
+- Anything weird (timestamps off, folders missing, item IDs that look
+  like negative 64-bit integers but get truncated, etc).

--- a/bench/bench.properties.bazqux.example
+++ b/bench/bench.properties.bazqux.example
@@ -1,0 +1,4 @@
+source=bazqux
+username=your_bazqux_email
+password=your_bazqux_password
+url=https://bazqux.com/

--- a/bench/src/main/kotlin/com/jocmp/bench/Commands.kt
+++ b/bench/src/main/kotlin/com/jocmp/bench/Commands.kt
@@ -72,15 +72,101 @@ suspend fun commandFeeds(account: Account) {
     }
 }
 
-suspend fun commandArticles(account: Account) {
-    val all = account.countAllByStatus(ArticleStatus.ALL).first()
-    val unread = account.countAllByStatus(ArticleStatus.UNREAD).first()
-    val starred = account.countAllByStatus(ArticleStatus.STARRED).first()
+suspend fun commandArticles(account: Account, status: String? = null) {
+    val filter = when (status?.lowercase()) {
+        null -> null
+        "all" -> ArticleStatus.ALL
+        "unread" -> ArticleStatus.UNREAD
+        "starred" -> ArticleStatus.STARRED
+        else -> {
+            System.err.println("Unknown status: $status. Expected: all|unread|starred")
+            return
+        }
+    }
 
-    println("articles:")
-    println("  all:     $all")
-    println("  unread:  $unread")
-    println("  starred: $starred")
+    if (filter == null) {
+        val all = account.countAllByStatus(ArticleStatus.ALL).first()
+        val unread = account.countAllByStatus(ArticleStatus.UNREAD).first()
+        val starred = account.countAllByStatus(ArticleStatus.STARRED).first()
+
+        println("articles:")
+        println("  all:     $all")
+        println("  unread:  $unread")
+        println("  starred: $starred")
+        return
+    }
+
+    val records = ArticleRecords(account.database)
+    val articles = records.byStatus.all(
+        status = filter,
+        limit = 50,
+        offset = 0,
+        sortOrder = SortOrder.NEWEST_FIRST,
+    ).executeAsList()
+
+    val count = account.countAllByStatus(filter).first()
+    println("articles ($filter): $count total — showing first ${articles.size}")
+    articles.forEach { article ->
+        val flags = buildString {
+            if (article.read) append("r") else append("-")
+            if (article.starred) append("s") else append("-")
+        }
+        println("  [${article.id}] [$flags] ${article.title}")
+    }
+}
+
+suspend fun commandLogin(account: Account) {
+    println("Logged in as ${account.preferences.username.get()}")
+    println("  source: ${account.source.value}")
+    println("  url:    ${account.preferences.url.get()}")
+}
+
+suspend fun commandFolders(account: Account) {
+    val folders = account.folders.first()
+    val ungrouped = account.feeds.first()
+    println("${folders.size} folders, ${ungrouped.size} ungrouped feeds:")
+    folders.forEach { folder ->
+        println("  ${folder.title} (${folder.feeds.size} feeds)")
+    }
+    if (ungrouped.isNotEmpty()) {
+        println("  (no folder): ${ungrouped.size} feeds")
+    }
+}
+
+suspend fun commandMarkRead(account: Account, articleID: String) {
+    val article = account.findArticle(articleID) ?: run {
+        System.err.println("Article $articleID not found locally. Try 'refresh' first.")
+        return
+    }
+
+    if (article.read) {
+        account.markUnread(articleID).getOrThrow()
+        println("marked unread: $articleID")
+    } else {
+        account.markRead(articleID).getOrThrow()
+        println("marked read: $articleID")
+    }
+
+    account.sendArticleStatus().getOrThrow()
+    println("synced status to remote")
+}
+
+suspend fun commandMarkStarred(account: Account, articleID: String) {
+    val article = account.findArticle(articleID) ?: run {
+        System.err.println("Article $articleID not found locally. Try 'refresh' first.")
+        return
+    }
+
+    if (article.starred) {
+        account.removeStar(articleID).getOrThrow()
+        println("unstarred: $articleID")
+    } else {
+        account.addStar(articleID).getOrThrow()
+        println("starred: $articleID")
+    }
+
+    account.sendArticleStatus().getOrThrow()
+    println("synced status to remote")
 }
 
 suspend fun commandSelectProfile(account: Account) {

--- a/bench/src/main/kotlin/com/jocmp/bench/Main.kt
+++ b/bench/src/main/kotlin/com/jocmp/bench/Main.kt
@@ -1,3 +1,4 @@
+// Created by Josiah Campbell
 package com.jocmp.bench
 
 import kotlinx.coroutines.runBlocking
@@ -19,20 +20,50 @@ fun main(args: Array<String>) {
         return
     }
 
-    val config = loadConfig(benchDir)
-    val (_, account) = loadOrCreateAccount(benchDir, config)
+    val config = try {
+        loadConfig(benchDir)
+    } catch (e: IllegalArgumentException) {
+        System.err.println(e.message.orEmpty())
+        exitProcess(1)
+    }
+
+    val (_, account) = try {
+        loadOrCreateAccount(benchDir, config)
+    } catch (e: Throwable) {
+        System.err.println("Login failed: ${e.message.orEmpty()}")
+        exitProcess(1)
+    }
 
     runBlocking {
         when (command) {
+            "login" -> commandLogin(account)
             "refresh" -> commandRefresh(account)
             "refresh-profile" -> commandRefreshProfile(account)
             "select-profile" -> commandSelectProfile(account)
             "add-feed" -> {
-                val url = args.getOrNull(1) ?: error("Usage: add-feed <url>")
+                val url = args.getOrNull(1) ?: run {
+                    System.err.println("Usage: add-feed <url>")
+                    exitProcess(1)
+                }
                 commandAddFeed(account, url)
             }
             "feeds" -> commandFeeds(account)
-            "articles" -> commandArticles(account)
+            "folders" -> commandFolders(account)
+            "articles" -> commandArticles(account, status = args.getOrNull(1))
+            "mark-read" -> {
+                val id = args.getOrNull(1) ?: run {
+                    System.err.println("Usage: mark-read <article-id>")
+                    exitProcess(1)
+                }
+                commandMarkRead(account, id)
+            }
+            "mark-starred" -> {
+                val id = args.getOrNull(1) ?: run {
+                    System.err.println("Usage: mark-starred <article-id>")
+                    exitProcess(1)
+                }
+                commandMarkStarred(account, id)
+            }
             else -> {
                 System.err.println("Unknown command: $command")
                 printUsage()
@@ -44,15 +75,21 @@ fun main(args: Array<String>) {
 }
 
 private fun printUsage() {
-    println("""
+    println(
+        """
         Usage: bench <command> [args]
 
         Commands:
-          refresh           Sync all feeds
-          refresh-profile   Sync with network vs query breakdown
-          add-feed <url>    Add a feed by URL
-          feeds             List all feeds
-          articles          Count articles by status
-          reset             Delete bench/data/ and start fresh
-    """.trimIndent())
+          login                       Verify credentials and create local account
+          refresh                     Sync all feeds
+          refresh-profile             Sync with network vs query breakdown
+          add-feed <url>              Add a feed by URL
+          feeds                       List all feeds
+          folders                     List folders/categories with feed counts
+          articles [status]           Count articles. status: all|unread|starred (default: summary of all three)
+          mark-read <article-id>      Toggle read state for an article
+          mark-starred <article-id>   Toggle starred state for an article
+          reset                       Delete bench/data/ and start fresh
+        """.trimIndent()
+    )
 }

--- a/capy/src/main/java/com/jocmp/capy/Account.kt
+++ b/capy/src/main/java/com/jocmp/capy/Account.kt
@@ -93,7 +93,8 @@ data class Account(
         )
 
         Source.FRESHRSS,
-        Source.READER -> buildReaderDelegate(
+        Source.READER,
+        Source.BAZQUX -> buildReaderDelegate(
             source = source,
             database = database,
             path = cacheDirectory,

--- a/capy/src/main/java/com/jocmp/capy/accounts/Credentials.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/Credentials.kt
@@ -35,7 +35,8 @@ interface Credentials {
                     clientCertManager = clientCertManager,
                 )
                 Source.FRESHRSS,
-                Source.READER -> ReaderCredentials(
+                Source.READER,
+                Source.BAZQUX -> ReaderCredentials(
                     username,
                     password,
                     url = normalizeURL(url),

--- a/capy/src/main/java/com/jocmp/capy/accounts/Source.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/Source.kt
@@ -13,13 +13,22 @@ enum class Source(val value: String) {
 
     /** Miniflux with API Token */
     MINIFLUX_TOKEN("miniflux_token"),
-    READER("reader");
+    READER("reader"),
+
+    /**
+     * BazQux Reader — hosted Google Reader-compatible service at bazqux.com.
+     * NetNewsWire treats BazQux as a fixed-host generic ReaderAPI variant
+     * (NNW: Modules/Account/Sources/Account/ReaderAPI/ReaderAPIVariant.swift).
+     * We follow the same pattern, plugging into the shared [ReaderAccountDelegate].
+     */
+    BAZQUX("bazqux");
 
     val hasCustomURL
         get() = this == FRESHRSS ||
                 this == MINIFLUX ||
                 this == MINIFLUX_TOKEN ||
-                this == READER
+                this == READER ||
+                this == BAZQUX
 
     val requiresUsername
         get() = this != MINIFLUX_TOKEN


### PR DESCRIPTION
## Summary

Adds BazQux Reader as a `Source` value that plugs into the existing readerclient module — the same way `Source.FRESHRSS` and `Source.READER` do today.

## Structural choice

Rather than introducing a `BazQuxAccount` class, BazQux flows through the existing parameterized `ReaderAccountDelegate(source: Source, …)`. `Source.FRESHRSS` and `Source.READER` already share that delegate; `Source.BAZQUX` is one more value in the same `when (source)` arms in `Account.kt` and `Credentials.kt`. No refactor of the FreshRSS path was needed.

## NetNewsWire-sourced quirks

I read every `bazqux` hit in NetNewsWire. The takeaway is that **NNW has no BazQux-specific code paths** in the ReaderAPI client. BazQux is treated as a fixed-host generic Google Reader API variant:

- Fixed host `https://bazqux.com` — `Modules/Account/Sources/Account/ReaderAPI/ReaderAPIVariant.swift` only differs from `.generic`/`.freshRSS` in that it returns a hard-coded host instead of the user-supplied `endpointURL`. capyreader stores the URL the user enters, so we just prefill `https://bazqux.com/` in the login form (`LoginViewModel.BAZQUX_DEFAULT_URL`).
- No header overrides — `ReaderAPICaller.addVariantHeaders` only branches for `.inoreader`. BazQux uses the generic GoogleLogin auth header.
- No item-ID rewriting — `ReaderAPIEntry.uniqueID(variant:)` only branches for `.theOldReader`.
- No folder/label semantics override — BazQux uses generic `reading-list` streams, so the existing `folderStream` arm (`source == Source.FRESHRSS` → `Stream.Label`, else `Stream.ReadingList`) is correct without modification.

The BazQux API doc itself (`/Users/jocmp/dev/bazqux/bazqux-api/README.md`) confirms this: "It's a copy of Google Reader API. The only thing you need to support BazQux Reader is to change endpoint URLs from google.com to bazqux.com."

NNW does have a couple of release-note bug fixes referencing BazQux (articles missing fields, feeds occasionally not updating) — those are downstream parser/feed-fetch bugs, not API-layer quirks, and capyreader's existing `ReaderAccountDelegate` already tolerates missing entry fields via Kotlin nullable parsing.

## Bench CLI

Extended for live round-trip testing:

- `login`, `folders`, `articles [all|unread|starred]`, `mark-read <id>`, `mark-starred <id>`.
- Cleaner failure path when `bench.properties` is missing (exit 1, single-line message).

See `bench/BAZQUX-TESTING.md` for the full walkthrough.

## Test plan

- `./gradlew :capy:test` — passing.
- `./gradlew :readerclient:test` — passing.
- `./gradlew assembleFreeDebug` — passing.
- Live BazQux verification pending @jocmp dropping credentials per `bench/BAZQUX-TESTING.md`.

## Open questions

- **Logo / icon.** This PR reuses `R.drawable.rss_logo` for BazQux's row in the account picker. The upstream BazQux brand assets in `/Users/jocmp/dev/bazqux/` are PNGs at various sizes; converting one to a vector drawable felt out of scope. Want a dedicated `bazqux_logo.xml` before merge, or is the generic icon fine for v1?
- **Folder semantics.** I left BazQux on the `Stream.ReadingList` arm of `folderStream`, matching `Source.READER`. Is that what you want? FreshRSS-style label streams (`Stream.Label`) might also work for BazQux folders since BazQux exposes labels — happy to flip it if you prefer, but NNW does not.
- **Subscription flag — `supportsLabels`.** Currently only `Source.FRESHRSS` returns `true`. BazQux supports tags too per its API docs. Leaving as-is until you weigh in.
- **Login URL field.** `source.hasCustomURL` is `true` for BAZQUX so the URL field shows (prefilled). I could hide it instead, since the host is always `bazqux.com`, but leaving it visible matches NNW's UX where users sometimes need to retype.