### PR TITLE
[codex] Reduce feed switch delay

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -351,9 +351,8 @@ fun ArticleScreen(
 
         fun openNextList(action: suspend () -> Unit) {
             coroutineScope.launchUI {
-                drawerState.close()
-                delay(300)
                 openNextStatus(action)
+                drawerState.close()
             }
         }
 


### PR DESCRIPTION
## Summary

- Start the article list/filter transition before closing the navigation drawer
- Remove the fixed wait before applying the selected feed/group filter

## Why

`drawerState.close()` is already a suspending call that waits for the close animation. The following `delay(300)` added a fixed pause before `openNextStatus(action)` could trigger the selected feed/group filter, making feed switches feel delayed.

This is related to #1485, where users report that the old article list can remain visible briefly after switching feeds or groups.

## Testing

- `ANDROID_HOME=/Users/raymond/Library/Android/sdk ANDROID_SDK_ROOT=/Users/raymond/Library/Android/sdk ./gradlew :app:compileFreeDebugKotlin`
- `ANDROID_HOME=/Users/raymond/Library/Android/sdk ANDROID_SDK_ROOT=/Users/raymond/Library/Android/sdk ./gradlew :app:assembleFreeDebug`