### PR TITLE
Fix bad dialog instantiation

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/feeds/edit/EditFeedDialog.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/feeds/edit/EditFeedDialog.kt
@@ -2,44 +2,35 @@ package com.capyreader.app.ui.articles.feeds.edit
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.capyreader.app.ui.components.DialogCard
 import com.jocmp.capy.EditFeedFormEntry
 import com.jocmp.capy.Feed
-import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun EditFeedDialog(
     feed: Feed,
-    isOpen: Boolean,
     form: EditFeedViewModel = koinViewModel(),
     onDismiss: () -> Unit
 ) {
     val folders by form.folders.collectAsStateWithLifecycle(emptyList())
-    val coroutineScope = rememberCoroutineScope()
 
     fun submit(entry: EditFeedFormEntry) {
-        coroutineScope.launch {
-            onDismiss()
-
-            form.submit(entry)
-        }
+        form.submit(entry)
+        onDismiss()
     }
 
-    if (isOpen) {
-        Dialog(onDismissRequest = onDismiss) {
-            DialogCard {
-                EditFeedView(
-                    feed = feed,
-                    folders = folders,
-                    showMultiselect = form.showMultiselect,
-                    onSubmit = ::submit,
-                    onCancel = onDismiss
-                )
-            }
+    Dialog(onDismissRequest = onDismiss) {
+        DialogCard {
+            EditFeedView(
+                feed = feed,
+                folders = folders,
+                showMultiselect = form.showMultiselect,
+                onSubmit = ::submit,
+                onCancel = onDismiss
+            )
         }
     }
 }

--- a/app/src/main/java/com/capyreader/app/ui/articles/feeds/edit/EditFeedView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/feeds/edit/EditFeedView.kt
@@ -74,7 +74,7 @@ fun EditFeedView(
     val scrollState = rememberScrollState()
     val (name, setName) = remember { mutableStateOf(feed.title) }
     val (selectedFolder, setSelectedFolder) = remember { mutableStateOf(defaultFolder()) }
-    val switchFolders = remember {
+    val switchFolders = remember(folders) {
         folders
             .map { it.title to feedFolderTitles.contains(it.title) }
             .toMutableStateMap()

--- a/app/src/main/java/com/capyreader/app/ui/articles/feeds/edit/EditFeedViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/feeds/edit/EditFeedViewModel.kt
@@ -1,14 +1,15 @@
 package com.capyreader.app.ui.articles.feeds.edit
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.jocmp.capy.Account
 import com.jocmp.capy.EditFeedFormEntry
-import com.jocmp.capy.Feed
 import com.jocmp.capy.Folder
 import com.jocmp.capy.common.sortedByTitle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class EditFeedViewModel(
@@ -17,11 +18,11 @@ class EditFeedViewModel(
     val folders: Flow<List<Folder>> = account.folders.map { it.sortedByTitle() }
     val showMultiselect = account.supportsMultiFolderFeeds
 
-    suspend fun submit(
-        form: EditFeedFormEntry,
-    ): Result<Feed> {
-        return withContext(Dispatchers.IO) {
-            account.editFeed(form = form)
+    fun submit(form: EditFeedFormEntry) {
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                account.editFeed(form = form)
+            }
         }
     }
 }

--- a/app/src/main/java/com/capyreader/app/ui/articles/list/FeedActionMenu.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/list/FeedActionMenu.kt
@@ -83,11 +83,12 @@ fun FeedActionMenu(
         )
     }
 
-    EditFeedDialog(
-        isOpen = isEditDialogOpen,
-        feed = feed,
-        onDismiss = {
-            setEditDialogOpen(false)
-        },
-    )
+    if (isEditDialogOpen) {
+        EditFeedDialog(
+            feed = feed,
+            onDismiss = {
+                setEditDialogOpen(false)
+            },
+        )
+    }
 }


### PR DESCRIPTION
Fixes a bug where the edit feed dialog was instantiated on each feed row such that the resulting feed allocations totaled O(N^2) which reliably caused an OutOfMemory exception.

For an account with 175 feeds, this resulted in ~30k feed allocations (175^2).

The fix is to only construct the dialog when it's opened.

Ref

- #2089