### PR TITLE
Bound unread/starred reconciliation scans

### DIFF
--- a/capy/src/main/sqldelight/com/jocmp/capy/db/27_AddPartialUnreadStarredIndexes.sqm
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/27_AddPartialUnreadStarredIndexes.sqm
@@ -1,0 +1,5 @@
+-- Partial index for updateStaleUnreads
+CREATE INDEX article_statuses_unread_partial_index ON article_statuses(article_id) WHERE read = 0;
+
+-- Partial index for updateStaleStars
+CREATE INDEX article_statuses_starred_partial_index ON article_statuses(article_id) WHERE starred = 1;

--- a/capy/src/main/sqldelight/com/jocmp/capy/db/articles.sq
+++ b/capy/src/main/sqldelight/com/jocmp/capy/db/articles.sq
@@ -159,14 +159,16 @@ upsertUnread {
 
 updateStaleUnreads {
     UPDATE article_statuses SET read = 1
-    WHERE article_id NOT IN (SELECT article_id FROM excluded_statuses WHERE type = 'unread');
+    WHERE read = 0
+    AND article_id NOT IN (SELECT article_id FROM excluded_statuses WHERE type = 'unread');
 
     DELETE FROM excluded_statuses WHERE type = 'unread';
 }
 
 updateStaleStars {
     UPDATE article_statuses SET starred = 0
-    WHERE article_id NOT IN (SELECT article_id FROM excluded_statuses WHERE type = 'starred');
+    WHERE starred = 1
+    AND article_id NOT IN (SELECT article_id FROM excluded_statuses WHERE type = 'starred');
 
     DELETE FROM excluded_statuses WHERE type = 'starred';
 }


### PR DESCRIPTION
Sync gets progressively slower over time, fixed instantly by "Clear all articles."

The potential root cause is that `updateStaleUnreads`/`updateStaleStars` run `UPDATE ... WHERE article_id NOT IN (...)` on every refresh. This full-scans the entire `article_statuses` table regardless of how many articles are actually unread/starred. Cost scales with total retained history instead of the current total unread count.

The fix is to add `read = 0`/`starred = 1` to those WHERE clauses backed by new partial indexes. This means the scan is bounded to the current unread/starred set instead of all history.

Benchmarked against a copy of a real FreshRSS account's synced DB (17,829 articles), skewed to 50 unread/rest read to match the reported scenario:

| Variant | Query plan | Cost | Time |
|---|---|---|---|
| Before | `SCAN article_statuses` (full table) | O(total retained history) | 15ms |
| After | `SEARCH ... USING INDEX` (bounded) | O(current unread/starred count) | 0.03ms |

~500x faster at this scale. The gap grows with however much read history an account has retained.