### PR TITLE
fix(bazqux): Wrap reader item IDs in tag URI

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegate.kt
+++ b/capy/src/main/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegate.kt
@@ -27,6 +27,7 @@ import com.jocmp.readerclient.GoogleReader
 import com.jocmp.readerclient.GoogleReader.Companion.BAD_TOKEN_HEADER_KEY
 import com.jocmp.readerclient.Item
 import com.jocmp.readerclient.ItemRef
+import com.jocmp.readerclient.taggedItemID
 import com.jocmp.readerclient.Stream
 import com.jocmp.readerclient.Stream.Read
 import com.jocmp.readerclient.Stream.UserLabel
@@ -446,7 +447,7 @@ internal class ReaderAccountDelegate(
                         val response = withPostToken {
                             googleReader.streamItemsContents(
                                 postToken = postToken.get(),
-                                ids = chunkedIDs
+                                ids = chunkedIDs.map { it.taggedItemID }
                             )
                         }
 
@@ -495,7 +496,7 @@ internal class ReaderAccountDelegate(
         val response = withPostToken {
             googleReader.streamItemsContents(
                 postToken = postToken.get(),
-                ids = items.map { it.hexID }
+                ids = items.map { it.hexID.taggedItemID }
             )
         }
 
@@ -574,7 +575,7 @@ internal class ReaderAccountDelegate(
         return withErrorHandling {
             val response = withPostToken {
                 googleReader.editTag(
-                    ids,
+                    ids.map { it.taggedItemID },
                     postToken = postToken.get(),
                     addTag = addTag?.id,
                     removeTag = removeTag?.id

--- a/capy/src/test/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegateTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/reader/ReaderAccountDelegateTest.kt
@@ -22,6 +22,7 @@ import com.jocmp.readerclient.Item.Link
 import com.jocmp.readerclient.Item.Origin
 import com.jocmp.readerclient.Item.Summary
 import com.jocmp.readerclient.ItemRef
+import com.jocmp.readerclient.taggedItemID
 import com.jocmp.readerclient.Stream
 import com.jocmp.readerclient.StreamItemIDsResult
 import com.jocmp.readerclient.StreamItemsContentsResult
@@ -331,7 +332,7 @@ class ReaderAccountDelegateTest {
                     unreadStarredItem,
                     readItem,
                     items.first()
-                ).map { it.hexID }, postToken = postToken
+                ).map { it.hexID.taggedItemID }, postToken = postToken
             )
         }.returns(Response.success(StreamItemsContentsResult(starredItems)))
 
@@ -385,7 +386,7 @@ class ReaderAccountDelegateTest {
 
         coEvery {
             googleReader.editTag(
-                ids = listOf(id),
+                ids = listOf(id.taggedItemID),
                 postToken = postToken,
                 addTag = Stream.Read().id,
             )
@@ -397,7 +398,7 @@ class ReaderAccountDelegateTest {
 
         coVerify {
             googleReader.editTag(
-                ids = listOf(id),
+                ids = listOf(id.taggedItemID),
                 postToken = postToken,
                 addTag = Stream.Read().id,
             )
@@ -410,7 +411,7 @@ class ReaderAccountDelegateTest {
 
         coEvery {
             googleReader.editTag(
-                ids = listOf(id),
+                ids = listOf(id.taggedItemID),
                 postToken = postToken,
                 removeTag = Stream.Read().id,
             )
@@ -422,7 +423,7 @@ class ReaderAccountDelegateTest {
 
         coVerify {
             googleReader.editTag(
-                ids = listOf(id),
+                ids = listOf(id.taggedItemID),
                 postToken = postToken,
                 removeTag = Stream.Read().id,
             )
@@ -435,7 +436,7 @@ class ReaderAccountDelegateTest {
 
         coEvery {
             googleReader.editTag(
-                ids = listOf(id),
+                ids = listOf(id.taggedItemID),
                 postToken = postToken,
                 addTag = Stream.Starred().id,
             )
@@ -447,7 +448,7 @@ class ReaderAccountDelegateTest {
 
         coVerify {
             googleReader.editTag(
-                ids = listOf(id),
+                ids = listOf(id.taggedItemID),
                 postToken = postToken,
                 addTag = Stream.Starred().id,
             )
@@ -460,7 +461,7 @@ class ReaderAccountDelegateTest {
 
         coEvery {
             googleReader.editTag(
-                ids = listOf(id),
+                ids = listOf(id.taggedItemID),
                 postToken = postToken,
                 removeTag = Stream.Starred().id,
             )
@@ -472,7 +473,7 @@ class ReaderAccountDelegateTest {
 
         coVerify {
             googleReader.editTag(
-                ids = listOf(id),
+                ids = listOf(id.taggedItemID),
                 postToken = postToken,
                 removeTag = Stream.Starred().id,
             )
@@ -486,7 +487,7 @@ class ReaderAccountDelegateTest {
 
         coEvery {
             googleReader.editTag(
-                ids = listOf(articleID),
+                ids = listOf(articleID.taggedItemID),
                 postToken = postToken,
                 addTag = savedSearchID,
             )
@@ -498,7 +499,7 @@ class ReaderAccountDelegateTest {
 
         coVerify {
             googleReader.editTag(
-                ids = listOf(articleID),
+                ids = listOf(articleID.taggedItemID),
                 postToken = postToken,
                 addTag = savedSearchID,
             )
@@ -523,7 +524,7 @@ class ReaderAccountDelegateTest {
 
         coEvery {
             googleReader.editTag(
-                ids = listOf(articleID),
+                ids = listOf(articleID.taggedItemID),
                 postToken = postToken,
                 removeTag = savedSearchID,
             )
@@ -535,7 +536,7 @@ class ReaderAccountDelegateTest {
 
         coVerify {
             googleReader.editTag(
-                ids = listOf(articleID),
+                ids = listOf(articleID.taggedItemID),
                 postToken = postToken,
                 removeTag = savedSearchID,
             )
@@ -573,7 +574,7 @@ class ReaderAccountDelegateTest {
 
         coEvery {
             googleReader.editTag(
-                ids = listOf(articleID),
+                ids = listOf(articleID.taggedItemID),
                 postToken = postToken,
                 addTag = savedSearchID,
             )
@@ -604,7 +605,7 @@ class ReaderAccountDelegateTest {
 
         coEvery {
             googleReader.editTag(
-                ids = listOf(articleID),
+                ids = listOf(articleID.taggedItemID),
                 postToken = postToken,
                 removeTag = savedSearchID,
             )
@@ -846,13 +847,13 @@ class ReaderAccountDelegateTest {
             ).build()
 
         coEvery {
-            googleReader.streamItemsContents(responseItems.map { it.hexID }, postToken = null)
+            googleReader.streamItemsContents(responseItems.map { it.hexID.taggedItemID }, postToken = null)
         }.returns(Response.error("".toResponseBody(), errorResponse))
 
         stubPostToken()
 
         coEvery {
-            googleReader.streamItemsContents(responseItems.map { it.hexID }, postToken = postToken)
+            googleReader.streamItemsContents(responseItems.map { it.hexID.taggedItemID }, postToken = postToken)
         }.returns(Response.success(StreamItemsContentsResult(responseItems)))
     }
 

--- a/readerclient/src/main/java/com/jocmp/readerclient/ItemIdentifiers.kt
+++ b/readerclient/src/main/java/com/jocmp/readerclient/ItemIdentifiers.kt
@@ -1,5 +1,10 @@
 package com.jocmp.readerclient
 
+private const val TAG_PREFIX = "tag:google.com,2005:reader/item/"
+
 object ItemIdentifiers {
     fun parseToHexID(numericID: String) = String.format("%016x", numericID.toLong())
 }
+
+val String.taggedItemID: String
+    get() = "$TAG_PREFIX$this"


### PR DESCRIPTION
BazQux rejects bare hex item IDs on stream/items/contents and edit-tag, returning a Haskell `error` 500.

The fix is to send canonical the `tag:google.com,2005:reader/item/<hex>` format which GReader-API variants such as FreshRSS, Miniflux, BazQux accept.

Ref

- https://github.com/jocmp/capyreader/issues/2028