### PR TITLE
Chunk sync-status IDs to stay under SQLite's variable limit

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/persistence/SyncStatusRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/SyncStatusRecords.kt
@@ -4,6 +4,12 @@ import com.jocmp.capy.SyncStatus
 import com.jocmp.capy.common.transactionWithErrorHandling
 import com.jocmp.capy.db.Database
 
+// SQLite's SQLITE_MAX_VARIABLE_NUMBER is 999 on the engine bundled with Android
+// (< 3.32). An IN-clause with more bound IDs than that fails to even compile
+// ("too many SQL variables"), which on a large account crashed every sync. Chunk
+// the ID list below the limit, leaving headroom for the extra "key" bind param.
+private const val SQL_VARIABLE_CHUNK = 500
+
 class SyncStatusRecords(
     private val database: Database
 ) {
@@ -41,13 +47,21 @@ class SyncStatusRecords(
     fun deleteSelected(articleIDs: List<String>, key: SyncStatus.Key) {
         if (articleIDs.isEmpty()) return
 
-        queries.deleteSelectedByID(articleIDs = articleIDs.toList(), key = key.raw)
+        database.transactionWithErrorHandling {
+            articleIDs.chunked(SQL_VARIABLE_CHUNK).forEach { chunk ->
+                queries.deleteSelectedByID(articleIDs = chunk, key = key.raw)
+            }
+        }
     }
 
     fun resetSelected(articleIDs: List<String>, key: SyncStatus.Key) {
         if (articleIDs.isEmpty()) return
 
-        queries.resetSelectedByID(articleIDs = articleIDs.toList(), key = key.raw)
+        database.transactionWithErrorHandling {
+            articleIDs.chunked(SQL_VARIABLE_CHUNK).forEach { chunk ->
+                queries.resetSelectedByID(articleIDs = chunk, key = key.raw)
+            }
+        }
     }
 
     fun pendingCount(): Long {


### PR DESCRIPTION
## Problem

On an account with a large backlog of queued read/unread changes, the app crashes on **every** sync (so it never recovers):

```
android.database.sqlite.SQLiteException: too many SQL variables (code 1 SQLITE_ERROR):
DELETE FROM article_sync_statuses WHERE selected = 1 AND article_id IN (?,?,… >999 …) AND "key" = ?
    at com.jocmp.capy.db.ArticleSyncStatusQueries.deleteSelectedByID
    at com.jocmp.capy.persistence.SyncStatusRecords.deleteSelected
    at com.jocmp.capy.Account.dispatch
```

`Account.dispatch` pushes the queued status changes, then calls `SyncStatusRecords.deleteSelected(ids, key)` / `resetSelected(ids, key)`, which pass the **entire** ID list into a single `IN (…)` clause. SQLite's `SQLITE_MAX_VARIABLE_NUMBER` is **999** on the engine bundled with Android (< 3.32), so once more than ~999 changes are queued the statement won't even compile and the app hard-crashes.

## Fix

Chunk the ID list into batches of 500 (well under the limit, leaving headroom for the `key` bind param) inside a transaction — matching the chunking already used by `Account.markAllRead` and `ArticleRecords.dismissNotifications`.

Reproduced and verified on a Boox device (Android 11) with a ~2,700-entry Miniflux account: the crash is gone and the backlog drains cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yVKgdxd3ZSrFeY5eWpFuA
