### PR TITLE
feat: volume-key page turning for e-ink + double-tap back

### DIFF
--- a/app/src/main/java/com/capyreader/app/MainActivity.kt
+++ b/app/src/main/java/com/capyreader/app/MainActivity.kt
@@ -2,10 +2,12 @@ package com.capyreader.app
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.KeyEvent
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import com.capyreader.app.common.VolumeKeyPager
 import com.capyreader.app.notifications.NotificationHelper
 import com.capyreader.app.preferences.AppPreferences
 import com.capyreader.app.ui.App
@@ -35,6 +37,44 @@ class MainActivity : BaseActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         pendingArticleID = NotificationHelper.openFromIntent(intent, appPreferences = appPreferences)
+    }
+
+    private var lastVolumeUpDownTime = 0L
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        val keyCode = event.keyCode
+        if (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN || keyCode == KeyEvent.KEYCODE_VOLUME_UP) {
+            // Only hijack volume keys while a reader is open, the setting is on,
+            // and no audio is playing; otherwise fall through to normal volume.
+            if (VolumeKeyPager.canHandle()) {
+                if (event.action == KeyEvent.ACTION_DOWN) {
+                    // Double-click volume-up acts as the Back button. Only
+                    // discrete presses (repeatCount 0) count, so holding to page
+                    // never misfires; volume-down never triggers back, so paging
+                    // forward through an article is always safe. Dispatching a
+                    // real back press means it honors the user's configured back
+                    // action — close the article in the reader, or open the
+                    // navigation drawer / navigate to parent in the list.
+                    if (keyCode == KeyEvent.KEYCODE_VOLUME_UP && event.repeatCount == 0) {
+                        val now = event.eventTime
+                        if (now - lastVolumeUpDownTime <= DOUBLE_CLICK_MS) {
+                            lastVolumeUpDownTime = 0L
+                            onBackPressedDispatcher.onBackPressed()
+                            return true
+                        }
+                        lastVolumeUpDownTime = now
+                    }
+                    VolumeKeyPager.handle(forward = keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)
+                }
+                // Consume both DOWN and UP so the system volume UI never shows.
+                return true
+            }
+        }
+        return super.dispatchKeyEvent(event)
+    }
+
+    companion object {
+        private const val DOUBLE_CLICK_MS = 320L
     }
 
     private fun startDestination(): Route {

--- a/app/src/main/java/com/capyreader/app/common/VolumeKeyPager.kt
+++ b/app/src/main/java/com/capyreader/app/common/VolumeKeyPager.kt
@@ -1,0 +1,81 @@
+package com.capyreader.app.common
+
+/**
+ * Bridges hardware volume keys (handled by the Activity) to page-scrolling the
+ * currently visible article reader (composed deep in the Compose tree).
+ *
+ * EinkBro-style paging: volume-down pages forward, volume-up pages back. The
+ * reader screen registers a scroller keyed by article id; the Activity calls
+ * [canHandle]/[handle] from dispatchKeyEvent. When a page-scroll can't advance
+ * (already at the top/bottom of the article), [onAtBoundary] rolls to the
+ * adjacent article so the whole feed reads with one thumb.
+ *
+ * Everything is touched only on the main thread (Compose + key dispatch), so no
+ * synchronization is needed.
+ */
+object VolumeKeyPager {
+    /** The article whose scroller should respond; null when no reader is open. */
+    var currentArticleId: String? = null
+
+    /** True when the "Volume keys turn pages" setting is on. */
+    var isEnabled: () -> Boolean = { false }
+
+    /** True when audio is playing, so volume keys yield to volume control. */
+    var isAudioActive: () -> Boolean = { false }
+
+    /** Advance to the next (forward=true) / previous article at a scroll edge. */
+    var onAtBoundary: ((forward: Boolean) -> Unit)? = null
+
+    // Scrollers registered per article id. Returns true if it will page-scroll,
+    // false if already at the boundary.
+    private val scrollers = mutableMapOf<String, (forward: Boolean) -> Boolean>()
+
+    fun registerScroller(articleId: String, scroller: (forward: Boolean) -> Boolean) {
+        scrollers[articleId] = scroller
+    }
+
+    fun unregisterScroller(articleId: String) {
+        scrollers.remove(articleId)
+    }
+
+    /**
+     * Pages the article *list* when no reader is open. Independent gating from
+     * the reader so it survives a reader open/close (which resets [isEnabled]).
+     */
+    private var listScroller: ((forward: Boolean) -> Boolean)? = null
+    var isListEnabled: () -> Boolean = { false }
+    var isListAudioActive: () -> Boolean = { false }
+
+    fun registerListScroller(scroller: (forward: Boolean) -> Boolean) {
+        listScroller = scroller
+    }
+
+    fun unregisterListScroller() {
+        listScroller = null
+    }
+
+    /** A reader is on screen when its scroller is registered as current. */
+    private val readerActive: Boolean
+        get() = scrollers[currentArticleId] != null
+
+    /** Whether a volume-key press should be consumed for paging right now. */
+    fun canHandle(): Boolean =
+        if (readerActive) {
+            isEnabled() && !isAudioActive()
+        } else {
+            listScroller != null && isListEnabled() && !isListAudioActive()
+        }
+
+    /** Page the current reader (rolling to the adjacent article at a boundary),
+     *  or the article list when no reader is open. */
+    fun handle(forward: Boolean) {
+        if (readerActive) {
+            val scroller = scrollers[currentArticleId] ?: return
+            if (!scroller(forward)) {
+                onAtBoundary?.invoke(forward)
+            }
+        } else {
+            listScroller?.invoke(forward)
+        }
+    }
+}

--- a/app/src/main/java/com/capyreader/app/preferences/AppPreferences.kt
+++ b/app/src/main/java/com/capyreader/app/preferences/AppPreferences.kt
@@ -123,6 +123,9 @@ class AppPreferences(context: Context) {
         val enableHorizontaPagination: Preference<Boolean>
             get() = preferenceStore.getBoolean("article_enable_horizontal_pagination", false)
 
+        val volumeKeyPaging: Preference<Boolean>
+            get() = preferenceStore.getBoolean("article_volume_key_paging", false)
+
         val improveTalkback: Preference<Boolean>
             get() = preferenceStore.getBoolean("article_improve_talkback", false)
 

--- a/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/ArticleScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -22,6 +23,7 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -82,6 +84,7 @@ import com.capyreader.app.ui.articles.list.SwipeUpActionBox
 import com.capyreader.app.ui.articles.list.resetScrollBehaviorListener
 import com.capyreader.app.ui.articles.media.ArticleMediaView
 import com.capyreader.app.ui.collectChangesWithCurrent
+import com.capyreader.app.common.VolumeKeyPager
 import com.capyreader.app.ui.collectChangesWithDefault
 import com.capyreader.app.ui.components.ArticleSearch
 import com.capyreader.app.ui.components.LocalSnackbarHost
@@ -236,6 +239,31 @@ fun ArticleScreen(
         }
 
         val listState = articles.rememberLazyListState()
+
+        // Route hardware volume keys to page-scroll the article list when no
+        // reader is open (EinkBro-style). Independent of the reader's own paging
+        // so it survives a reader open/close, and yields to audio so the volume
+        // rocker still controls volume during podcast/read-aloud playback.
+        val volumeKeyPaging by appPreferences.readerOptions.volumeKeyPaging.collectChangesWithDefault()
+        val isAnyAudioPlaying by audioController.isPlaying.collectAsState()
+        DisposableEffect(listState, volumeKeyPaging, isAnyAudioPlaying) {
+            VolumeKeyPager.isListEnabled = { volumeKeyPaging }
+            VolumeKeyPager.isListAudioActive = { isAnyAudioPlaying }
+            VolumeKeyPager.registerListScroller { forward ->
+                val viewport = listState.layoutInfo.viewportSize.height
+                val canScroll =
+                    if (forward) listState.canScrollForward else listState.canScrollBackward
+                if (canScroll && viewport > 0) {
+                    // Overlap ~10% of the viewport so no row is skipped between pages.
+                    val delta = viewport * 0.9f
+                    coroutineScope.launch {
+                        listState.animateScrollBy(if (forward) delta else -delta)
+                    }
+                }
+                canScroll
+            }
+            onDispose { VolumeKeyPager.unregisterListScroller() }
+        }
 
         fun scrollToArticle(index: Int) {
             coroutineScope.launch {

--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleReader.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleReader.kt
@@ -1,6 +1,7 @@
 package com.capyreader.app.ui.articles.detail
 
 import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -26,6 +28,7 @@ import androidx.compose.ui.res.stringResource
 import com.capyreader.app.R
 import com.capyreader.app.common.AudioEnclosure
 import com.capyreader.app.common.Media
+import com.capyreader.app.common.VolumeKeyPager
 import com.capyreader.app.common.rememberTalkbackPreference
 import com.capyreader.app.common.shareImage
 import com.capyreader.app.preferences.AppPreferences
@@ -44,6 +47,7 @@ import com.jocmp.capy.Article
 import com.jocmp.capy.common.launchIO
 import com.jocmp.capy.common.launchUI
 import com.jocmp.capy.common.withUIContext
+import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import kotlin.math.roundToInt
 
@@ -174,6 +178,31 @@ fun ScrollableWebView(webViewState: WebViewState, article: Article, showImages: 
     }
 
     var lastScrollYPercent by rememberSaveable(article.id) { mutableFloatStateOf(0f) }
+
+    // Hardware volume keys page-scroll this article (EinkBro-style). Registers
+    // while this article's reader is on screen; the Activity drives it via
+    // VolumeKeyPager. Returns whether it could page in the requested direction —
+    // false at a scroll edge lets ArticleView roll to the adjacent article.
+    val pageScope = rememberCoroutineScope()
+    DisposableEffect(article.id, scrollState) {
+        VolumeKeyPager.registerScroller(article.id) { forward ->
+            val viewport = scrollState.viewportSize
+            val canScroll = if (forward) {
+                scrollState.value < scrollState.maxValue
+            } else {
+                scrollState.value > 0
+            }
+            if (canScroll && viewport > 0) {
+                // Overlap ~10% of the viewport so no line is skipped between pages.
+                val delta = viewport * 0.9f
+                pageScope.launch {
+                    scrollState.animateScrollBy(if (forward) delta else -delta)
+                }
+            }
+            canScroll
+        }
+        onDispose { VolumeKeyPager.unregisterScroller(article.id) }
+    }
 
     CornerTapGestureScroll(
         maxArticleHeight = maxHeight,

--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleView.kt
@@ -30,8 +30,10 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.paging.compose.LazyPagingItems
+import androidx.compose.runtime.DisposableEffect
 import com.capyreader.app.common.AudioEnclosure
 import com.capyreader.app.common.Media
+import com.capyreader.app.common.VolumeKeyPager
 import com.capyreader.app.preferences.AppPreferences
 import com.capyreader.app.preferences.ArticleVerticalSwipe
 import com.capyreader.app.preferences.ArticleVerticalSwipe.DISABLED
@@ -130,6 +132,31 @@ fun ArticleView(
     }
 
     val snackbarHostState = remember { SnackbarHostState() }
+
+    // Route hardware volume keys to page-scrolling this article. Yields to audio
+    // so the volume rocker still controls volume during playback, and at a scroll
+    // edge rolls to the adjacent article. Double-click volume-up acts as Back
+    // (handled in MainActivity via the back dispatcher).
+    val volumeKeyPaging by appPreferences.readerOptions.volumeKeyPaging.collectChangesWithDefault()
+    DisposableEffect(article.id, hasNext, hasPrevious, volumeKeyPaging, isAudioPlaying) {
+        VolumeKeyPager.currentArticleId = article.id
+        VolumeKeyPager.isEnabled = { volumeKeyPaging }
+        VolumeKeyPager.isAudioActive = { isAudioPlaying }
+        VolumeKeyPager.onAtBoundary = { forward ->
+            if (forward && hasNext) {
+                selectNext()
+            } else if (!forward && hasPrevious) {
+                selectPrevious()
+            }
+        }
+        onDispose {
+            if (VolumeKeyPager.currentArticleId == article.id) {
+                VolumeKeyPager.currentArticleId = null
+                VolumeKeyPager.onAtBoundary = null
+                VolumeKeyPager.isEnabled = { false }
+            }
+        }
+    }
 
     val contentPadding = rememberContentPadding(pinToolbars)
 

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/GesturesSettingsPanel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/GesturesSettingsPanel.kt
@@ -37,6 +37,8 @@ fun GesturesSettingPanel(
         updateListSwipeBottom = viewModel::updateListSwipeBottom,
         updateHorizontalPagination = viewModel::updateHorizontalPagination,
         enableHorizontalPagination = viewModel.enableHorizontalPagination,
+        updateVolumeKeyPaging = viewModel::updateVolumeKeyPaging,
+        enableVolumeKeyPaging = viewModel.enableVolumeKeyPaging,
         backAction = viewModel.backAction,
         bottomSwipe = viewModel.readerBottomSwipe,
         enablePagingTapGesture = viewModel.enablePagingTapGesture,
@@ -60,6 +62,8 @@ private fun GesturesSettingsPanelView(
     updateListSwipeBottom: (swipe: ArticleListVerticalSwipe) -> Unit,
     updateHorizontalPagination: (enable: Boolean) -> Unit,
     enableHorizontalPagination: Boolean,
+    updateVolumeKeyPaging: (enabled: Boolean) -> Unit,
+    enableVolumeKeyPaging: Boolean,
     backAction: BackAction,
     bottomSwipe: ArticleVerticalSwipe,
     enablePagingTapGesture: Boolean,
@@ -113,6 +117,15 @@ private fun GesturesSettingsPanelView(
                         checked = enablePagingTapGesture,
                         title = stringResource(R.string.settings_gestures_reader_tap_to_page_title),
                         subtitle = stringResource(R.string.settings_gestures_reader_tap_to_page_subtitle)
+                    )
+                }
+
+                RowItem {
+                    TextSwitch(
+                        onCheckedChange = updateVolumeKeyPaging,
+                        checked = enableVolumeKeyPaging,
+                        title = stringResource(R.string.settings_gestures_volume_key_paging_title),
+                        subtitle = stringResource(R.string.settings_gestures_volume_key_paging_subtitle)
                     )
                 }
 
@@ -181,6 +194,8 @@ fun GesturesSettingsPanelPreview() {
             updateReaderBottomSwipe = {},
             updatePagingTapGesture = {},
             updateHorizontalPagination = {},
+            updateVolumeKeyPaging = {},
+            enableVolumeKeyPaging = false,
             updateListSwipeBottom = {},
             backAction = BackAction.OPEN_DRAWER,
             topSwipe = ArticleVerticalSwipe.PREVIOUS_ARTICLE,

--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/GesturesSettingsViewModel.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/GesturesSettingsViewModel.kt
@@ -37,6 +37,9 @@ class GesturesSettingsViewModel(
     var enableHorizontalPagination by mutableStateOf(readerOptions.enableHorizontaPagination.get())
         private set
 
+    var enableVolumeKeyPaging by mutableStateOf(readerOptions.volumeKeyPaging.get())
+        private set
+
     var improveTalkback by mutableStateOf(readerOptions.improveTalkback.get())
         private set
 
@@ -83,6 +86,12 @@ class GesturesSettingsViewModel(
         enableHorizontalPagination = scroll
 
         readerOptions.enableHorizontaPagination.set(scroll)
+    }
+
+    fun updateVolumeKeyPaging(enabled: Boolean) {
+        enableVolumeKeyPaging = enabled
+
+        readerOptions.volumeKeyPaging.set(enabled)
     }
 
     fun updateRowSwipeEnd(swipe: RowSwipeOption) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -282,6 +282,8 @@
     <string name="settings_gestures_enable_horizontal_pagination_title">Enable horizontal scroll</string>
     <string name="settings_gestures_enable_horizontal_pagination_subtitle">Swipe left or right to navigate articles</string>
     <string name="settings_gestures_reader_tap_to_page_subtitle">Tap bottom corners to navigate article content</string>
+    <string name="settings_gestures_volume_key_paging_title">Volume keys turn pages</string>
+    <string name="settings_gestures_volume_key_paging_subtitle">Volume down/up scrolls the article by a page, then moves to the next or previous article. Double-tap volume up to go back. Pauses while audio is playing.</string>
     <string name="settings_enable_high_contrast_dark_theme">Enable high contrast dark theme</string>
     <string name="settings_section_mark_all_as_read">Mark All As Read</string>
     <string name="settings_section_browser">Browser</string>


### PR DESCRIPTION
## What

Adds an opt-in **Volume keys turn pages** gesture (Settings → Gestures → Reader), aimed at e-ink devices:

- **Volume-down** pages the article forward ~90% of the viewport; **volume-up** pages back.
- At a scroll edge it **rolls to the next / previous article**.
- **Double-tap volume-up = Back**, dispatched through the normal back handler so it honors the existing back-action setting (close article / open drawer / navigate to parent).
- Also pages the **article list**.
- **Yields to audio** — while something is playing, the rocker still controls volume.
- **Off by default.**

## Why

On e-ink readers (Boox, etc.) the hardware volume rocker is the natural way to turn pages hands-free without touching the screen — screen taps/swipes cause ghosting, and physical page keys are a defining e-ink affordance (à la EinkBro). This is a frequently-requested pattern for reading apps on those devices.

## How it's built

- A small `VolumeKeyPager` singleton bridges `MainActivity.dispatchKeyEvent` (which consumes the volume keys only when the feature is active) to the reader/list scrollers registered from Compose.
- Discrete-press + repeat-count guards mean holding to page never misfires, and only volume-**up** double-taps trigger Back, so paging forward is always safe.
- Self-contained and independent of other features; ~230 lines, off by default.

Happy to adjust naming, the settings placement, the double-tap window, or gate it behind an "e-ink" section if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)