### PR TITLE
Clean up orphaned statuses on the same cutoff as articles

### DIFF
--- a/app/src/main/java/com/capyreader/app/ui/settings/panels/AutoDeleteMenu.kt
+++ b/app/src/main/java/com/capyreader/app/ui/settings/panels/AutoDeleteMenu.kt
@@ -18,7 +18,7 @@ fun AutoDeleteMenu(
     autoDelete: AutoDelete,
     updateAutoDelete: (interval: AutoDelete) -> Unit,
 ) {
-    val options = AutoDelete.entries
+    val options = AutoDelete.entries.filterNot { it == AutoDelete.DISABLED }
 
     Column(
         modifier = Modifier.padding(bottom = 16.dp),

--- a/capy/src/main/java/com/jocmp/capy/Account.kt
+++ b/capy/src/main/java/com/jocmp/capy/Account.kt
@@ -232,7 +232,7 @@ data class Account(
             if (cutoffDate != null) {
                 articleRecords.deleteOldArticles(before = cutoffDate)
 
-                articleRecords.deleteOrphanedStatuses()
+                articleRecords.deleteOrphanedStatuses(before = cutoffDate)
             }
 
             result

--- a/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/ArticleRecords.kt
@@ -147,9 +147,9 @@ class ArticleRecords(
         }
     }
 
-    fun deleteOrphanedStatuses(now: ZonedDateTime = nowUTC()) {
+    fun deleteOrphanedStatuses(before: ZonedDateTime) {
         database.transactionWithErrorHandling {
-            val cutoffDate = now.minusDays(180).toEpochSecond()
+            val cutoffDate = before.toEpochSecond()
 
             database.articlesQueries.deleteOrphanedStatuses(cutoffDate = cutoffDate)
         }

--- a/capy/src/test/java/com/jocmp/capy/persistence/ArticleRecordsTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/persistence/ArticleRecordsTest.kt
@@ -415,7 +415,7 @@ class ArticleRecordsTest {
         val missingBefore = articleRecords.findMissingArticles()
         assertEquals(expected = 2, actual = missingBefore.size)
 
-        articleRecords.deleteOrphanedStatuses()
+        articleRecords.deleteOrphanedStatuses(before = nowUTC().minusDays(90))
 
         val missingAfter = articleRecords.findMissingArticles()
         assertContentEquals(expected = missingAfter, listOf(recentOrphanedArticle.id))


### PR DESCRIPTION
Old read/unstarred articles lose their content on the retention cutoff, but the status row stuck around for a separate, hardcoded 180 days. In that gap, every refresh saw the article as missing and re-fetched it, only for it to get deleted again right after - a wasted fetch every sync for whatever fell into that window.

`deleteOrphanedStatuses` now uses the same cutoff as article deletion, so the status row never outlives its content.

Also drops "Keep forever" from the retention picker going forward. Existing selections aren't touched.