### PR TITLE
Expire stale conditional-GET validators

### DIFF
--- a/capy/src/main/java/com/jocmp/capy/persistence/FeedRecords.kt
+++ b/capy/src/main/java/com/jocmp/capy/persistence/FeedRecords.kt
@@ -5,6 +5,8 @@ import app.cash.sqldelight.coroutines.mapToList
 import com.jocmp.capy.Feed
 import com.jocmp.capy.FeedPriority
 import com.jocmp.capy.Folder
+import com.jocmp.capy.common.TimeHelpers.nowUTC
+import com.jocmp.capy.common.toDateTimeFromSeconds
 import com.jocmp.capy.common.withIOContext
 import com.jocmp.capy.db.Database
 import com.jocmp.rssparser.model.ConditionalGetInfo
@@ -21,13 +23,30 @@ internal class FeedRecords(private val database: Database) {
         database.feedsQueries.findByFeedURL(feedURL, mapper = ::feedMapper).executeAsOneOrNull()
     }
 
+    /**
+     * Some servers respond 304 to any conditional GET regardless of whether the
+     * feed content changed (observed with YouTube's channel feeds). Dropping the
+     * stored validator periodically forces an unconditional refetch so those feeds
+     * don't get stuck forever. NetNewsWire uses the same 8-day expiry for this reason.
+     */
     suspend fun findConditionalGet(feedID: String): ConditionalGetInfo = withIOContext {
         val feed = database.feedsQueries.findConditionalGet(feedID).executeAsOneOrNull()
+        val refreshedAt = feed?.conditional_get_refreshed_at
+
+        if (refreshedAt == null || isConditionalGetExpired(refreshedAt)) {
+            return@withIOContext ConditionalGetInfo.EMPTY
+        }
 
         ConditionalGetInfo(
-            etag = feed?.etag,
-            lastModified = feed?.last_modified,
+            etag = feed.etag,
+            lastModified = feed.last_modified,
         )
+    }
+
+    private fun isConditionalGetExpired(refreshedAt: Long): Boolean {
+        val expiresAt = refreshedAt.toDateTimeFromSeconds.plusDays(CONDITIONAL_GET_TTL_DAYS)
+
+        return nowUTC() > expiresAt
     }
 
     /**
@@ -206,4 +225,8 @@ internal class FeedRecords(private val database: Database) {
         showUnreadBadge = showUnreadBadge,
         isReadLater = readLater,
     )
+
+    companion object {
+        private const val CONDITIONAL_GET_TTL_DAYS = 8L
+    }
 }

--- a/capy/src/test/java/com/jocmp/capy/accounts/local/LocalAccountDelegateTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/accounts/local/LocalAccountDelegateTest.kt
@@ -213,14 +213,14 @@ class LocalAccountDelegateTest {
         val feedID = channel.link!!
         FeedFixture(database).create(feedID = feedID, feedURL = feedID)
 
+        val mockNow = ZonedDateTime.parse("2024-12-25T09:00:00-00:00")
         val feedRecords = FeedRecords(database)
         feedRecords.updateConditionalGet(
             feedID = feedID,
             conditionalGet = ConditionalGetInfo(etag = "abc", lastModified = "Mon, 01 Jan 2024 00:00:00 GMT"),
-            refreshedAt = 1_000L,
+            refreshedAt = mockNow.minusDays(1).toEpochSecond(),
         )
 
-        val mockNow = ZonedDateTime.parse("2024-12-25T09:00:00-00:00")
         mockkObject(TimeHelpers)
         every { TimeHelpers.nowUTC() }.returns(mockNow)
 
@@ -261,7 +261,7 @@ class LocalAccountDelegateTest {
         FeedRecords(database).updateConditionalGet(
             feedID = feedID,
             conditionalGet = stored,
-            refreshedAt = 1_000L,
+            refreshedAt = TimeHelpers.nowUTC().minusDays(1).toEpochSecond(),
         )
 
         val captured = slot<ConditionalGetInfo>()

--- a/capy/src/test/java/com/jocmp/capy/persistence/FeedRecordsTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/persistence/FeedRecordsTest.kt
@@ -83,16 +83,18 @@ class FeedRecordsTest {
         val records = FeedRecords(database)
         val feed = FeedFixture(database, records = records).create()
 
+        val lastModified = "Tue, 21 Jul 2026 03:47:50 GMT"
+
         records.updateConditionalGet(
             feedID = feed.id,
-            conditionalGet = ConditionalGetInfo(etag = "abc123", lastModified = "yesterday"),
+            conditionalGet = ConditionalGetInfo(etag = "abc123", lastModified = lastModified),
             refreshedAt = nowUTC().toEpochSecond(),
         )
 
         val result = records.findConditionalGet(feed.id)
 
         assertEquals(expected = "abc123", actual = result.etag)
-        assertEquals(expected = "yesterday", actual = result.lastModified)
+        assertEquals(expected = lastModified, actual = result.lastModified)
     }
 
     @Test
@@ -102,7 +104,7 @@ class FeedRecordsTest {
 
         records.updateConditionalGet(
             feedID = feed.id,
-            conditionalGet = ConditionalGetInfo(etag = "abc123", lastModified = "yesterday"),
+            conditionalGet = ConditionalGetInfo(etag = "abc123", lastModified = "Tue, 21 Jul 2026 03:47:50 GMT"),
             refreshedAt = nowUTC().minusDays(9).toEpochSecond(),
         )
 

--- a/capy/src/test/java/com/jocmp/capy/persistence/FeedRecordsTest.kt
+++ b/capy/src/test/java/com/jocmp/capy/persistence/FeedRecordsTest.kt
@@ -2,9 +2,11 @@ package com.jocmp.capy.persistence
 
 import com.jocmp.capy.InMemoryDatabaseProvider
 import com.jocmp.capy.awaitRepeated
+import com.jocmp.capy.common.TimeHelpers.nowUTC
 import com.jocmp.capy.db.Database
 import com.jocmp.capy.fixtures.ArticleFixture
 import com.jocmp.capy.fixtures.FeedFixture
+import com.jocmp.rssparser.model.ConditionalGetInfo
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import kotlin.test.Test
@@ -74,5 +76,38 @@ class FeedRecordsTest {
             expected = setOf(false),
             actual = updated.map { it.enableStickyFullContent }.toSet()
         )
+    }
+
+    @Test
+    fun findConditionalGet_returnsStoredValue() = runTest {
+        val records = FeedRecords(database)
+        val feed = FeedFixture(database, records = records).create()
+
+        records.updateConditionalGet(
+            feedID = feed.id,
+            conditionalGet = ConditionalGetInfo(etag = "abc123", lastModified = "yesterday"),
+            refreshedAt = nowUTC().toEpochSecond(),
+        )
+
+        val result = records.findConditionalGet(feed.id)
+
+        assertEquals(expected = "abc123", actual = result.etag)
+        assertEquals(expected = "yesterday", actual = result.lastModified)
+    }
+
+    @Test
+    fun findConditionalGet_expiresAfter8Days() = runTest {
+        val records = FeedRecords(database)
+        val feed = FeedFixture(database, records = records).create()
+
+        records.updateConditionalGet(
+            feedID = feed.id,
+            conditionalGet = ConditionalGetInfo(etag = "abc123", lastModified = "yesterday"),
+            refreshedAt = nowUTC().minusDays(9).toEpochSecond(),
+        )
+
+        val result = records.findConditionalGet(feed.id)
+
+        assertTrue(result.isEmpty)
     }
 }


### PR DESCRIPTION
Some servers (e.g. YouTube channel feeds) send 304 regardless of content changes, which permanently starves refreshes once a validator is stored. Drop it after 8 days, matching NetNewsWire's approach.