### PR TITLE
feat: read-aloud (TTS) via media3, with voice picker + offline fallback

### DIFF
--- a/app/src/main/java/com/capyreader/app/preferences/AppPreferences.kt
+++ b/app/src/main/java/com/capyreader/app/preferences/AppPreferences.kt
@@ -140,6 +140,10 @@ class AppPreferences(context: Context) {
 
         val readAloudPitch: Preference<Float>
             get() = preferenceStore.getFloat("article_read_aloud_pitch", 1.0f)
+
+        // Read-aloud voice by engine voice name; blank = automatic (best neural).
+        val readAloudVoice: Preference<String>
+            get() = preferenceStore.getString("article_read_aloud_voice")
     }
 
     class ArticleListOptions(private val preferenceStore: PreferenceStore) {

--- a/app/src/main/java/com/capyreader/app/preferences/AppPreferences.kt
+++ b/app/src/main/java/com/capyreader/app/preferences/AppPreferences.kt
@@ -134,6 +134,12 @@ class AppPreferences(context: Context) {
 
         val titleFollowsBodyFont: Preference<Boolean>
             get() = preferenceStore.getBoolean("article_title_follows_body_font", false)
+
+        val readAloudSpeed: Preference<Float>
+            get() = preferenceStore.getFloat("article_read_aloud_speed", 1.0f)
+
+        val readAloudPitch: Preference<Float>
+            get() = preferenceStore.getFloat("article_read_aloud_pitch", 1.0f)
     }
 
     class ArticleListOptions(private val preferenceStore: PreferenceStore) {

--- a/app/src/main/java/com/capyreader/app/ui/articles/audio/ArticleTextToSpeech.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/audio/ArticleTextToSpeech.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
+import android.speech.tts.Voice
 import androidx.core.text.HtmlCompat
 import com.jocmp.capy.logging.CapyLog
 import kotlinx.coroutines.CompletableDeferred
@@ -28,6 +29,13 @@ import java.util.concurrent.ConcurrentHashMap
 class ArticleTextToSpeech(context: Context) {
     private val ready = CompletableDeferred<Boolean>()
     private val pending = ConcurrentHashMap<String, CompletableDeferred<Boolean>>()
+
+    // Offline auto-fallback: if the chosen neural voice needs the network and a
+    // chunk fails to synthesize (e.g. reading offline), switch once to an
+    // on-device voice and retry, so read-aloud still works without a connection.
+    private var fallbackVoice: Voice? = null
+    private var chosenIsNetwork = false
+    private var fellBackToLocal = false
 
     private val tts = TextToSpeech(context.applicationContext) { status ->
         ready.complete(status == TextToSpeech.SUCCESS)
@@ -60,12 +68,73 @@ class ArticleTextToSpeech(context: Context) {
      * pitch (which affect every subsequent utterance). Returns false if the engine
      * failed to initialize. Call from a background dispatcher.
      */
-    suspend fun begin(speed: Float, pitch: Float): Boolean {
+    suspend fun begin(speed: Float, pitch: Float, voiceName: String = ""): Boolean {
         if (!ready.await()) return false
+        fellBackToLocal = false
         tts.language = Locale.getDefault()
+        applyBestVoice(Locale.getDefault(), voiceName)
         tts.setSpeechRate(speed)
         tts.setPitch(pitch)
         return true
+    }
+
+    /**
+     * Upgrade from the engine's default voice (usually a low-quality on-device
+     * pack) to a good neural voice. On Google TTS every English voice reports the
+     * same quality (HIGH), so [Voice.getQuality] can't rank them — the real split
+     * is the streamed `-network` (neural) voices vs the robotic `-local` ones,
+     * and the neural ones aren't selectable in Android's system TTS settings at
+     * all, only through this API.
+     *
+     * We pick deterministically: a curated neural voice from [PREFERRED_VOICES]
+     * if installed, else any installed network voice, else any installed voice
+     * for the reading language. `notInstalled` voices are skipped (their data
+     * isn't downloaded). The chosen neural voice needs a network connection at
+     * synthesis time — fine here since chunks are synthesized up front, so
+     * connectivity is only needed while generating, not while listening.
+     */
+    private fun applyBestVoice(preferred: Locale, preferredName: String) {
+        val voices = try {
+            tts.voices
+        } catch (e: Exception) {
+            CapyLog.warn("read_aloud_voices", mapOf("error" to e.message))
+            null
+        } ?: return
+
+        val lang = if (preferred.language.equals("en", true)) "en" else preferred.language
+        val installed = voices.filter {
+            it.locale.language.equals(lang, true) &&
+                it.features?.contains(NOT_INSTALLED) != true
+        }
+        if (installed.isEmpty()) return
+
+        val byName = installed.associateBy { it.name }
+        // The user's explicit pick wins (if still installed); otherwise auto-pick.
+        val chosen = byName[preferredName]
+            ?: PREFERRED_VOICES.firstNotNullOfOrNull { byName[it] }
+            ?: installed.filter { it.isNetworkConnectionRequired }.minByOrNull { it.name }
+            ?: installed.minByOrNull { it.name }
+            ?: return
+
+        // Offline fallback = the on-device twin of the chosen voice if present
+        // (its "-network" name with "-local"), else any installed local voice.
+        chosenIsNetwork = chosen.isNetworkConnectionRequired
+        fallbackVoice = if (chosenIsNetwork) {
+            byName[chosen.name.replace("-network", "-local")]
+                ?: installed.filterNot { it.isNetworkConnectionRequired }.minByOrNull { it.name }
+        } else {
+            null
+        }
+
+        val result = tts.setVoice(chosen)
+        CapyLog.info(
+            "read_aloud_voice",
+            mapOf(
+                "voice" to chosen.name,
+                "network" to chosen.isNetworkConnectionRequired.toString(),
+                "set" to result.toString(),
+            )
+        )
     }
 
     /**
@@ -85,7 +154,22 @@ class ArticleTextToSpeech(context: Context) {
             return null
         }
 
-        return if (deferred.await() && file.exists() && file.length() > 0) file else null
+        val ok = deferred.await() && file.exists() && file.length() > 0
+        if (ok) return file
+
+        // The network voice failed (likely offline). Fall back to the on-device
+        // voice once and retry this chunk; subsequent chunks reuse the local
+        // voice too, so a whole article still reads without connectivity.
+        if (chosenIsNetwork && !fellBackToLocal) {
+            val local = fallbackVoice
+            if (local != null) {
+                fellBackToLocal = true
+                tts.setVoice(local)
+                CapyLog.info("read_aloud_fallback", mapOf("voice" to local.name))
+                return synthesize(chunk, index, outputDir)
+            }
+        }
+        return null
     }
 
     fun shutdown() {
@@ -98,6 +182,23 @@ class ArticleTextToSpeech(context: Context) {
     companion object {
         // Stay under TextToSpeech.getMaxSpeechInputLength() (~4000).
         private const val MAX_CHUNK = 3500
+
+        private val NOT_INSTALLED = TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED
+
+        // Curated Google US-English neural (network) voices, best-first. All
+        // report the same quality metadata, so this order is by listening
+        // preference; the first one installed on the device wins. Falls back to
+        // any installed network voice if none of these are present.
+        private val PREFERRED_VOICES = listOf(
+            "en-us-x-iol-network",
+            "en-us-x-tpf-network",
+            "en-us-x-iog-network",
+            "en-us-x-iom-network",
+            "en-us-x-tpd-network",
+            "en-us-x-tpc-network",
+            "en-us-x-iob-network",
+            "en-us-x-sfg-network",
+        )
 
         fun plainText(html: String): String =
             HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_COMPACT)

--- a/app/src/main/java/com/capyreader/app/ui/articles/audio/ArticleTextToSpeech.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/audio/ArticleTextToSpeech.kt
@@ -1,0 +1,129 @@
+package com.capyreader.app.ui.articles.audio
+
+import android.content.Context
+import android.os.Bundle
+import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
+import androidx.core.text.HtmlCompat
+import com.jocmp.capy.logging.CapyLog
+import kotlinx.coroutines.CompletableDeferred
+import java.io.File
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Renders article text to audio files using the platform [TextToSpeech] engine.
+ *
+ * The article body is HTML, so it is converted to plain text and split into
+ * utterance-sized chunks (a single TTS utterance is capped at
+ * [TextToSpeech.getMaxSpeechInputLength], typically 4000 chars). Each chunk is
+ * synthesized to a WAV file via [TextToSpeech.synthesizeToFile]. Those files are
+ * then played back through the shared media3 pipeline ([MediaPlaybackService]),
+ * which is what gives read-aloud a MediaSession, notification/lock-screen
+ * controls, and screen-off/Doze survival.
+ *
+ * Speech rate and pitch are applied on the engine before synthesis, per
+ * [TextToSpeech.setSpeechRate] / [TextToSpeech.setPitch].
+ */
+class ArticleTextToSpeech(context: Context) {
+    private val ready = CompletableDeferred<Boolean>()
+    private val pending = ConcurrentHashMap<String, CompletableDeferred<Boolean>>()
+
+    private val tts = TextToSpeech(context.applicationContext) { status ->
+        ready.complete(status == TextToSpeech.SUCCESS)
+        if (status != TextToSpeech.SUCCESS) {
+            CapyLog.warn("read_aloud_init", mapOf("status" to status.toString()))
+        }
+    }
+
+    init {
+        tts.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
+            override fun onStart(utteranceId: String?) {}
+
+            override fun onDone(utteranceId: String?) {
+                pending.remove(utteranceId)?.complete(true)
+            }
+
+            @Deprecated("Deprecated in Java")
+            override fun onError(utteranceId: String?) {
+                pending.remove(utteranceId)?.complete(false)
+            }
+
+            override fun onError(utteranceId: String?, errorCode: Int) {
+                pending.remove(utteranceId)?.complete(false)
+            }
+        })
+    }
+
+    /**
+     * Prepare the engine for a read: wait for init, then apply language, rate and
+     * pitch (which affect every subsequent utterance). Returns false if the engine
+     * failed to initialize. Call from a background dispatcher.
+     */
+    suspend fun begin(speed: Float, pitch: Float): Boolean {
+        if (!ready.await()) return false
+        tts.language = Locale.getDefault()
+        tts.setSpeechRate(speed)
+        tts.setPitch(pitch)
+        return true
+    }
+
+    /**
+     * Synthesize a single chunk to [outputDir] and suspend until it is rendered.
+     * Returns the WAV file on success, or null on failure. This is what enables
+     * progressive playback: chunk 0 can play while later chunks render.
+     */
+    suspend fun synthesize(chunk: String, index: Int, outputDir: File): File? {
+        val utteranceId = "read_aloud_$index"
+        val file = File(outputDir, "read_aloud_$index.wav")
+        val deferred = CompletableDeferred<Boolean>()
+        pending[utteranceId] = deferred
+
+        val result = tts.synthesizeToFile(chunk, Bundle(), file, utteranceId)
+        if (result != TextToSpeech.SUCCESS) {
+            pending.remove(utteranceId)
+            return null
+        }
+
+        return if (deferred.await() && file.exists() && file.length() > 0) file else null
+    }
+
+    fun shutdown() {
+        pending.values.forEach { it.complete(false) }
+        pending.clear()
+        tts.stop()
+        tts.shutdown()
+    }
+
+    companion object {
+        // Stay under TextToSpeech.getMaxSpeechInputLength() (~4000).
+        private const val MAX_CHUNK = 3500
+
+        fun plainText(html: String): String =
+            HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_COMPACT)
+                .toString()
+                .replace(Regex("\\n{2,}"), "\n")
+                .trim()
+
+        /** Split into <= [MAX_CHUNK] pieces, breaking on sentence/whitespace boundaries. */
+        fun chunk(text: String): List<String> {
+            if (text.length <= MAX_CHUNK) {
+                return if (text.isBlank()) emptyList() else listOf(text)
+            }
+
+            val chunks = mutableListOf<String>()
+            var start = 0
+            while (start < text.length) {
+                var end = minOf(start + MAX_CHUNK, text.length)
+                if (end < text.length) {
+                    val boundary =
+                        text.lastIndexOfAny(charArrayOf('.', '!', '?', '\n', ' '), end - 1)
+                    if (boundary > start) end = boundary + 1
+                }
+                chunks.add(text.substring(start, end).trim())
+                start = end
+            }
+            return chunks.filter { it.isNotBlank() }
+        }
+    }
+}

--- a/app/src/main/java/com/capyreader/app/ui/articles/audio/AudioPlayerController.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/audio/AudioPlayerController.kt
@@ -2,6 +2,9 @@ package com.capyreader.app.ui.articles.audio
 
 import android.content.ComponentName
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
 import android.net.Uri
 import android.os.Looper
 import androidx.annotation.OptIn
@@ -12,6 +15,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
+import com.capyreader.app.R
 import com.capyreader.app.common.AudioEnclosure
 import com.google.common.util.concurrent.ListenableFuture
 import com.jocmp.capy.logging.CapyLog
@@ -24,6 +28,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+import java.io.File
+import kotlin.coroutines.resume
 
 class AudioPlayerController(
     private val context: Context,
@@ -31,10 +40,16 @@ class AudioPlayerController(
     private var controllerFuture: ListenableFuture<MediaController>? = null
     private var mediaController: MediaController? = null
     private var positionUpdateJob: Job? = null
+    private var synthJob: Job? = null
     private val mainScope = CoroutineScope(Dispatchers.Main)
+    private val synthesizer by lazy { ArticleTextToSpeech(context) }
 
     private val _isPlaying = MutableStateFlow(false)
     val isPlaying: StateFlow<Boolean> = _isPlaying.asStateFlow()
+
+    /** Non-null while the current media session is reading an article aloud (TTS). */
+    private val _currentReadAloudArticleId = MutableStateFlow<String?>(null)
+    val currentReadAloudArticleId: StateFlow<String?> = _currentReadAloudArticleId.asStateFlow()
 
     private val _currentPosition = MutableStateFlow(0L)
     val currentPosition: StateFlow<Long> = _currentPosition.asStateFlow()
@@ -75,6 +90,15 @@ class AudioPlayerController(
         }, ContextCompat.getMainExecutor(context))
     }
 
+    private suspend fun awaitController(): MediaController? =
+        suspendCancellableCoroutine { continuation ->
+            ensureController { controller ->
+                if (continuation.isActive) {
+                    continuation.resume(controller)
+                }
+            }
+        }
+
     private fun setupPlayerListener(controller: MediaController) {
         controller.addListener(object : Player.Listener {
             override fun onIsPlayingChanged(isPlaying: Boolean) {
@@ -88,7 +112,10 @@ class AudioPlayerController(
 
             override fun onPlaybackStateChanged(playbackState: Int) {
                 if (playbackState == Player.STATE_READY) {
-                    _duration.value = controller.duration
+                    val known = PlaylistTimeline.knownDuration(controller)
+                    if (known > 0) {
+                        _duration.value = known
+                    }
                 }
                 if (playbackState == Player.STATE_ENDED) {
                     _isPlaying.value = false
@@ -101,6 +128,8 @@ class AudioPlayerController(
     @OptIn(UnstableApi::class)
     fun play(audio: AudioEnclosure) {
         mainScope.launch {
+            synthJob?.cancel()
+            _currentReadAloudArticleId.value = null
             val currentUrl = _currentAudio.value?.url
 
             if (currentUrl == audio.url && mediaController?.isConnected == true) {
@@ -132,6 +161,165 @@ class AudioPlayerController(
         }
     }
 
+    /**
+     * Read an article aloud through the shared media session, loading progressively:
+     * chunk 0 is synthesized and playback starts immediately, then the remaining
+     * chunks render in the background and are appended to the playlist as they land
+     * (so playback begins without waiting for the whole article and the seek range
+     * grows over time). Playback runs through the media3 player, so it continues
+     * with the screen off and exposes notification/lock-screen controls. Always
+     * (re)starts from the beginning — call again with a new [speed]/[pitch] to
+     * restart at a different rate.
+     */
+    @OptIn(UnstableApi::class)
+    fun readAloud(
+        articleID: String,
+        title: String,
+        feedName: String,
+        artworkUrl: String?,
+        contentHTML: String,
+        speed: Float,
+        pitch: Float,
+    ) {
+        synthJob?.cancel()
+        synthJob = mainScope.launch {
+            clearMedia()
+
+            val chunks = ArticleTextToSpeech.chunk(ArticleTextToSpeech.plainText(contentHTML))
+            if (chunks.isEmpty()) return@launch
+
+            _currentReadAloudArticleId.value = articleID
+            _currentAudio.value = AudioEnclosure(
+                url = "tts:$articleID",
+                title = title,
+                feedName = feedName,
+                durationSeconds = null,
+                artworkUrl = artworkUrl,
+            )
+            // Surface as active while the first chunk synthesizes.
+            _isPlaying.value = true
+
+            val outputDir = ttsCacheDir().apply {
+                deleteRecursively()
+                mkdirs()
+            }
+
+            val ready = withContext(Dispatchers.IO) { synthesizer.begin(speed, pitch) }
+            if (!isActive || _currentReadAloudArticleId.value != articleID) return@launch
+            if (!ready) {
+                dismiss()
+                return@launch
+            }
+
+            val controller = awaitController()
+            if (controller == null || !isActive || _currentReadAloudArticleId.value != articleID) {
+                return@launch
+            }
+
+            var started = false
+            chunks.forEachIndexed { index, chunk ->
+                if (!isActive || _currentReadAloudArticleId.value != articleID) return@launch
+
+                val file = withContext(Dispatchers.IO) {
+                    synthesizer.synthesize(chunk, index, outputDir)
+                } ?: return@forEachIndexed
+
+                if (!isActive || _currentReadAloudArticleId.value != articleID) return@launch
+
+                controller.addMediaItem(mediaItemFor(file, title, feedName, artworkUrl))
+
+                if (!started) {
+                    controller.prepare()
+                    controller.playWhenReady = true
+                    started = true
+                }
+            }
+
+            if (!started) {
+                dismiss()
+            }
+        }
+    }
+
+    private fun mediaItemFor(
+        file: File,
+        title: String,
+        feedName: String,
+        artworkUrl: String?,
+    ): MediaItem {
+        val metadata = MediaMetadata.Builder()
+            .setTitle(title)
+            .setArtist(feedName)
+
+        if (artworkUrl != null) {
+            metadata.setArtworkUri(Uri.parse(artworkUrl))
+        } else {
+            // Articles without an image would otherwise fall back to the system
+            // default media-notification accent (blue), which renders as a dark,
+            // low-contrast gray on e-ink. Supply the capy on the app's warm
+            // launcher-icon background so the notification stays high-contrast.
+            defaultArtwork?.let { metadata.setArtworkData(it, MediaMetadata.PICTURE_TYPE_FRONT_COVER) }
+        }
+
+        return MediaItem.Builder()
+            .setUri(Uri.fromFile(file))
+            .setMediaMetadata(metadata.build())
+            .build()
+    }
+
+    /** The capy on the app's warm launcher-icon background (#E2D4B0), as PNG bytes. */
+    private val defaultArtwork: ByteArray? by lazy { buildDefaultArtwork() }
+
+    private fun buildDefaultArtwork(): ByteArray? = try {
+        val size = 512
+        val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(Color.parseColor("#E2D4B0"))
+        ContextCompat.getDrawable(context, R.drawable.ic_launcher_foreground)?.let { capy ->
+            val inset = (size * 0.14f).toInt()
+            capy.setBounds(inset, inset, size - inset, size - inset)
+            capy.draw(canvas)
+        }
+        ByteArrayOutputStream().use { stream ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
+            stream.toByteArray()
+        }
+    } catch (e: Exception) {
+        CapyLog.error("read_aloud_artwork", e)
+        null
+    }
+
+    /** Stop reading aloud if the active session is a TTS read (leaves podcasts alone). */
+    fun stopReadAloud() {
+        if (_currentReadAloudArticleId.value != null) {
+            dismiss()
+        }
+    }
+
+    /** Stop an active read-aloud unless it belongs to [articleID] (used on article change). */
+    fun stopReadAloudIfNot(articleID: String?) {
+        val current = _currentReadAloudArticleId.value ?: return
+        if (current != articleID) {
+            dismiss()
+        }
+    }
+
+    private fun ttsCacheDir(): File = File(context.cacheDir, "read_aloud")
+
+    private suspend fun clearMedia() {
+        mediaController?.let { controller ->
+            if (controller.isConnected) {
+                controller.stop()
+                controller.clearMediaItems()
+            }
+        }
+        _currentAudio.value = null
+        _currentReadAloudArticleId.value = null
+        _isPlaying.value = false
+        _currentPosition.value = 0L
+        _duration.value = 0L
+    }
+
     fun pause() {
         mainScope.launch {
             mediaController?.pause()
@@ -144,19 +332,21 @@ class AudioPlayerController(
         }
     }
 
+    /** Seek to a global position that spans every synthesized chunk. */
     fun seekTo(positionMs: Long) {
         mainScope.launch {
-            mediaController?.seekTo(positionMs)
-            _currentPosition.value = positionMs
+            mediaController?.let { controller ->
+                PlaylistTimeline.seekToGlobal(controller, positionMs)
+                _currentPosition.value = PlaylistTimeline.globalPosition(controller)
+            }
         }
     }
 
     fun skipBack() {
         mainScope.launch {
             mediaController?.let { controller ->
-                val newPosition = SkipCalculator.skipBack(controller.currentPosition)
-                controller.seekTo(newPosition)
-                _currentPosition.value = newPosition
+                PlaylistTimeline.skip(controller, -SKIP_INTERVAL_MS)
+                _currentPosition.value = PlaylistTimeline.globalPosition(controller)
             }
         }
     }
@@ -164,28 +354,31 @@ class AudioPlayerController(
     fun skipForward() {
         mainScope.launch {
             mediaController?.let { controller ->
-                val newPosition = SkipCalculator.skipForward(controller.currentPosition, controller.duration)
-                controller.seekTo(newPosition)
-                _currentPosition.value = newPosition
+                PlaylistTimeline.skip(controller, SKIP_INTERVAL_MS)
+                _currentPosition.value = PlaylistTimeline.globalPosition(controller)
             }
         }
     }
 
     fun dismiss() {
+        synthJob?.cancel()
         mainScope.launch {
             mediaController?.let { controller ->
                 controller.stop()
                 controller.clearMediaItems()
             }
             _currentAudio.value = null
+            _currentReadAloudArticleId.value = null
             _isPlaying.value = false
             _currentPosition.value = 0L
             _duration.value = 0L
+            ttsCacheDir().deleteRecursively()
         }
     }
 
     fun release() {
         stopPositionUpdates()
+        synthJob?.cancel()
         controllerFuture?.let {
             MediaController.releaseFuture(it)
         }
@@ -198,9 +391,10 @@ class AudioPlayerController(
         positionUpdateJob = mainScope.launch {
             while (isActive) {
                 mediaController?.let {
-                    _currentPosition.value = it.currentPosition
-                    if (_duration.value == 0L && it.duration > 0) {
-                        _duration.value = it.duration
+                    _currentPosition.value = PlaylistTimeline.globalPosition(it)
+                    val known = PlaylistTimeline.knownDuration(it)
+                    if (known > 0) {
+                        _duration.value = known
                     }
                 }
                 delay(500)
@@ -211,5 +405,9 @@ class AudioPlayerController(
     private fun stopPositionUpdates() {
         positionUpdateJob?.cancel()
         positionUpdateJob = null
+    }
+
+    companion object {
+        private const val SKIP_INTERVAL_MS = 10_000L
     }
 }

--- a/app/src/main/java/com/capyreader/app/ui/articles/audio/AudioPlayerController.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/audio/AudioPlayerController.kt
@@ -180,6 +180,7 @@ class AudioPlayerController(
         contentHTML: String,
         speed: Float,
         pitch: Float,
+        voiceName: String = "",
     ) {
         synthJob?.cancel()
         synthJob = mainScope.launch {
@@ -204,7 +205,7 @@ class AudioPlayerController(
                 mkdirs()
             }
 
-            val ready = withContext(Dispatchers.IO) { synthesizer.begin(speed, pitch) }
+            val ready = withContext(Dispatchers.IO) { synthesizer.begin(speed, pitch, voiceName) }
             if (!isActive || _currentReadAloudArticleId.value != articleID) return@launch
             if (!ready) {
                 dismiss()

--- a/app/src/main/java/com/capyreader/app/ui/articles/audio/FloatingAudioPlayer.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/audio/FloatingAudioPlayer.kt
@@ -18,9 +18,11 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Forward10
 import androidx.compose.material.icons.rounded.Headphones
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Replay10
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -65,6 +67,8 @@ fun FloatingAudioPlayer(
         duration = duration,
         onPlayPause = { if (isPlaying) controller.pause() else controller.resume() },
         onSeek = { controller.seekTo(it) },
+        onSkipBack = { controller.skipBack() },
+        onSkipForward = { controller.skipForward() },
         onDismiss = onDismiss,
         modifier = modifier,
     )
@@ -79,6 +83,8 @@ internal fun FloatingAudioPlayer(
     duration: Long,
     onPlayPause: () -> Unit,
     onSeek: (Long) -> Unit,
+    onSkipBack: () -> Unit = {},
+    onSkipForward: () -> Unit = {},
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -140,11 +146,27 @@ internal fun FloatingAudioPlayer(
                     )
                 }
 
+                IconButton(onClick = onSkipBack) {
+                    Icon(
+                        imageVector = Icons.Rounded.Replay10,
+                        contentDescription = stringResource(R.string.audio_player_skip_back),
+                        modifier = Modifier.size(28.dp),
+                    )
+                }
+
                 IconButton(onClick = onPlayPause) {
                     Icon(
                         imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
                         contentDescription = stringResource(if (isPlaying) R.string.audio_player_pause else R.string.audio_player_play),
                         modifier = Modifier.size(32.dp),
+                    )
+                }
+
+                IconButton(onClick = onSkipForward) {
+                    Icon(
+                        imageVector = Icons.Rounded.Forward10,
+                        contentDescription = stringResource(R.string.audio_player_skip_forward),
+                        modifier = Modifier.size(28.dp),
                     )
                 }
 

--- a/app/src/main/java/com/capyreader/app/ui/articles/audio/MediaPlaybackService.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/audio/MediaPlaybackService.kt
@@ -9,6 +9,7 @@ import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.database.StandaloneDatabaseProvider
+import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
 import androidx.media3.datasource.cache.SimpleCache
@@ -59,8 +60,12 @@ class MediaPlaybackService : MediaSessionService() {
                 }
             }
 
+        // Route http(s) through the OkHttp cache pipeline, but handle local
+        // file:// URIs (synthesized read-aloud audio) with the built-in file source.
+        val dataSourceFactory = DefaultDataSource.Factory(this, cacheDataSourceFactory)
+
         val mediaSourceFactory = DefaultMediaSourceFactory(this)
-            .setDataSourceFactory(cacheDataSourceFactory)
+            .setDataSourceFactory(dataSourceFactory)
 
         val exoPlayer = ExoPlayer.Builder(this)
             .setMediaSourceFactory(mediaSourceFactory)
@@ -165,15 +170,13 @@ class MediaPlaybackService : MediaSessionService() {
         ): ListenableFuture<SessionResult> {
             val player = session.player
             when (customCommand.customAction) {
-                CUSTOM_COMMAND_SKIP_BACK -> {
-                    val newPosition = SkipCalculator.skipBack(player.currentPosition)
-                    player.seekTo(newPosition)
-                }
+                // Timeline-aware so notification skips cross chunk boundaries on
+                // read-aloud playlists; single-item podcasts behave as before.
+                CUSTOM_COMMAND_SKIP_BACK ->
+                    PlaylistTimeline.skip(player, -SkipCalculator.SKIP_DURATION_MS)
 
-                CUSTOM_COMMAND_SKIP_FORWARD -> {
-                    val newPosition = SkipCalculator.skipForward(player.currentPosition, player.duration)
-                    player.seekTo(newPosition)
-                }
+                CUSTOM_COMMAND_SKIP_FORWARD ->
+                    PlaylistTimeline.skip(player, SkipCalculator.SKIP_DURATION_MS)
             }
             return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
         }

--- a/app/src/main/java/com/capyreader/app/ui/articles/audio/PlaylistTimeline.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/audio/PlaylistTimeline.kt
@@ -1,0 +1,76 @@
+package com.capyreader.app.ui.articles.audio
+
+import androidx.media3.common.C
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline
+
+/**
+ * Helpers that treat a media3 playlist (multiple [Player] windows) as one
+ * continuous timeline. Read-aloud plays each synthesized chunk as its own
+ * MediaItem, so position, duration, seeking and ±skip need to span every chunk
+ * rather than stopping at a chunk boundary.
+ *
+ * All functions operate on any [Player] (both the ExoPlayer inside
+ * [MediaPlaybackService] and the [androidx.media3.session.MediaController] the
+ * app holds), so single-item podcasts behave exactly as before.
+ */
+object PlaylistTimeline {
+    /** Elapsed position across the whole playlist, in ms. */
+    fun globalPosition(player: Player): Long {
+        val timeline = player.currentTimeline
+        if (timeline.isEmpty) return player.currentPosition.coerceAtLeast(0)
+
+        val window = Timeline.Window()
+        val priorWindows = (0 until player.currentMediaItemIndex).sumOf { index ->
+            timeline.getWindow(index, window)
+            if (window.durationMs != C.TIME_UNSET) window.durationMs else 0L
+        }
+        return priorWindows + player.currentPosition.coerceAtLeast(0)
+    }
+
+    /** Total duration of all windows whose duration is known so far, in ms. */
+    fun knownDuration(player: Player): Long {
+        val timeline = player.currentTimeline
+        if (timeline.isEmpty) {
+            val duration = player.duration
+            return if (duration == C.TIME_UNSET) 0 else duration
+        }
+
+        val window = Timeline.Window()
+        return (0 until timeline.windowCount).sumOf { index ->
+            timeline.getWindow(index, window)
+            if (window.durationMs != C.TIME_UNSET) window.durationMs else 0L
+        }
+    }
+
+    /** Seek to a global position, mapping it onto the correct window + offset. */
+    fun seekToGlobal(player: Player, globalMs: Long) {
+        val timeline = player.currentTimeline
+        if (timeline.isEmpty) {
+            player.seekTo(globalMs.coerceAtLeast(0))
+            return
+        }
+
+        val window = Timeline.Window()
+        var remaining = globalMs.coerceAtLeast(0)
+        val lastIndex = timeline.windowCount - 1
+        for (i in 0..lastIndex) {
+            timeline.getWindow(i, window)
+            val duration = window.durationMs
+            if (duration == C.TIME_UNSET || remaining < duration || i == lastIndex) {
+                val offset =
+                    if (duration == C.TIME_UNSET) remaining else remaining.coerceAtMost(duration)
+                player.seekTo(i, offset)
+                return
+            }
+            remaining -= duration
+        }
+    }
+
+    /** Skip by [deltaMs] across the whole timeline, clamped to the known range. */
+    fun skip(player: Player, deltaMs: Long) {
+        val known = knownDuration(player).coerceAtLeast(0)
+        val target = (globalPosition(player) + deltaMs).coerceIn(0, known)
+        seekToGlobal(player, target)
+    }
+}

--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleTopBar.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleTopBar.kt
@@ -19,7 +19,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Label
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.FormatSize
+import androidx.compose.material.icons.outlined.Forward10
+import androidx.compose.material.icons.outlined.Pause
+import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.material.icons.outlined.RecordVoiceOver
+import androidx.compose.material.icons.outlined.Replay10
 import androidx.compose.material.icons.outlined.Save
+import androidx.compose.material.icons.outlined.Stop
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -63,6 +69,17 @@ fun ArticleTopBar(
     onDeletePage: () -> Unit = {},
     isFullscreen: Boolean = false,
     onToggleFullscreen: () -> Unit = {},
+    isReadingAloud: Boolean = false,
+    isReadAloudPlaying: Boolean = false,
+    onStartReadAloud: () -> Unit = {},
+    onPlayPauseReadAloud: () -> Unit = {},
+    onStopReadAloud: () -> Unit = {},
+    onSkipBackReadAloud: () -> Unit = {},
+    onSkipForwardReadAloud: () -> Unit = {},
+    readAloudSpeed: Float = 1.0f,
+    readAloudPitch: Float = 1.0f,
+    onSelectReadAloudSpeed: (Float) -> Unit = {},
+    onSelectReadAloudPitch: (Float) -> Unit = {},
     onClose: () -> Unit,
 ) {
     val containerColor = MaterialTheme.colorScheme.surface
@@ -160,6 +177,70 @@ fun ArticleTopBar(
                                 }
                             }
                         }
+                        if (isReadingAloud) {
+                            val skipBackLabel = stringResource(R.string.audio_player_skip_back)
+                            ToolbarTooltip(message = skipBackLabel) {
+                                IconButton(onClick = onSkipBackReadAloud) {
+                                    Icon(
+                                        Icons.Outlined.Replay10,
+                                        contentDescription = skipBackLabel,
+                                        modifier = Modifier.size(24.dp)
+                                    )
+                                }
+                            }
+                            val playPauseLabel = stringResource(
+                                if (isReadAloudPlaying) R.string.audio_player_pause
+                                else R.string.audio_player_play
+                            )
+                            ToolbarTooltip(message = playPauseLabel) {
+                                IconButton(onClick = onPlayPauseReadAloud) {
+                                    Icon(
+                                        if (isReadAloudPlaying) Icons.Outlined.Pause
+                                        else Icons.Outlined.PlayArrow,
+                                        contentDescription = playPauseLabel,
+                                        modifier = Modifier.size(24.dp)
+                                    )
+                                }
+                            }
+                            val skipForwardLabel = stringResource(R.string.audio_player_skip_forward)
+                            ToolbarTooltip(message = skipForwardLabel) {
+                                IconButton(onClick = onSkipForwardReadAloud) {
+                                    Icon(
+                                        Icons.Outlined.Forward10,
+                                        contentDescription = skipForwardLabel,
+                                        modifier = Modifier.size(24.dp)
+                                    )
+                                }
+                            }
+                            val stopLabel = stringResource(R.string.article_actions_read_aloud_stop)
+                            ToolbarTooltip(message = stopLabel) {
+                                IconButton(onClick = onStopReadAloud) {
+                                    Icon(
+                                        Icons.Outlined.Stop,
+                                        contentDescription = stopLabel,
+                                        modifier = Modifier.size(24.dp)
+                                    )
+                                }
+                            }
+                        } else {
+                            val readAloudLabel =
+                                stringResource(R.string.article_actions_read_aloud)
+                            ToolbarTooltip(message = readAloudLabel) {
+                                IconButton(onClick = onStartReadAloud) {
+                                    Icon(
+                                        Icons.Outlined.RecordVoiceOver,
+                                        contentDescription = readAloudLabel,
+                                        modifier = Modifier.size(24.dp)
+                                    )
+                                }
+                            }
+                        }
+                        ReadAloudSpeedMenu(
+                            speed = readAloudSpeed,
+                            pitch = readAloudPitch,
+                            onSelectSpeed = onSelectReadAloudSpeed,
+                            onSelectPitch = onSelectReadAloudPitch,
+                        )
                         ToolbarTooltip(
                             message = stringResource(R.string.article_style_options)
                         ) {

--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleTopBar.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleTopBar.kt
@@ -78,8 +78,10 @@ fun ArticleTopBar(
     onSkipForwardReadAloud: () -> Unit = {},
     readAloudSpeed: Float = 1.0f,
     readAloudPitch: Float = 1.0f,
+    readAloudVoice: String = "",
     onSelectReadAloudSpeed: (Float) -> Unit = {},
     onSelectReadAloudPitch: (Float) -> Unit = {},
+    onSelectReadAloudVoice: (String) -> Unit = {},
     onClose: () -> Unit,
 ) {
     val containerColor = MaterialTheme.colorScheme.surface
@@ -238,8 +240,10 @@ fun ArticleTopBar(
                         ReadAloudSpeedMenu(
                             speed = readAloudSpeed,
                             pitch = readAloudPitch,
+                            voice = readAloudVoice,
                             onSelectSpeed = onSelectReadAloudSpeed,
                             onSelectPitch = onSelectReadAloudPitch,
+                            onSelectVoice = onSelectReadAloudVoice,
                         )
                         ToolbarTooltip(
                             message = stringResource(R.string.article_style_options)

--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleView.kt
@@ -41,10 +41,12 @@ import com.capyreader.app.preferences.ArticleVerticalSwipe.OPEN_ARTICLE_IN_BROWS
 import com.capyreader.app.preferences.ArticleVerticalSwipe.PREVIOUS_ARTICLE
 import com.capyreader.app.ui.LocalLinkOpener
 import com.capyreader.app.ui.articles.LocalFullContent
+import com.capyreader.app.ui.articles.audio.AudioPlayerController
 import com.capyreader.app.ui.collectChangesWithDefault
 import com.capyreader.app.ui.components.pullrefresh.SwipeRefresh
 import com.capyreader.app.ui.components.LocalSnackbarHost
 import com.jocmp.capy.Article
+import androidx.compose.runtime.collectAsState
 import org.koin.compose.koinInject
 
 @Composable
@@ -131,6 +133,30 @@ fun ArticleView(
 
     val snackbarHostState = remember { SnackbarHostState() }
 
+    val audioController: AudioPlayerController = koinInject()
+    val readAloudArticleId by audioController.currentReadAloudArticleId.collectAsState()
+    val isReadingAloud = readAloudArticleId == article.id
+    val isReadAloudPlaying by audioController.isPlaying.collectAsState()
+    val readAloudSpeed by appPreferences.readerOptions.readAloudSpeed.collectChangesWithDefault()
+    val readAloudPitch by appPreferences.readerOptions.readAloudPitch.collectChangesWithDefault()
+
+    fun startReadAloud(speed: Float, pitch: Float) {
+        audioController.readAloud(
+            articleID = article.id,
+            title = article.title,
+            feedName = article.feedName,
+            artworkUrl = article.imageURL,
+            contentHTML = article.content,
+            speed = speed,
+            pitch = pitch,
+        )
+    }
+
+    // Stop reading aloud when navigating away to a different article.
+    LaunchedEffect(article.id) {
+        audioController.stopReadAloudIfNot(article.id)
+    }
+
     val contentPadding = rememberContentPadding(pinToolbars)
 
     CompositionLocalProvider(
@@ -187,6 +213,25 @@ fun ArticleView(
                 onDeletePage = onDeletePage,
                 isFullscreen = isFullscreen,
                 onToggleFullscreen = onToggleFullscreen,
+                isReadingAloud = isReadingAloud,
+                isReadAloudPlaying = isReadAloudPlaying,
+                onStartReadAloud = { startReadAloud(readAloudSpeed, readAloudPitch) },
+                onPlayPauseReadAloud = {
+                    if (isReadAloudPlaying) audioController.pause() else audioController.resume()
+                },
+                onStopReadAloud = { audioController.stopReadAloud() },
+                onSkipBackReadAloud = { audioController.skipBack() },
+                onSkipForwardReadAloud = { audioController.skipForward() },
+                readAloudSpeed = readAloudSpeed,
+                readAloudPitch = readAloudPitch,
+                onSelectReadAloudSpeed = { speed ->
+                    appPreferences.readerOptions.readAloudSpeed.set(speed)
+                    if (isReadingAloud) startReadAloud(speed, readAloudPitch)
+                },
+                onSelectReadAloudPitch = { pitch ->
+                    appPreferences.readerOptions.readAloudPitch.set(pitch)
+                    if (isReadingAloud) startReadAloud(readAloudSpeed, pitch)
+                },
                 onClose = onBackPressed,
             )
 

--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleView.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/ArticleView.kt
@@ -139,8 +139,9 @@ fun ArticleView(
     val isReadAloudPlaying by audioController.isPlaying.collectAsState()
     val readAloudSpeed by appPreferences.readerOptions.readAloudSpeed.collectChangesWithDefault()
     val readAloudPitch by appPreferences.readerOptions.readAloudPitch.collectChangesWithDefault()
+    val readAloudVoice by appPreferences.readerOptions.readAloudVoice.collectChangesWithDefault()
 
-    fun startReadAloud(speed: Float, pitch: Float) {
+    fun startReadAloud(speed: Float, pitch: Float, voice: String) {
         audioController.readAloud(
             articleID = article.id,
             title = article.title,
@@ -149,6 +150,7 @@ fun ArticleView(
             contentHTML = article.content,
             speed = speed,
             pitch = pitch,
+            voiceName = voice,
         )
     }
 
@@ -215,7 +217,7 @@ fun ArticleView(
                 onToggleFullscreen = onToggleFullscreen,
                 isReadingAloud = isReadingAloud,
                 isReadAloudPlaying = isReadAloudPlaying,
-                onStartReadAloud = { startReadAloud(readAloudSpeed, readAloudPitch) },
+                onStartReadAloud = { startReadAloud(readAloudSpeed, readAloudPitch, readAloudVoice) },
                 onPlayPauseReadAloud = {
                     if (isReadAloudPlaying) audioController.pause() else audioController.resume()
                 },
@@ -224,13 +226,18 @@ fun ArticleView(
                 onSkipForwardReadAloud = { audioController.skipForward() },
                 readAloudSpeed = readAloudSpeed,
                 readAloudPitch = readAloudPitch,
+                readAloudVoice = readAloudVoice,
                 onSelectReadAloudSpeed = { speed ->
                     appPreferences.readerOptions.readAloudSpeed.set(speed)
-                    if (isReadingAloud) startReadAloud(speed, readAloudPitch)
+                    if (isReadingAloud) startReadAloud(speed, readAloudPitch, readAloudVoice)
                 },
                 onSelectReadAloudPitch = { pitch ->
                     appPreferences.readerOptions.readAloudPitch.set(pitch)
-                    if (isReadingAloud) startReadAloud(readAloudSpeed, pitch)
+                    if (isReadingAloud) startReadAloud(readAloudSpeed, pitch, readAloudVoice)
+                },
+                onSelectReadAloudVoice = { voice ->
+                    appPreferences.readerOptions.readAloudVoice.set(voice)
+                    if (isReadingAloud) startReadAloud(readAloudSpeed, readAloudPitch, voice)
                 },
                 onClose = onBackPressed,
             )

--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/ReadAloudSpeedMenu.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/ReadAloudSpeedMenu.kt
@@ -13,16 +13,21 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import android.speech.tts.TextToSpeech
+import android.speech.tts.Voice
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.capyreader.app.R
 import com.capyreader.app.ui.components.ToolbarTooltip
+import kotlinx.coroutines.CompletableDeferred
 
 private val SPEED_OPTIONS = listOf(0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f)
 
@@ -40,8 +45,10 @@ private val PITCH_OPTIONS = listOf(
 fun ReadAloudSpeedMenu(
     speed: Float,
     pitch: Float,
+    voice: String,
     onSelectSpeed: (Float) -> Unit,
     onSelectPitch: (Float) -> Unit,
+    onSelectVoice: (String) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val label = stringResource(R.string.read_aloud_speed)
@@ -104,8 +111,94 @@ fun ReadAloudSpeedMenu(
                     },
                 )
             }
+
+            HorizontalDivider()
+
+            Text(
+                text = stringResource(R.string.read_aloud_voice),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.read_aloud_voice_automatic)) },
+                trailingIcon = {
+                    if (voice.isBlank()) {
+                        Icon(Icons.Outlined.Check, contentDescription = null)
+                    }
+                },
+                onClick = {
+                    onSelectVoice("")
+                    expanded = false
+                },
+            )
+            // Enumerated only while the menu is open (see rememberReadAloudVoices).
+            rememberReadAloudVoices().forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option.label) },
+                    trailingIcon = {
+                        if (option.name == voice) {
+                            Icon(Icons.Outlined.Check, contentDescription = null)
+                        }
+                    },
+                    onClick = {
+                        onSelectVoice(option.name)
+                        expanded = false
+                    },
+                )
+            }
         }
     }
+}
+
+private data class VoiceOption(val name: String, val label: String, val network: Boolean)
+
+/**
+ * Installed English TTS voices for the picker. Spins up a short-lived
+ * [TextToSpeech] to enumerate voices and shuts it down when the menu closes, so
+ * there's no always-on engine. Neural (network) voices are listed first;
+ * `notInstalled` voices are skipped. Returns empty until the engine has bound.
+ */
+@Composable
+private fun rememberReadAloudVoices(): List<VoiceOption> {
+    val context = LocalContext.current
+    val voices by produceState(initialValue = emptyList<VoiceOption>()) {
+        var engine: TextToSpeech? = null
+        val result = CompletableDeferred<List<VoiceOption>>()
+        engine = TextToSpeech(context.applicationContext) { status ->
+            val tts = engine
+            val list = if (status == TextToSpeech.SUCCESS && tts != null) {
+                runCatching { tts.voices }.getOrNull().orEmpty()
+                    .filter {
+                        it.locale.language.equals("en", true) &&
+                            it.features?.contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED) != true
+                    }
+                    .map { VoiceOption(it.name, voiceLabel(it), it.isNetworkConnectionRequired) }
+                    .distinctBy { it.name }
+                    .sortedWith(compareByDescending<VoiceOption> { it.network }.thenBy { it.label })
+            } else {
+                emptyList()
+            }
+            result.complete(list)
+        }
+        value = result.await()
+        awaitDispose { engine?.shutdown() }
+    }
+    return voices
+}
+
+private fun voiceLabel(voice: Voice): String {
+    val country = when (voice.locale.country.uppercase()) {
+        "US" -> "US"
+        "GB" -> "UK"
+        "AU" -> "Australia"
+        "IN" -> "India"
+        "NG" -> "Nigeria"
+        else -> voice.locale.country.ifBlank { "English" }
+    }
+    val kind = if (voice.isNetworkConnectionRequired) "Neural" else "On-device"
+    val variant = voice.name.substringAfter("-x-", "").substringBefore("-")
+    return if (variant.isBlank()) "$country · $kind" else "$country · $kind ($variant)"
 }
 
 private fun formatSpeed(speed: Float): String {

--- a/app/src/main/java/com/capyreader/app/ui/articles/detail/ReadAloudSpeedMenu.kt
+++ b/app/src/main/java/com/capyreader/app/ui/articles/detail/ReadAloudSpeedMenu.kt
@@ -1,0 +1,114 @@
+package com.capyreader.app.ui.articles.detail
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.Speed
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.capyreader.app.R
+import com.capyreader.app.ui.components.ToolbarTooltip
+
+private val SPEED_OPTIONS = listOf(0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f)
+
+private val PITCH_OPTIONS = listOf(
+    R.string.read_aloud_pitch_low to 0.8f,
+    R.string.read_aloud_pitch_normal to 1.0f,
+    R.string.read_aloud_pitch_high to 1.2f,
+)
+
+/**
+ * Toolbar control for read-aloud playback speed (and pitch). Opens a dropdown of
+ * speed multipliers plus a pitch selector. Selections are persisted by the caller.
+ */
+@Composable
+fun ReadAloudSpeedMenu(
+    speed: Float,
+    pitch: Float,
+    onSelectSpeed: (Float) -> Unit,
+    onSelectPitch: (Float) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val label = stringResource(R.string.read_aloud_speed)
+
+    Box {
+        ToolbarTooltip(message = label) {
+            IconButton(onClick = { expanded = true }) {
+                Icon(
+                    Icons.Outlined.Speed,
+                    contentDescription = label,
+                    modifier = Modifier.size(24.dp),
+                )
+            }
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+            SPEED_OPTIONS.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(formatSpeed(option)) },
+                    trailingIcon = {
+                        if (option == speed) {
+                            Icon(Icons.Outlined.Check, contentDescription = null)
+                        }
+                    },
+                    onClick = {
+                        onSelectSpeed(option)
+                        expanded = false
+                    },
+                )
+            }
+
+            HorizontalDivider()
+
+            Text(
+                text = stringResource(R.string.read_aloud_pitch),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+            PITCH_OPTIONS.forEach { (labelRes, option) ->
+                DropdownMenuItem(
+                    text = { Text(stringResource(labelRes)) },
+                    trailingIcon = {
+                        if (option == pitch) {
+                            Icon(Icons.Outlined.Check, contentDescription = null)
+                        }
+                    },
+                    onClick = {
+                        onSelectPitch(option)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+private fun formatSpeed(speed: Float): String {
+    val text = if (speed % 1f == 0f) speed.toInt().toString() else speed.toString()
+    return "${text}×"
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -358,6 +358,13 @@
     <string name="badge_style_simple">Simple</string>
     <string name="badge_style_exact">Exact</string>
     <string name="show_unread_badge">Show Unread Badge</string>
+    <string name="article_actions_read_aloud">Read aloud</string>
+    <string name="article_actions_read_aloud_stop">Stop reading</string>
+    <string name="read_aloud_speed">Speed</string>
+    <string name="read_aloud_pitch">Pitch</string>
+    <string name="read_aloud_pitch_low">Low</string>
+    <string name="read_aloud_pitch_normal">Normal</string>
+    <string name="read_aloud_pitch_high">High</string>
     <string name="article_actions_save_externally">Save</string>
     <string name="article_actions_save_externally_success">Saved</string>
     <string name="article_actions_save_externally_failure">Failed to save</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -365,6 +365,8 @@
     <string name="read_aloud_pitch_low">Low</string>
     <string name="read_aloud_pitch_normal">Normal</string>
     <string name="read_aloud_pitch_high">High</string>
+    <string name="read_aloud_voice">Voice</string>
+    <string name="read_aloud_voice_automatic">Automatic (best)</string>
     <string name="article_actions_save_externally">Save</string>
     <string name="article_actions_save_externally_success">Saved</string>
     <string name="article_actions_save_externally_failure">Failed to save</string>


### PR DESCRIPTION
## What

Text-to-speech read-aloud for articles, played through the app's existing **media3** pipeline (so it inherits the MediaSession, notification/lock-screen controls, and screen-off playback — same stack as podcast enclosures):

- Article toolbar action → reads the article aloud. HTML → plain text → chunked → `TextToSpeech.synthesizeToFile()` → WAV → media3.
- **Progressive**: plays chunk 0 while the rest synthesize.
- Transport: ⏪10 · play/pause · ⏩10 · stop, plus **speed** (0.75×–2×) and **pitch** selectors (persisted). Also ungates the ±10s skip for regular podcast playback.
- **Auto-picks the best voice** — on Google TTS every English voice reports the same "quality", so it prefers a neural (network) voice and skips `notInstalled` ones. This matters because Android's *system* TTS settings can't select the neural voices at all.
- **In-app voice picker** in the read-aloud menu (Automatic + installed voices, neural first), enumerated lazily only while the menu is open.
- **Offline auto-fallback**: if a network voice fails to synthesize offline, it switches once to the on-device voice and retries.

## Note on #1298

I know read-aloud was marked **Not planned** in #1298 — no worries at all if that's still the call, and feel free to close this. I built it out for my own e-ink use and figured a complete, working implementation (reusing the existing media3 stack rather than adding a parallel audio path, and off-by-nothing since it's just a new toolbar action) might be worth a second look, or at least useful reference for anyone who wants it. Totally your call on scope/maintenance appetite.

Split out from a companion PR (volume-key paging) so each stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)