### PR TITLE
feat: enable arm memory tagging extension

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
         android:supportsRtl="true"
         android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/Theme.CapyReader"
+        android:memtagMode="async"
         tools:targetApi="33">
         <meta-data
             android:name="firebase_crashlytics_collection_enabled"


### PR DESCRIPTION
makes app exploitation much harder on devices and OS's with MTE support https://source.android.com/docs/security/test/memory-safety/arm-mte#enable-mte-apps

Capy Reader runs fine for ~6 months for me on GrapheneOS with Memory tagging enabled for an app. Propose to enable it by default.

This change will affect:
- Google Pixel's users with stock OS with Advanced Protection enabled
- Google Pixel's users with GrapheneOS
- Samsung Galaxy users [in some near future](https://www.androidauthority.com/one-ui-9-memory-tagging-extension-spotted-3654992/)
- other devices with other OS's in some not that near future