### PR TITLE
fix(bazqux): Handle missing url on Reader API subscriptions

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegate.kt
@@ -310,10 +310,10 @@ internal class ReaderAccountDelegate(
             id = subscription.id,
             subscription_id = subscription.id,
             title = subscription.title,
-            feed_url = subscription.url,
+            feed_url = subscription.feedURL,
             site_url = subscription.htmlUrl,
             favicon_url = subscription.iconUrl?.ifBlank {
-                CapyLog.warn(tag("blank_icon"), mapOf("feed_url" to subscription.url))
+                CapyLog.warn(tag("blank_icon"), mapOf("feed_url" to subscription.feedURL))
                 null
             },
             priority = subscription.frssPriority,

--- a/readerclient/src/main/java/com/jocmp/readerclient/Subscription.kt
+++ b/readerclient/src/main/java/com/jocmp/readerclient/Subscription.kt
@@ -8,9 +8,14 @@ data class Subscription(
     val id: String,
     val title: String,
     val categories: List<Category>,
-    val url: String,
+    val url: String?,
     val htmlUrl: String,
     val iconUrl: String?,
     @Json(name = "frss:priority")
     val frssPriority: String?,
-)
+) {
+    // BazQux omits "url" on subscriptions. The feed URL is embedded in "id" as "feed/<url>".
+    // https://github.com/Ranchero-Software/NetNewsWire/blob/43a06494033c93125a62f37464add7477b3ed664/Modules/Account/Sources/Account/ReaderAPI/ReaderAPISubscription.swift#L79
+    val feedURL: String
+        get() = url ?: id.removePrefix("feed/")
+}

--- a/readerclient/src/test/kotlin/com/jocmp/readerclient/SubscriptionTest.kt
+++ b/readerclient/src/test/kotlin/com/jocmp/readerclient/SubscriptionTest.kt
@@ -1,0 +1,39 @@
+package com.jocmp.readerclient
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class SubscriptionTest {
+    @Test
+    fun `feedURL prefers explicit url`() {
+        val sub = Subscription(
+            id = "feed/http://example.com/rss",
+            title = "Example",
+            categories = emptyList(),
+            url = "http://feeds.example.com/rss",
+            htmlUrl = "http://example.com",
+            iconUrl = null,
+            frssPriority = null,
+        )
+
+        assertEquals(expected = "http://feeds.example.com/rss", actual = sub.feedURL)
+    }
+
+    @Test
+    fun `feedURL falls back to id when url is missing`() {
+        val sub = Subscription(
+            id = "feed/http://feeds.propublica.org/propublica/main",
+            title = "ProPublica",
+            categories = emptyList(),
+            url = null,
+            htmlUrl = "https://www.propublica.org/",
+            iconUrl = null,
+            frssPriority = null,
+        )
+
+        assertEquals(
+            expected = "http://feeds.propublica.org/propublica/main",
+            actual = sub.feedURL,
+        )
+    }
+}


### PR DESCRIPTION
BazQux omits `url` on subscriptions and embeds the feed URL in `id` as `feed/<url>`. Fall back to that when `url` is null. Matches NNW (`ReaderAPISubscription.swift` `var url`).

Ref

- https://github.com/jocmp/capyreader/issues/2028