### PR TITLE
Guard widget preview against Android 17 crash

### DIFF
--- a/app/src/main/java/com/capyreader/app/MainApplication.kt
+++ b/app/src/main/java/com/capyreader/app/MainApplication.kt
@@ -56,13 +56,23 @@ class MainApplication : Application(), SingletonImageLoader.Factory {
 
     /**
      * [Docs](https://developer.android.com/develop/ui/compose/glance/generated-previews)
+     *
+     * On Android 17 the underlying `setWidgetPreview` binder call throws when the
+     * receiver isn't a registered AppWidget provider in the current profile (e.g. a
+     * private/work space), which would otherwise crash the app on launch.
+     * See https://issuetracker.google.com/issues/488125748
      */
     private fun loadWidgetPreview() {
         MainScope().launchUI {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
                 val manager = GlanceAppWidgetManager(applicationContext)
-                manager.setWidgetPreviews(HeadlinesWidgetReceiver::class)
-                manager.setWidgetPreviews(SpotlightWidgetReceiver::class)
+
+                try {
+                    manager.setWidgetPreviews(HeadlinesWidgetReceiver::class)
+                    manager.setWidgetPreviews(SpotlightWidgetReceiver::class)
+                } catch (e: IllegalArgumentException) {
+                    CapyLog.error("widget_preview", e)
+                }
             }
         }
     }

--- a/fastlane/metadata/android/en-US/changelogs/1211.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1211.txt
@@ -1,0 +1,1 @@
+Fix crash for widgets on Android 17. Thanks for the bug reports here!


### PR DESCRIPTION
On Android 17 in a work/private profile, Glance's `setWidgetPreviews` throws `IllegalArgumentException` because the receiver isn't a registered AppWidget provider, crashing the app on every launch ([platform bug](https://issuetracker.google.com/issues/488125748)).

This wraps the preview calls in a catch so the app launches normally and just skips previews until Google ships a fix.

Ref #2164